### PR TITLE
Add resin-image-fs as a package.json dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "mountutils": "^1.2.0",
     "nodegit": "^0.18.3",
     "progress-stream": "^2.0.0",
+    "resin-image-fs": "^4.0.2",
     "resin-sdk": "^7.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
See: https://github.com/resin-io/resinos-tests/pull/34
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>