### PR TITLE
Rework 'push an application' test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,13 @@ RUN npm install
 
 FROM node:6
 
-RUN apt-get update && apt-get install -y qemu-system-x86 qemu-kvm && \
+RUN echo 'deb http://ftp.debian.org/debian jessie-backports main' >> /etc/apt/sources.list
+
+
+# Avoid using a ssh agent by using GIT_SSH_COMMAND (requires git v2.10+)
+RUN apt-get update && \
+    apt-get install -y qemu-system-x86 qemu-kvm && \
+    apt-get install -y -t jessie-backports git && \
     rm -rf /var/lib/apt/lists/*
 
 ENV INITSYSTEM on

--- a/package.json
+++ b/package.json
@@ -39,11 +39,12 @@
     "etcher-image-write": "^9.1.3",
     "fs-extra": "^3.0.1",
     "mountutils": "^1.2.0",
-    "nodegit": "^0.18.3",
     "progress-stream": "^2.0.0",
     "resin-cli-visuals": "^1.4.0",
     "resin-image-fs": "^4.0.2",
     "resin-sdk": "^7.0.0",
+    "simple-git": "^1.85.0",
+    "ssh-keygen": "^0.4.1",
     "ts-node": "^3.3.0",
     "typescript": "^2.6.1"
   },


### PR DESCRIPTION
* Handle SSH keys internally
* Avoid using ssh-agent by using GIT_SSH_COMMAND (requires git 2.10+)
* Fix the way we construct remote url
* Simple-git connects our process to stdout/stderr
which is required to keep the builder connected
* Implement waitForDeviceStatus, this function waits
for a device to reach a given state

Change-type: patch
Signed-off-by: Theodor Gherzan <theodor@resin.io>