### PR TITLE
Add Getting Started section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Leviathan
 
-[![Build Status (master)](https://jenkins.dev.resin.io/buildStatus/icon?job=balena-tests-master)](https://jenkins.dev.resin.io/job/balena-tests-master/)
 [![GitHub Issues](https://img.shields.io/github/issues/balena-io/leviathan.svg)](https://github.com/balena-io/leviathan/issues)
 [![GitHub pull requests](https://img.shields.io/github/issues-pr/balena-io/leviathan.svg)](https://github.com/balena-io/leviathan/pulls)
 [![node](https://img.shields.io/badge/node-v9.0.0-green.svg)](https://nodejs.org/download/release/v9.0.0/)
@@ -22,22 +21,20 @@ To set up Leviathan both hardware and software need to be configured. If you are
 ### Prerequisites needed
 
 - Install node and npm in your system. We recommend installing [LTS versions from NVM](https://github.com/nvm-sh/nvm#install--update-script).
-- **Important**, You would need access to balena's NPM registry beforehand to download private packages. 
 - Download the image you want to test on your DUT from [balena.io/os](balena.io/os)
 
 
 ### Configuration needed
 
 - Start building your standalone testbot by [following the guide](https://github.com/balena-io/testbot/blob/master/documentation/getting-started.md#quick-start-guide-for-testbot). 
-- Add NPM auth token with read permission to [install private packages](https://docs.npmjs.com/using-private-packages-in-a-ci-cd-workflow#create-and-check-in-a-project-specific-npmrc-file).
 - Create your test configuration, by creating a `config.json` file in the `workspace` directory, following instructions mentioned in the [testbot docs](https://github.com/balena-io/testbot/blob/master/documentation/getting-started.md#run-your-first-test).
-- Copy your downloaded balenaOS image inside the `workspace` directory.
-- Extract, rename, and recompress the image into the `.gz` format. The final file would look like `balena.img.gz` file.
+- Move the image zip file you want to test with inside the `workspace` directory in Leviathan.
+- Extract the image, rename it to balena.img, and recompress the image into the `.gz` format. The final file would look like `balena.img.gz` file and has to be in the `./leviathan/workspace` directory. 
 
 
 ### Packages needed for installation
 
-(Taken from `Dockerfile.template` of each service, so might be incomplete or overkill)
+(Taken from `Dockerfile.template` of each service, so might be incomplete or properly overkill)
 
 1. Install OS packages
 
@@ -72,7 +69,7 @@ rm -rf ~/.node-gyp
 npm cache clear --force
 ```
 
-## Instructions for rig-owners 
+## [Not Needed Anymore] Instructions for rig-owners 
 
 - If you are pushing new releases of Leviathan to balenaCloud, then place the `.npmrc` file over with NPM token at the location `leviathan/.balena/secrets/.npmrc`
 - Next, create a [build time only secret file](https://www.balena.io/docs/learn/deploy/deployment/#build-time-secrets-and-variables), `.balena.yml` will be needed. Create a `balena.yml` in the `.balena` directory with the following configuration. 

--- a/README.md
+++ b/README.md
@@ -10,59 +10,52 @@
 
 ## Getting Started
 
-Leviathan needs configuration of both hardware and software to set it up. If you are setting up your standalone testbot, then please follow the instructions given below carefully before running tests on the Device Under Test (DUT). 
+To set up Leviathan both hardware and software need to be configured. If you are setting up your standalone testbot, then please follow the instructions given below carefully before running tests on the Device Under Test (DUT). 
 
 
-**Clone the repository**
+### Clone the repository
 
 - Clone this repository with `git clone --recursive` or   
 - Run `git clone` and then `git submodule update --init --recursive` to install submodules.
 
 
-**Prerequistes needed**
-  
-  - Install node and npm in your system. We recommend installing [LTS versions from NVM](https://github.com/nvm-sh/nvm#install--update-script).
-  - You would need access to balena's NPM registry.
-  - Download the image you want to test on your DUT from [balena.io/os](balena.io/os)
+### Prerequisites needed
+
+- Install node and npm in your system. We recommend installing [LTS versions from NVM](https://github.com/nvm-sh/nvm#install--update-script).
+- You would need access to balena's NPM registry.
+- Download the image you want to test on your DUT from [balena.io/os](balena.io/os)
 
 
-**Configuration needed**
+### Configuration needed
 
-  - Start building your standalone testbot by [following the guide](). 
-  - Add NPM auth token with read permission to [install private packages](https://docs.npmjs.com/using-private-packages-in-a-ci-cd-workflow#create-and-check-in-a-project-specific-npmrc-file).
-  - Create your test configuration, by creating a `config.json` file in the `workspace` directory, following instructions mentioned in the [testbot docs](https://github.com/balena-io/testbot/).
-  - Copy your downloaded balenaOS image inside the `workspace` directory.
-  - Extract, rename and recompress the image into the `.gz` format. Final file would look like `balena.img.gz` file.
+- Start building your standalone testbot by [following the guide](https://github.com/balena-io/testbot/blob/master/documentation/getting-started.md#quick-start-guide-for-testbot). 
+- Add NPM auth token with read permission to [install private packages](https://docs.npmjs.com/using-private-packages-in-a-ci-cd-workflow#create-and-check-in-a-project-specific-npmrc-file).
+- Create your test configuration, by creating a `config.json` file in the `workspace` directory, following instructions mentioned in the [testbot docs](https://github.com/balena-io/testbot/blob/master/documentation/getting-started.md#run-your-first-test).
+- Copy your downloaded balenaOS image inside the `workspace` directory.
+- Extract, rename, and recompress the image into the `.gz` format. The final file would look like `balena.img.gz` file.
 
 
-**Packages needed for installation**
+### Packages needed for installation
 
 (Taken from `Dockerfile.template` of each service, so might be incomplete or overkill)
 
-1. First step is to install OS packages that are needed. 
+1. Install OS packages
 
 ```
 sudo apt-get install qemu-kvm pkg-config libvirt-daemon-system bridge-utils libvirt-clients build-essential g++ python git make gcc gcc-multilib node-gyp libusb-dev libdbus-1-dev libvirt-dev qemu-system-x86
 ```
 
-2. Install global NPM packages needed
+2. Install NPM packages
 
 ```
 npm install node-pre-gyp node-gyp -g
-```
-
-3. Install NPM packages. 
-
-```
 npm install
 ```
 
-Make sure the `npm install` goes without errors (other than the optional dependencies), as it recursively installs packages for all 3 services. If it fails, you can follow the command below for troubleshooting. 
+Make sure the `npm install` goes without errors (other than the optional dependencies), as it recursively installs packages for all 3 services. If it fails, you can follow the commands below for troubleshooting. 
 
 
-**Run the tests**
-
-- Navigate to the workspace directory, 
+3. Run the tests by navigating to the workspace directory and running 
 
 ```
 ./run-tests.sh
@@ -94,7 +87,7 @@ build-secrets:
 ```
 
 
-**To push new release to balenaCloud**
+**To push a new release to balenaCloud**
 
 - Run the command with the <appname> as the name of your application.
 
@@ -108,13 +101,13 @@ If you're having any problem, please [raise an issue][newissue] on GitHub and th
 
 ## Contribute
 
-- Issue Tracker: [github.com/balena-io/balena-tests/issues][issues]
+- Issue Tracker: [github.com/balena-io/leviathan/issues][issues]
 - Source Code: [github.com/balena-io/leviathan][source]
 
 ## License
 
 The project is licensed under the Apache 2.0 license.
 
-[issues]: https://github.com/balena-io/balena-tests/issues
-[newissue]: https://github.com/balena-io/balena-tests/issues/new
-[source]: https://github.com/balena-io/balena-tests
+[issues]: https://github.com/balena-io/leviathan/issues
+[newissue]: https://github.com/balena-io/leviathan/issues/new
+[source]: https://github.com/balena-io/leviathan

--- a/README.md
+++ b/README.md
@@ -10,6 +10,57 @@
 
 ## Getting Started
 
+Instructions for Linux Ubuntu 20.04 distribution.
+
+**Clone**
+
+- Clone this repository with `git clone --recursive` or   
+- Run `git clone` and then `git submodule update --init --recursive`
+
+**Configuration needed**
+
+  - Install node and npm. LTS versions.  
+  - NPM auth token with read permission atleast to install packages locally (`~/.npmrc`) and when pushing to BalenCloud (~/leviathan/.balena/.npmrc)
+  - Create a `balena.yml` in the `.balena` directory to handle secrets only while pushing to BalenaCloud. 
+  - `git submodule update --init --recursive` if not done at the time of cloning.
+  - Create your configuration in the `workspace` directory for testing.
+  - Put on your BalenaOS image for the device type you are testing with, and make sure the extension is `.img.gz` inside the `workspace` directory.
+  
+**Packages needed**
+
+(Taken from `Dockerfile.template` of each service, might be incomplete)
+
+```
+sudo apt-get install qemu-kvm pkg-config libvirt-daemon-system bridge-utils libvirt-clients build-essential g++ python git make gcc gcc-multilib node-gyp libusb-dev libdbus-1-dev libvirt-dev qemu-system-x86
+```
+
+**Global NPM packages needed**
+
+```
+npm install node-pre-gyp node-gyp -g
+```
+
+## Helpful commands for troubleshooting
+
+At times, when `npm install` leads to errors. Use the commands below before trying again to begin again with a clean slate.
+
+```
+rm core/package-lock.json worker/package-lock.json client/package-lock.json package-lock.json
+rm -rf node_modules/ core/node_modules/ worker/node_modules/ client/node_modules/
+rm -rf ~/.node-gyp
+npm cache clear --force
+```
+
+The `npm install` should finish install without any errors if configured right 
+
+## Pushing new release to BalenaCloud
+
+After configuring Leviathan, run the command 
+
+```
+PUSH=<appname> make balena
+```
+
 ## Support
 
 If you're having any problem, please [raise an issue][newissue] on GitHub and the Balena team will be happy to help.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To set up Leviathan both hardware and software need to be configured. If you are
 ### Prerequisites needed
 
 - Install node and npm in your system. We recommend installing [LTS versions from NVM](https://github.com/nvm-sh/nvm#install--update-script).
-- You would need access to balena's NPM registry.
+- **Important**, You would need access to balena's NPM registry beforehand to download private packages. 
 - Download the image you want to test on your DUT from [balena.io/os](balena.io/os)
 
 
@@ -72,7 +72,6 @@ rm -rf ~/.node-gyp
 npm cache clear --force
 ```
 
-
 ## Instructions for rig-owners 
 
 - If you are pushing new releases of Leviathan to balenaCloud, then place the `.npmrc` file over with NPM token at the location `leviathan/.balena/secrets/.npmrc`
@@ -94,6 +93,8 @@ build-secrets:
 ```
 PUSH=<appname> make balena
 ```
+
+To monitior leviathan tests connected to its pipeline for the rigs, you would need to request Jenkins access.
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -10,39 +10,67 @@
 
 ## Getting Started
 
-Instructions for Linux Ubuntu 20.04 distribution.
+Leviathan needs configuration of both hardware and software to set it up. If you are setting up your standalone testbot, then please follow the instructions given below carefully before running tests on the Device Under Test (DUT). 
 
-**Clone**
+
+**Clone the repository**
 
 - Clone this repository with `git clone --recursive` or   
 - Run `git clone` and then `git submodule update --init --recursive` to install submodules.
 
+
+**Prerequistes needed**
+  
+  - Install node and npm in your system. We recommend installing [LTS versions from NVM](https://github.com/nvm-sh/nvm#install--update-script).
+  - You would need access to balena's NPM registry.
+  - Download the image you want to test on your DUT from [balena.io/os](balena.io/os)
+
+
 **Configuration needed**
 
-  - Install node and npm in your system. LTS versions recommended.  
-  - Add NPM auth token with read permission to [install private packages](https://docs.npmjs.com/using-private-packages-in-a-ci-cd-workflow#create-and-check-in-a-project-specific-npmrc-file) locally in your system (in a `~/.npmrc` located in home directory). If pushing to balenaCloud, then place the `.npmrc` file over at `<cloned_repo>/.balena/secrets/.npmrc`
-  - If pushing new release to balenaCloud, then a [Build Time only Secret File](https://www.balena.io/docs/learn/deploy/deployment/#build-time-secrets-and-variables) `.balena.yml` will be needed. Create a `balena.yml` in the `.balena` directory. 
-  - Don't forget to install submodules with `git submodule update --init --recursive`
-  - Create your configuration `config.json` in the `workspace` directory for testing with instructions mentioned in [testbot repository](https://github.com/balena-io/testbot/).
-  - Place the balenaOS image for the deviceType you are testing with, and make sure the extension is `.img.gz` inside the `workspace` directory.
-  
+  - Start building your standalone testbot by [following the guide](). 
+  - Add NPM auth token with read permission to [install private packages](https://docs.npmjs.com/using-private-packages-in-a-ci-cd-workflow#create-and-check-in-a-project-specific-npmrc-file).
+  - Create your test configuration, by creating a `config.json` file in the `workspace` directory, following instructions mentioned in the [testbot docs](https://github.com/balena-io/testbot/).
+  - Copy your downloaded balenaOS image inside the `workspace` directory.
+  - Extract, rename and recompress the image into the `.gz` format. Final file would look like `balena.img.gz` file.
+
+
 **Packages needed for installation**
 
-(Taken from `Dockerfile.template` of each service, might be incomplete)
+(Taken from `Dockerfile.template` of each service, so might be incomplete or overkill)
+
+1. First step is to install OS packages that are needed. 
 
 ```
 sudo apt-get install qemu-kvm pkg-config libvirt-daemon-system bridge-utils libvirt-clients build-essential g++ python git make gcc gcc-multilib node-gyp libusb-dev libdbus-1-dev libvirt-dev qemu-system-x86
 ```
 
-**Global NPM packages needed**
+2. Install global NPM packages needed
 
 ```
 npm install node-pre-gyp node-gyp -g
 ```
 
+3. Install NPM packages. 
+
+```
+npm install
+```
+
+Make sure the `npm install` goes without errors (other than the optional dependencies), as it recursively installs packages for all 3 services. If it fails, you can follow the command below for troubleshooting. 
+
+
+**Run the tests**
+
+- Navigate to the workspace directory, 
+
+```
+./run-tests.sh
+```
+
 ## Helpful commands for troubleshooting
 
-At times, when `npm install` leads to errors. Use the commands below before trying again to begin again with a clean slate.
+At times, when `npm install` leads to errors. Use the commands below before trying again to start with a clean slate.
 
 ```
 rm core/package-lock.json worker/package-lock.json client/package-lock.json package-lock.json
@@ -51,11 +79,24 @@ rm -rf ~/.node-gyp
 npm cache clear --force
 ```
 
-The `npm install` should finish install without any errors if configured right 
 
-## Pushing new release to balenaCloud
+## Instructions for rig-owners 
 
-After configuring Leviathan, run the command 
+- If you are pushing new releases of Leviathan to balenaCloud, then place the `.npmrc` file over with NPM token at the location `leviathan/.balena/secrets/.npmrc`
+- Next, create a [build time only secret file](https://www.balena.io/docs/learn/deploy/deployment/#build-time-secrets-and-variables), `.balena.yml` will be needed. Create a `balena.yml` in the `.balena` directory with the following configuration. 
+
+```
+build-secrets:
+  services:
+    worker:
+      - source: .npmrc
+        dest: .npmrc
+```
+
+
+**To push new release to balenaCloud**
+
+- Run the command with the <appname> as the name of your application.
 
 ```
 PUSH=<appname> make balena

--- a/README.md
+++ b/README.md
@@ -15,18 +15,18 @@ Instructions for Linux Ubuntu 20.04 distribution.
 **Clone**
 
 - Clone this repository with `git clone --recursive` or   
-- Run `git clone` and then `git submodule update --init --recursive`
+- Run `git clone` and then `git submodule update --init --recursive` to install submodules.
 
 **Configuration needed**
 
-  - Install node and npm. LTS versions.  
-  - NPM auth token with read permission atleast to install packages locally (`~/.npmrc`) and when pushing to BalenCloud (~/leviathan/.balena/.npmrc)
-  - Create a `balena.yml` in the `.balena` directory to handle secrets only while pushing to BalenaCloud. 
-  - `git submodule update --init --recursive` if not done at the time of cloning.
-  - Create your configuration in the `workspace` directory for testing.
-  - Put on your BalenaOS image for the device type you are testing with, and make sure the extension is `.img.gz` inside the `workspace` directory.
+  - Install node and npm in your system. LTS versions recommended.  
+  - Add NPM auth token with read permission to [install private packages](https://docs.npmjs.com/using-private-packages-in-a-ci-cd-workflow#create-and-check-in-a-project-specific-npmrc-file) locally in your system (in a `~/.npmrc` located in home directory). If pushing to balenaCloud, then place the `.npmrc` file over at `<cloned_repo>/.balena/secrets/.npmrc`
+  - If pushing new release to balenaCloud, then a [Build Time only Secret File](https://www.balena.io/docs/learn/deploy/deployment/#build-time-secrets-and-variables) `.balena.yml` will be needed. Create a `balena.yml` in the `.balena` directory. 
+  - Don't forget to install submodules with `git submodule update --init --recursive`
+  - Create your configuration `config.json` in the `workspace` directory for testing with instructions mentioned in [testbot repository](https://github.com/balena-io/testbot/).
+  - Place the balenaOS image for the deviceType you are testing with, and make sure the extension is `.img.gz` inside the `workspace` directory.
   
-**Packages needed**
+**Packages needed for installation**
 
 (Taken from `Dockerfile.template` of each service, might be incomplete)
 
@@ -53,7 +53,7 @@ npm cache clear --force
 
 The `npm install` should finish install without any errors if configured right 
 
-## Pushing new release to BalenaCloud
+## Pushing new release to balenaCloud
 
 After configuring Leviathan, run the command 
 
@@ -63,7 +63,7 @@ PUSH=<appname> make balena
 
 ## Support
 
-If you're having any problem, please [raise an issue][newissue] on GitHub and the Balena team will be happy to help.
+If you're having any problem, please [raise an issue][newissue] on GitHub and the balena team will be happy to help.
 
 ## Contribute
 


### PR DESCRIPTION
Change-type: patch
Getting Started section wasn't documented for Leviathan, added it along with the instruction to push releases to applications on BalenaCloud 