### PR TITLE
Use namespaced env vars

### DIFF
--- a/env.list.example
+++ b/env.list.example
@@ -1,5 +1,6 @@
-APPLICATION_NAME=MochaTest
-EMAIL=<replace with account email>
-PASSWORD=<replace with account password>
-WIFI_SSID=<replace with router SSID>
-WIFI_KEY=<replace with router password>
+RESINOS_TESTS_APPLICATION_NAME=<replace with application name>
+RESINOS_TESTS_EMAIL=<replace with account email>
+RESINOS_TESTS_PASSWORD=<replace with account password>
+RESINOS_TESTS_WIFI_SSID=<replace with router SSID>
+RESINOS_TESTS_WIFI_KEY=<replace with router password>
+RESINOS_TESTS_DISK=<replace with disk device>

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -10,12 +10,12 @@ const TEMPORARY_DIRECTORY = path.join(__dirname, '..', '.tmp')
 fse.ensureDirSync(TEMPORARY_DIRECTORY)
 
 const options = <any>{
-  deviceType: process.env.DEVICE_TYPE,
-  resinOSVersion: process.env.RESINOS_VERSION,
-  applicationName: process.env.APPLICATION_NAME,
-  disk: process.env.DISK,
-  email: process.env.EMAIL,
-  password: process.env.PASSWORD
+  deviceType: process.env.RESINOS_TESTS_DEVICE_TYPE,
+  resinOSVersion: process.env.RESINOS_TESTS_RESINOS_VERSION,
+  applicationName: process.env.RESINOS_TESTS_APPLICATION_NAME,
+  disk: process.env.RESINOS_TESTS_DISK,
+  email: process.env.RESINOS_TESTS_EMAIL,
+  password: process.env.RESINOS_TESTS_PASSWORD
 }
 
 const utils = require('./utils')


### PR DESCRIPTION
To avoid collisions.

Change-Type: patch
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>