### PR TITLE
Make changes to upload retry mechanism

### DIFF
--- a/client/bin/multi-client.js
+++ b/client/bin/multi-client.js
@@ -456,7 +456,7 @@ class State {
 					// check if device is idle & public URL is reachable
 					let deviceUrl = await balenaCloud.resolveDeviceUrl(device)
 					try{
-						let status = await rp.get(`${(url.parse(deviceUrl)).href}/state`);
+						let status = await rp.get(`${deviceUrl}/state`);
 						if (status === "IDLE") {
 							// make sure that the worker being targetted isn't already about to be used by another child process
 							if(!busyWorkers.includes(deviceUrl)){

--- a/client/lib/index.js
+++ b/client/lib/index.js
@@ -81,7 +81,7 @@ module.exports = class Client extends PassThrough {
 
 	async handleArtifact(artifact, token, attempt) {
 		if (attempt > 1){
-			this.log(`Previously failed to upload artifact - retrying...`);
+			this.log(`Previously failed to upload artifact ${artifact.name} - retrying...`);
 		}
 		const ignore = ['node_modules', 'package-lock.json'];
 
@@ -218,9 +218,7 @@ module.exports = class Client extends PassThrough {
 				const pipeEnd = zlib.createGzip({ level: 6 });
 				const line = pipeline(metadata.stream, str, pipeEnd)
 					.delay(1000)
-					.catch(e => {
-						throw e
-					});
+					.catch(error => {throw error});
 				pipeEnd.pipe(req);
 
 				req.on('data', async data => {

--- a/core/lib/main.js
+++ b/core/lib/main.js
@@ -114,16 +114,12 @@ async function setup() {
 			} else {
 				res.write('upload: start');
 				// Make sure we start clean
-				await remove(artifact.path);
-				const gz = createGunzip()
-				const tarExtr = tar.extract(config.get('leviathan.workdir'))
-
+				await remove(artifact.path);				
 				const line = pipeline(
 					req,
-					gz,
-					tarExtr,
+					createGunzip(),
+					tar.extract(config.get('leviathan.workdir')),
 				).catch((err) =>{ 
-					console.log(err)
 					throw err 
 				})
 
@@ -132,7 +128,7 @@ async function setup() {
 				res.write('upload: done');
 			}
 		} catch (e) {
-			console.log(`detected error ${e}`)
+			console.log(`Error detected: ${e}`)
 			upload.error = e
 			upload.success = false
 		} finally {


### PR DESCRIPTION
We were often seeing an error during the upload of images from clients to workers. After a long investigation in to why, I think that the following was the problem:

1. core asks for image, client receives that request
2. client responds by sending image
3. in core, if there is a connection problem, the stream is closed. 
4. an error is created in core, and it tries to signal this to the client - this message never made it back to the client, because the stream was closed - therefore the client never attempted to retry
5. There was no mechanism for the core to know that it had failed the transfer of the image, so it requested the next artifact

So mainly there were 2 problems:
1. if an error happened during the transfer of the image, related to the stream closing early, there was no way to know - so the process would continue, and when the image was unpacked in the suite, the zlib "unexpected end of file" error appeared
2. Even if we did alert the client that something went wrong, the client would still ask for the next artifact - this would lead to the core re-attempting to send the image, alongside the config or suite, leading to unauthorized upload errors

-----------------
In this PR, I tried to change the retry mechanism around - if there is an error in the transfer, the core detects it, and requests that the client re-sends the artifact. Alongside the request, it also sends the number of attempts that have been made so far. After 4 failed attempts, the process throws an error, which will then cause the client and core to gracefully stop