### PR TITLE
Add cloud helpers

### DIFF
--- a/core/lib/components/balena/cli.js
+++ b/core/lib/components/balena/cli.js
@@ -68,12 +68,12 @@ module.exports = class CLI {
 			const child = spawn(
 				'balena',
 				[
-					`preload --docker ${socketPath} --app ${options.app} --commit ${
-						options.commit
-					} ${options.pin ? '--pin-device-to-release ' : ''} ${join(
+					`preload ${join(
 						Mount.Source,
 						basename(image),
-					)}`,
+					)} --docker ${socketPath} --app ${options.app} --commit ${
+						options.commit
+					} ${options.pin ? '--pin-device-to-release ' : ''}`,
 				],
 				{
 					stdio: 'pipe',

--- a/documentation/Getting-started.md
+++ b/documentation/Getting-started.md
@@ -239,7 +239,7 @@ await exec(
 ```
 
 ### Cloud helpers
-The `BalenaSDK` class, defined in `core/components/balena/sdk`, contains an instance of the balena sdk, as well as some helper methods that you can examine in the file. The `balena` attribute of the class contains the sdk, which can then be used as follows:
+The `BalenaSDK` class, defined in [`core/components/balena/sdk`](https://github.com/balena-os/leviathan/blob/master/core/lib/components/balena/sdk.js), contains an instance of the balena sdk, as well as some helper methods. The `balena` attribute of the class contains the sdk, which can then be used as follows:
 ```js
 const Cloud = this.require("components/balena/sdk");
 

--- a/documentation/Getting-started.md
+++ b/documentation/Getting-started.md
@@ -238,8 +238,31 @@ await exec(
 ); 
 ```
 
-### Using balena sdk
-Balena SDK is imported into the testing environment by default, so you can create an instance of the SDK and use it to manipulate the device or applications from within tests (in this exampe using context so we can use it in all tests): 
+### Cloud helpers
+The `BalenaSDK` class, defined in `core/components/balena/sdk`, contains an instance of the balena sdk, as well as some helper methods that you can examine in the file. The `balena` attribute of the class contains the sdk, which can then be used as follows:
+```js
+const Cloud = this.require("components/balena/sdk");
+
+this.suite.context.set({
+	cloud: new Balena(`https://api.balena-cloud.com/`, this.getLogger())
+});
+
+
+// login
+await this.context
+	.get()
+	.cloud.balena.auth.loginWithToken(this.suite.options.balena.apiKey);
+
+// create a balena application
+await this.context.get().cloud.balena.models.application.create({
+	name: `NAME`,
+	deviceType: `DEVICE_TYPE`,
+	organization: `ORG`,
+});
+
+```
+
+Alternatively, Balena SDK is imported into the testing environment by default, so you can create an instance of the SDK and use it without the cloud helpers class:
 
 ```js
 this.suite.context.set({


### PR DESCRIPTION
adds several helpers to `lib/components/sdk.js` intended to help with tests involving balena cloud

- push to application
- wait until services running
- get supervisor version
- execute command in container