### PR TITLE
Fix error handling

### DIFF
--- a/core/lib/main.js
+++ b/core/lib/main.js
@@ -160,6 +160,7 @@ async function setup() {
 			}
 		};
 
+		let suiteStarted = false;
 		try {
 			ws.on('error', console.error);
 			ws.on('close', () => {
@@ -212,6 +213,7 @@ async function setup() {
 				suite = fork('./lib/common/suite', {
 					stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
 				});
+				suiteStarted = true;
 			}
 
 			ws.on('message', message => {
@@ -268,7 +270,9 @@ async function setup() {
 			}
 		} finally {
 			ws.close();
-			suite = null;
+			if (suiteStarted) {
+				suite = null;
+			}
 		}
 	});
 


### PR DESCRIPTION
Previous version waas not handling errors reported by the on-device core service.
Also, avoid resetting the test suite in case of the init error in the core.

Change-type: patch
Signed-off-by: Roman Mazur <roman@balena.io>