### PR TITLE
Use SDK interface functions instead of inspecting device properties

### DIFF
--- a/src/components/resinio/sdk.js
+++ b/src/components/resinio/sdk.js
@@ -66,3 +66,11 @@ exports.getApplicationDevices = (application) => {
 exports.isDeviceOnline = (device) => {
   return resin.models.device.isOnline(device)
 }
+
+exports.getDeviceHostOSVersion = (device) => {
+  return resin.models.device.get(device).get('os_version')
+}
+
+exports.getDeviceCommit = (device) => {
+  return resin.models.device.get(device).get('commit')
+}

--- a/src/resin/container.js
+++ b/src/resin/container.js
@@ -36,7 +36,9 @@ module.exports = (opt) => {
 
       // eslint-disable-next-line prefer-arrow-callback
       it(`Push: (${global.options.gitAppURL})`, function () {
-        return chai.expect(global.provDevice.commit).to.have.length(40)
+        return sdk.getDeviceCommit(global.provDevice).then((commit) => {
+          return chai.expect(commit).to.have.length(40)
+        })
       })
     }
   }

--- a/src/resin/device.js
+++ b/src/resin/device.js
@@ -34,7 +34,7 @@ module.exports = (opt) => {
             return devices[0]
           })
           .then((device) => {
-            global.provDevice = device
+            global.provDevice = device.id
             return sdk.isDeviceOnline(device)
           }).then((isOnline) => {
             return chai.expect(isOnline).to.be.true
@@ -43,7 +43,9 @@ module.exports = (opt) => {
 
       // eslint-disable-next-line prefer-arrow-callback
       it(`Device should report hostOS version: ${global.options.version}`, function () {
-        return chai.expect(global.provDevice.os_version).to.equal('Resin OS 2.0.6+rev3')
+        return sdk.getDeviceHostOSVersion(global.provDevice).then((version) => {
+          return chai.expect(version).to.equal('Resin OS 2.0.6+rev3')
+        })
       })
     }
   }


### PR DESCRIPTION
For encapsulation purposes. The current code is assuming SDK output.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>