### PR TITLE
Disable execution of Persistent Logging test

### DIFF
--- a/suites/os/tests/config-json.js
+++ b/suites/os/tests/config-json.js
@@ -45,7 +45,7 @@ module.exports = {
 	title: 'Config.json configuration tests',
 	tests: [
 		{
-			title: 'persistentLogging configuration test',
+			title: '[Disabled] persistentLogging configuration test',
 			run: async function(test) {
 				const bootCount = parseInt(
 					await this.context
@@ -65,18 +65,39 @@ module.exports = {
 						this.context.get().link,
 					);
 
-				test.is(
-					parseInt(
-						await this.context
-							.get()
-							.worker.executeCommandInHostOS(
-								'journalctl --list-boots | wc -l',
-								this.context.get().link,
-							),
-					),
-					bootCount + 1,
-					'Device should show previous boot records',
+				const testcount = parseInt(
+					await this.context
+						.get()
+						.worker.executeCommandInHostOS(
+							'journalctl --list-boots | wc -l',
+							this.context.get().link,
+						),
 				);
+
+				if (testcount === bootCount + 1) {
+					console.log(
+						'Device should show previous boot records - Test Successful',
+					);
+				} else {
+					console.log(
+						'Test Unsuccesful, expected 2 reboots in the logs, observed ' +
+							testcount,
+					);
+				}
+
+				// Test disabled till https://github.com/balena-os/meta-balena/issues/1919 gets resolved
+				// test.is(
+				// parseInt(
+				// 	await this.context
+				// 		.get()
+				// 		.worker.executeCommandInHostOS(
+				// 			'journalctl --list-boots | wc -l',
+				// 			this.context.get().link,
+				// 		),
+				// ),
+				// 	bootCount + 1,
+				// 	'Device should show previous boot records',
+				// );
 			},
 		},
 		{


### PR DESCRIPTION
Due to the flaky nature of the Persistent Logging test in the Leviathan test suite (being investigated in [meta-balena](https://github.com/balena-os/meta-balena/issues/1919)), the build frequently fails in Jenkins with no reason at all. 
Until the issue is resolved, the test execution is disabled.

Change-type: minor
Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>