### PR TITLE
Present a clear interface to the resin.io SDK component

### DIFF
--- a/src/components/resinio/sdk.js
+++ b/src/components/resinio/sdk.js
@@ -1,5 +1,68 @@
 'use strict'
 
-module.exports = require('resin-sdk')({
+const fs = require('fs')
+const Bluebird = require('bluebird')
+const progressStream = require('progress-stream')
+const resin = require('resin-sdk')({
   apiUrl: 'https://api.resin.io/'
 })
+
+exports.downloadDeviceTypeOS = (deviceType, version, destination) => {
+  return Bluebird.props({
+    stream: resin.models.os.download(deviceType, version),
+    size: resin.models.os.getDownloadSize(deviceType, version)
+  }).then((results) => {
+    return new Bluebird((resolve, reject) => {
+      const output = fs.createWriteStream(destination)
+      output.on('error', reject)
+
+      const progress = progressStream({
+        length: results.size,
+        time: 1000
+      })
+
+      progress.on('error', reject)
+      progress.on('progress', (data) => {
+        console.log(`Downloading OS: ${data.percentage.toFixed(2)}%`)
+      })
+
+      results.stream.on('error', reject)
+      results.stream.on('finish', resolve)
+      results.stream.pipe(output)
+    })
+  })
+}
+
+exports.getApplicationOSConfiguration = (application, options) => {
+  return resin.models.os.getConfig(application, options)
+}
+
+exports.getApplicationGitRemote = (application) => {
+  return resin.models.application.get(application).get('git_repository')
+}
+
+exports.loginWithToken = (token) => {
+  return resin.auth.loginWithToken(token)
+}
+
+exports.hasApplication = (application) => {
+  return resin.models.application.has(application)
+}
+
+exports.removeApplication = (application) => {
+  return resin.models.application.remove(application)
+}
+
+exports.createApplication = (name, deviceType) => {
+  return resin.models.application.create(name, deviceType)
+}
+
+exports.getApplicationDevices = (application) => {
+  return resin.models.device.getAllByApplication(application).map((device) => {
+    return device.id
+  })
+}
+
+exports.isDeviceOnline = (device) => {
+  return resin.models.device.isOnline(device)
+}

--- a/src/main.js
+++ b/src/main.js
@@ -39,19 +39,19 @@ describe('Test ResinOS', function () {
 
   // eslint-disable-next-line prefer-arrow-callback
   before(function () {
-    return sdk.auth.loginWithToken(process.env.AUTH_TOKEN)
+    return sdk.loginWithToken(process.env.AUTH_TOKEN)
       .then(() => {
-        return sdk.models.application.has(process.env.APPLICATION_NAME)
+        return sdk.hasApplication(process.env.APPLICATION_NAME)
       })
       .then((hasApplication) => {
         if (hasApplication) {
-          return sdk.models.application.remove(process.env.APPLICATION_NAME)
+          return sdk.removeApplication(process.env.APPLICATION_NAME)
         }
 
         return Bluebird.resolve()
       })
       .then(() => {
-        return sdk.models.application.create(process.env.APPLICATION_NAME, global.options.deviceType)
+        return sdk.createApplication(process.env.APPLICATION_NAME, global.options.deviceType)
       })
   })
 

--- a/src/resin/container.js
+++ b/src/resin/container.js
@@ -20,9 +20,9 @@ module.exports = (opt) => {
           return git.Clone(global.options.gitAppURL, path.resolve(global.assetDir, 'test'))
         }).then((repo) => {
           repository = repo
-          return sdk.models.application.get(process.env.APPLICATION_NAME)
-        }).then((app) => {
-          return git.Remote.create(repository, 'resin', `telphan@git.resin.io:${app.git_repository}.git`)
+          return sdk.getApplicationGitRemote(process.env.APPLICATION_NAME)
+        }).then((remote) => {
+          return git.Remote.create(repository, 'resin', remote)
         }).then((remote) => {
           return remote.push([ 'refs/heads/master:refs/heads/master' ], {
             callbacks: {

--- a/src/resin/device.js
+++ b/src/resin/device.js
@@ -27,15 +27,17 @@ module.exports = (opt) => {
 
         return Bluebird.delay(10000)
           .return(process.env.APPLICATION_NAME)
-          .then(sdk.models.device.getAllByApplication)
-          .then((dev) => {
-            chai.expect(dev).to.have.length(1)
-            chai.expect(dev).to.be.instanceof(Array)
-            return dev[0]
+          .then(sdk.getApplicationDevices)
+          .then((devices) => {
+            chai.expect(devices).to.have.length(1)
+            chai.expect(devices).to.be.instanceof(Array)
+            return devices[0]
           })
-          .then((dev) => {
-            global.provDevice = dev
-            return chai.expect(dev).to.have.property('is_online', true)
+          .then((device) => {
+            global.provDevice = device
+            return sdk.isDeviceOnline(device)
+          }).then((isOnline) => {
+            return chai.expect(isOnline).to.be.true
           })
       })
 


### PR DESCRIPTION
The resin.io platform has an interface, which consists of functions such
as download device type OS, create an application, etc.

This interface is implemented by the Resin SDK. In the future, we will
implement the same interface using the Resin CLI, and even the Dashboard
by using a browser driver technology.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>