### PR TITLE
fix hdmi capture

### DIFF
--- a/client/bin/multi-client.js
+++ b/client/bin/multi-client.js
@@ -135,7 +135,7 @@ class NonInteractiveState {
 		const downloadLog = request
 			.get(dutLogUrl)
 			.pipe(nativeFs.createWriteStream(`reports/dut-serial-${workerData.prefix}.log`));
-		await new Promise(resolve =>
+		let downloadLogDone =  new Promise(resolve =>
 			downloadLog.on('end', resolve).on('error', resolve),
 		);
 		const dutArtifactUrl = `${workerData.workerUrl}/artifacts`;
@@ -143,9 +143,11 @@ class NonInteractiveState {
 		const downloadImages = request
 			.get(dutArtifactUrl)
 			.pipe(nativeFs.createWriteStream(`reports/artifacts-${workerData.prefix}.tar.gz`));
-		await new Promise(resolve =>
+		let downloadArtifactDone =  new Promise(resolve =>
 			downloadImages.on('end', resolve).on('error', resolve),
 		);
+
+		await Promise.all([downloadLogDone, downloadArtifactDone])
 	}
 
 	async teardown() {

--- a/client/bin/multi-client.js
+++ b/client/bin/multi-client.js
@@ -140,7 +140,7 @@ class NonInteractiveState {
 		console.log(`Downloading artifacts`);
 		const downloadImages = request
 			.get(dutArtifactUrl)
-			.pipe(nativeFs.createWriteStream(`reports/artifacts.tar.gz`));
+			.pipe(nativeFs.createWriteStream(`reports/artifacts-${workerData.prefix}.tar.gz`));
 		await new Promise(resolve =>
 			downloadImages.on('end', resolve).on('error', resolve),
 		);

--- a/client/bin/multi-client.js
+++ b/client/bin/multi-client.js
@@ -135,8 +135,14 @@ class NonInteractiveState {
 		const download = request
 			.get(dutLogUrl)
 			.pipe(nativeFs.createWriteStream(`reports/dut-serial-${workerData.prefix}.log`));
+
+		const dutArtifactUrl = `${workerData.workerUrl}/artifacts`;
+		console.log(`Downloading artifacts`);
+		const downloadImages = request
+			.get(dutArtifactUrl)
+			.pipe(nativeFs.createWriteStream(`reports/artifacts.tar.gz`));
 		await new Promise(resolve =>
-			download.on('end', resolve).on('error', resolve),
+			downloadImages.on('end', resolve).on('error', resolve),
 		);
 	}
 

--- a/client/bin/multi-client.js
+++ b/client/bin/multi-client.js
@@ -132,10 +132,12 @@ class NonInteractiveState {
 		}
 		const dutLogUrl = `${workerData.workerUrl}/reports/dut-serial.txt`;
 		console.log(`Downloading DUT serial log with ${dutLogUrl}`);
-		const download = request
+		const downloadLog = request
 			.get(dutLogUrl)
 			.pipe(nativeFs.createWriteStream(`reports/dut-serial-${workerData.prefix}.log`));
-
+		await new Promise(resolve =>
+			downloadLog.on('end', resolve).on('error', resolve),
+		);
 		const dutArtifactUrl = `${workerData.workerUrl}/artifacts`;
 		console.log(`Downloading artifacts`);
 		const downloadImages = request

--- a/compose/balena.yml
+++ b/compose/balena.yml
@@ -1,7 +1,6 @@
 version: '2.1'
 volumes:
   core-storage:
-  worker-storage:
   reports-storage:
 services:
   core:
@@ -11,7 +10,6 @@ services:
     network_mode: host
     volumes:
       - 'core-storage:/data'
-      - 'worker-storage:/worker'
       - 'reports-storage:/reports'
     labels:
       share: core-storage
@@ -25,7 +23,7 @@ services:
     network_mode: host
     ipc: host
     volumes:
-      - 'worker-storage:/data'
+      - 'core-storage:/data'
       - 'reports-storage:/reports'
     labels:
       io.balena.features.dbus: '1'

--- a/compose/balena.yml
+++ b/compose/balena.yml
@@ -11,6 +11,7 @@ services:
     network_mode: host
     volumes:
       - 'core-storage:/data'
+      - 'worker-storage:/worker'
       - 'reports-storage:/reports'
     labels:
       share: core-storage

--- a/core/lib/common/suite.js
+++ b/core/lib/common/suite.js
@@ -22,6 +22,7 @@ const isEmpty = require('lodash/isEmpty');
 const isObject = require('lodash/isObject');
 const isString = require('lodash/isString');
 const template = require('lodash/template');
+const fs = require('fs-extra');
 
 const AJV = require('ajv');
 const ajv = new AJV();
@@ -93,6 +94,10 @@ class Suite {
 	async init() {
 		await Bluebird.try(async () => {
 			await this.installDependencies();
+			if(fs.existsSync(config.get('leviathan.artifacts'))){
+				this.state.log(`Removing artifacts from previous tests...`);
+				fs.emptyDirSync(config.get('leviathan.artifacts'))
+			}
 			this.rootTree = this.resolveTestTree(
 				path.join(config.get('leviathan.uploads.suite'), 'suite'),
 			);

--- a/documentation/Getting-started.md
+++ b/documentation/Getting-started.md
@@ -299,6 +299,32 @@ module.exports = {
 }
 ```
 
+
+### Screen capture
+If screen capture is supported and appropriate hardware is attached, the video output of the DUT can be captured. For the testbot, this requires a compatible video capture device to be connected, that works with v4l2 and enumerates on the `/dev/video0 interface`.
+
+If that is the case, then capture can be started using the `Worker` class `capture()` method, for example:
+```js
+const Worker = this.require('common/worker');
+const worker = new Worker('DEVICE_TYPE_SLUG', this.getLogger())
+await worker.capture('start');
+```
+
+This will trigger video capture to start, and frames will be saved as `jpg` files to the shared volume at `/data/capture`. Capture will continue until stopped with:
+
+```js
+await worker.capture('stop');
+```
+### Sending reports and artifacts back to the client from the testbot
+By default, serial logs (given that the hardware is set up correctly), and the logs from the tests will be sent back to the client that started the test, upon the test finishing. Other artifacts can be sent back to the client using the `archiver` method. This method is available within any test:
+
+```js
+this.archiver.add(`FILE OR DIRECTORY`)
+```
+
+Using this method, at the end of the test, any artifacts added to the archive are zipped and downloaded by the client.
+
+
 ### What should go in the suite.js of a suite
 The recommended pattern is to put the code that gets the device into the state ready for the tests, into the suite. 
 Usually, this will include:

--- a/documentation/Getting-started.md
+++ b/documentation/Getting-started.md
@@ -301,7 +301,7 @@ module.exports = {
 
 
 ### Screen capture
-If screen capture is supported and appropriate hardware is attached, the video output of the DUT can be captured. For the testbot, this requires a compatible video capture device to be connected, that works with v4l2 and enumerates on the `/dev/video0 interface`.
+If screen capture is supported and appropriate hardware is attached, the video output of the DUT can be captured. For the testbot, this requires a compatible video capture device to be connected, that works with v4L2 and enumerates on the `/dev/video0` interface.
 
 If that is the case, then capture can be started using the `Worker` class `capture()` method, for example:
 ```js
@@ -310,7 +310,7 @@ const worker = new Worker('DEVICE_TYPE_SLUG', this.getLogger())
 await worker.capture('start');
 ```
 
-This will trigger video capture to start, and frames will be saved as `jpg` files to the shared volume at `/data/capture`. Capture will continue until stopped with:
+This will trigger video capture to start, and frames will be saved as `jpg` files in the `/data/capture` directory (which is a shared volume). Capture will continue until stopped with:
 
 ```js
 await worker.capture('stop');
@@ -322,7 +322,7 @@ By default, serial logs (given that the hardware is set up correctly), and the l
 this.archiver.add(`FILE OR DIRECTORY`)
 ```
 
-Using this method, at the end of the test, any artifacts added to the archive are zipped and downloaded by the client.
+Using this method, at the end of the test, any artifacts added to the archive are compressed and downloaded by the client. These are available in the `workspace/reports` directory at the end of the test.
 
 
 ### What should go in the suite.js of a suite

--- a/worker/config/default.js
+++ b/worker/config/default.js
@@ -4,7 +4,7 @@ module.exports = {
 		runtimeConfiguration: {
 			workdir: process.env.WORKDIR || '/data',
 			workerType: process.env.WORKER_TYPE || 'testbot_hat',
-			screenCapture: (process.env.SCREEN_CAPTURE || 'true') === 'true',
+			screenCapture: process.env.SCREEN_CAPTURE === 'true',
 			network: {
 				wired: process.env.NETWORK_WIRED_INTERFACE || 'eth1',
 				wireless: process.env.NETWORK_WIRELESS_INTERFACE || 'wlan0',

--- a/worker/lib/helpers/graphics.ts
+++ b/worker/lib/helpers/graphics.ts
@@ -99,7 +99,7 @@ export default class ScreenCapture {
 		}
 	}
 
-	public stopCapture(): Promise<Readable> {
+	public stopCapture(): Promise<void> {
 		return new Promise(async (resolve, reject) => {
 			if (this.proc != null) {
 				const clean = () => {
@@ -113,15 +113,7 @@ export default class ScreenCapture {
 				};
 				const exitHandler = () => {
 					clean();
-
-					resolve(
-						pack(this.destination, {
-							map: header => {
-								header.name = basename(header.name);
-								return header;
-							},
-						}).pipe(createGzip()),
-					);
+					resolve();
 				};
 
 				// For an unknown reason the gst process sometimes refuses to die, so let's check

--- a/worker/lib/index.ts
+++ b/worker/lib/index.ts
@@ -26,6 +26,7 @@ async function setup(): Promise<express.Application> {
 	]({
 		worker: { workdir: runtimeConfiguration.workdir },
 		network: runtimeConfiguration.network,
+		screenCapture: runtimeConfiguration.screenCapture
 	});
 
 	/**

--- a/worker/lib/index.ts
+++ b/worker/lib/index.ts
@@ -145,9 +145,8 @@ async function setup(): Promise<express.Application> {
 			next: express.NextFunction,
 		) => {
 			try {
-				res.connection.setTimeout(0);
-				// Forcing the type as the return cannot be void
-				((await worker.captureScreen('stop')) as Readable).pipe(res);
+				await worker.captureScreen('stop');
+				res.send('OK')
 			} catch (err) {
 				next(err);
 			}

--- a/worker/lib/workers/testbot.ts
+++ b/worker/lib/workers/testbot.ts
@@ -44,7 +44,7 @@ class TestBotWorker extends EventEmitter implements Leviathan.Worker {
 				this.networkCtl = new NetworkManager(options.network);
 			}
 
-			if (options.screen != null) {
+			if (options.screenCapture === true) {
 				this.screenCapturer = new ScreenCapture(
 					{
 						type: 'v4l2src',

--- a/worker/typings/worker.d.ts
+++ b/worker/typings/worker.d.ts
@@ -49,6 +49,7 @@ declare global {
 						wired: string;
 				  };
 			screen?: { VNC: { host: string; port: string }; HDMI: { dev: number } };
+			screenCapture?: boolean
 		}
 	}
 }


### PR DESCRIPTION
This PR re-enables the capability for screen capture. In this old PR (https://github.com/balena-os/leviathan/commit/276e24a815e1985c29f28ac3ee91c3289d10e547), the /select route of the worker was removed. This prevented the `screen` option from being passed to the worker object (e.g the testbot worker object), which meant the screen capture could not be enabled.

This PR is required in order to run the HDMI boot-splash test


Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>