### PR TITLE
Add the verbose flag to Ava

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "files": [
       "lib/main.ts"
     ],
+    "verbose": true,
     "failFast": true,
     "failWithoutAssertions": true
   },


### PR DESCRIPTION
This prevents Ava from showing a dynamic spinner on Circle CI, which
doesn't work very well.

Change-Type: patch
See: https://github.com/resin-io/resinos-tests/pull/79
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>