### PR TITLE
Patch Persistent logging & DNS tests

### DIFF
--- a/suites/os/tests/config-json.js
+++ b/suites/os/tests/config-json.js
@@ -45,7 +45,7 @@ module.exports = {
 	title: 'Config.json configuration tests',
 	tests: [
 		{
-			title: '[Disabled] persistentLogging configuration test',
+			title: 'persistentLogging configuration test',
 			run: async function(test) {
 				const bootCount = parseInt(
 					await this.context
@@ -65,39 +65,18 @@ module.exports = {
 						this.context.get().link,
 					);
 
-				const testcount = parseInt(
-					await this.context
-						.get()
-						.worker.executeCommandInHostOS(
-							'journalctl --list-boots | wc -l',
-							this.context.get().link,
-						),
+				test.is(
+					parseInt(
+						await this.context
+							.get()
+							.worker.executeCommandInHostOS(
+								'journalctl --list-boots | wc -l',
+								this.context.get().link,
+							),
+					),
+					bootCount + 1,
+					'Device should show previous boot records',
 				);
-
-				if (testcount === bootCount + 1) {
-					console.log(
-						'Device should show previous boot records - Test Successful',
-					);
-				} else {
-					console.log(
-						'Test Unsuccesful, expected 2 reboots in the logs, observed ' +
-							testcount,
-					);
-				}
-
-				// Test disabled till https://github.com/balena-os/meta-balena/issues/1919 gets resolved
-				// test.is(
-				// parseInt(
-				// 	await this.context
-				// 		.get()
-				// 		.worker.executeCommandInHostOS(
-				// 			'journalctl --list-boots | wc -l',
-				// 			this.context.get().link,
-				// 		),
-				// ),
-				// 	bootCount + 1,
-				// 	'Device should show previous boot records',
-				// );
 			},
 		},
 		{

--- a/suites/os/tests/config-json.js
+++ b/suites/os/tests/config-json.js
@@ -206,7 +206,7 @@ module.exports = {
 				const serverFile = await this.context
 					.get()
 					.worker.executeCommandInHostOS(
-						"systemctl show dnsmasq  | grep ExecStart | sed -n 's/.*--servers-file=\\([^ ]*\\)\\s.*$/\\1/p'",
+						"systemctl show dnsmasq  | grep ExecStart= | sed -n 's/.*--servers-file=\\([^ ]*\\)\\s.*$/\\1/p'",
 						this.context.get().link,
 					);
 


### PR DESCRIPTION
- Reactivates previously disabled persistent logging test here #338 
- Patch permission denied error in DNS test. Reference below.

Reference:
- https://jenkins.dev.resin.io/job/leviathan-raspberrypi4-64/376/console (and other RPi builds)
- In context to: https://www.flowdock.com/app/rulemotion/device-testing/threads/HS7QbT8ghvW6il95FOqE4pMexc6