### PR TITLE
Don't wait for stdin on provision before continuing

### DIFF
--- a/lib/components/device-type/default.ts
+++ b/lib/components/device-type/default.ts
@@ -1,12 +1,6 @@
 'use strict'
 
-import Bluebird = require('bluebird')
-
 exports.provision = async (writer, imagePath, options) => {
   await writer.writeImage(imagePath, options.destination)
   console.log(`Write complete. Please remove ${options.destination}, plug it into the device, and turn it on.`)
-  return new Bluebird((resolve) => {
-    console.log('Press any key to continue.')
-    process.stdin.once('data', resolve)
-  })
 }


### PR DESCRIPTION
We can't access stdin from Ava, so we'll rely on polling the API for
now.

Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>