### PR TITLE
make timeout on waitUntilServicesRunning() configurable

### DIFF
--- a/core/lib/components/balena/sdk.js
+++ b/core/lib/components/balena/sdk.js
@@ -465,8 +465,9 @@ module.exports = class BalenaSDK {
 	 * @param The UUID of the device
 	 * @param An array of the service names
 	 * @param The release commit hash that services should be on
+	 * @param (optional) The number of attemps to retry. Retries are spaced 30s apart
 	*/
-	async waitUntilServicesRunning(uuid, services, commit){
+	async waitUntilServicesRunning(uuid, services, commit, __times = 50){
 		await utils.waitUntil(async () => {
 			let deviceServices = await this.balena.models.device.getWithServiceDetails(
 				uuid
@@ -476,7 +477,7 @@ module.exports = class BalenaSDK {
 				return (deviceServices.current_services[service][0].status === "Running") && (deviceServices.current_services[service][0].commit === commit)
 			})
 			return running;
-		}, false)
+		}, false, __times)
 	}
 
 	/** Executes the command in the targetted container of a device


### PR DESCRIPTION
We have had multiple tests that use the /core/components/sdk.js `waitUntilServicesRunning()` function fail when running on the RPi0 because the device is slow, and was thus exceeding the ~10 minute timeout (20 tries, 30 seconds apart) that was hard coded into this function. 

This fix allows the user of the function to configure the number of retries.

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>