### PR TITLE
Prevent throwing errors in waitUntil of pushContainerToDUT helper

### DIFF
--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -204,22 +204,17 @@ module.exports = class Worker {
 		);
 
 		// now wait for new container to be available
+		let state = {};
 		await utils.waitUntil(async () => {
-			const state = await rp({
+			state = await rp({
 				method: 'GET',
 				uri: `http://${target}:48484/v2/containerId`,
 				json: true,
 			});
 
 			return state.services[containerName] != null;
-		});
+		}, false);
 
-		const state = await rp({
-			method: 'GET',
-			uri: `http://${target}:48484/v2/containerId`,
-			json: true,
-		});
-		
 		return state
 	}
 


### PR DESCRIPTION
In a test here: https://jenkins.dev.resin.io/job/leviathan-raspberry-pi/741/console

We seemed to have a socket-hang up error when trying to make a get request to the supervisor to fetch a container ID. This PR makes sure that the retry that is is place doesn't throw if we can't contact the supervisor, and tries again. 

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>