### PR TITLE
Generalise os helpers

### DIFF
--- a/core/config/default.js
+++ b/core/config/default.js
@@ -12,6 +12,7 @@ module.exports = {
   },
   leviathan: {
     artifacts: '/tmp/artifacts',
+    downloads: '/tmp/downloads', // add an images directory in /tmp
     workdir: '/data',
     uploads: defer(function() {
       return mapValues({ image: 'os.img', config: 'config.json', suite: 'suite' }, value => {

--- a/core/config/default.js
+++ b/core/config/default.js
@@ -11,8 +11,8 @@ module.exports = {
     port: 2000
   },
   leviathan: {
-    artifacts: '/tmp/artifacts',
-    downloads: '/tmp/downloads', // add an images directory in /tmp
+    artifacts: '/tmp/artifacts',    // To store artifacts meant to be reported as results at the end of the suite
+    downloads: '/tmp/downloads',    // To store/download assets needed for the suite (non-persistent) 
     workdir: '/data',
     uploads: defer(function() {
       return mapValues({ image: 'os.img', config: 'config.json', suite: 'suite' }, value => {

--- a/core/lib/common/suite.js
+++ b/core/lib/common/suite.js
@@ -94,6 +94,7 @@ class Suite {
 	async init() {
 		await Bluebird.try(async () => {
 			await this.installDependencies();
+			await fs.ensureDir(config.get('leviathan.downloads'));
 			if(fs.existsSync(config.get('leviathan.artifacts'))){
 				this.state.log(`Removing artifacts from previous tests...`);
 				fs.emptyDirSync(config.get('leviathan.artifacts'))
@@ -103,6 +104,7 @@ class Suite {
 			);
 		}).catch(async error => {
 			await this.removeDependencies();
+			await this.removeDownloads();
 			throw error;
 		});
 	}
@@ -171,6 +173,7 @@ class Suite {
 			await treeExpander([this.rootTree, tap]);
 		} finally {
 			await this.removeDependencies();
+			await this.removeDownloads();
 			await this.teardown.runAll();
 			tap.end();
 		}
@@ -247,6 +250,13 @@ class Suite {
 		await Bluebird.promisify(fse.remove)(
 			path.join(config.get('leviathan.uploads.suite'), 'node_modules'),
 		);
+	}
+
+	async removeDownloads(){
+		if(fs.existsSync(config.get('leviathan.downloads'))){
+			this.state.log(`Removing downloads directory...`);
+			fs.emptyDirSync(config.get('leviathan.downloads'))
+		}
 	}
 }
 

--- a/core/lib/common/suite.js
+++ b/core/lib/common/suite.js
@@ -253,7 +253,7 @@ class Suite {
 	}
 
 	async removeDownloads(){
-		if(fs.existsSync(config.get('leviathan.downloads'))){
+		if (fs.existsSync(config.get('leviathan.downloads'))) {
 			this.state.log(`Removing downloads directory...`);
 			fs.emptyDirSync(config.get('leviathan.downloads'))
 		}

--- a/core/lib/common/test.js
+++ b/core/lib/common/test.js
@@ -39,7 +39,7 @@ module.exports = class Test {
 		this.id = id;
 
 		this.teardown = {
-			run: async() => {
+			run: async () => {
 				await suite.teardown.run(this.id);
 			},
 			register: fn => {

--- a/core/lib/common/test.js
+++ b/core/lib/common/test.js
@@ -39,8 +39,8 @@ module.exports = class Test {
 		this.id = id;
 
 		this.teardown = {
-			run: () => {
-				suite.teardown.run(this.id);
+			run: async() => {
+				await suite.teardown.run(this.id);
 			},
 			register: fn => {
 				this.suite.teardown.register(fn, id);

--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -247,4 +247,24 @@ module.exports = class Worker {
 		}, false);
 		this.logger.log(`DUT has rebooted & is back online`);
 	};
+
+	async getOSVersion(target){
+		// maybe https://github.com/balena-io/leviathan/blob/master/core/lib/components/balena/sdk.js#L210
+		// will do? that one works entirely on the device though...
+		const output = await this.executeCommandInHostOS(
+			"cat /etc/os-release",
+			target
+		  );
+		let match;
+		output
+		  .split("\n")
+		  .every(x => {
+			if (x.startsWith("VERSION=")) {
+			  match = x.split("=")[1];
+			  return false;
+			}
+			return true;
+		  })
+		return match.replace(/"/g, '');
+	  }
 };

--- a/core/lib/components/balena/sdk.js
+++ b/core/lib/components/balena/sdk.js
@@ -26,6 +26,8 @@ const Bluebird = require('bluebird');
 const retry = require('bluebird-retry');
 const utils = require('../../common/utils');
 const exec = Bluebird.promisify(require('child_process').exec);
+const config = require('config');
+
 // const fse = require('fs-extra')
 // const semver = require('balena-semver')
 // var glob = require("glob")
@@ -559,8 +561,7 @@ module.exports = class BalenaSDK {
 			version = versions.latest.replace('prod', 'dev');
 		}
 
-		if (!fs.existsSync(`/data/images/`)) fs.mkdirSync(`/data/images/`);
-		const path = join(`/data/images/`, `balenaOs-${version}.img`);
+		const path = join(config.get('leviathan.downloads'), `balenaOs-${version}.img`);
 
 		// Caching implmentation in progress - Not yet complete
 		// glob("/data/images/balenaOs-*.img", (err, files) => {

--- a/core/lib/components/os/balenaos.js
+++ b/core/lib/components/os/balenaos.js
@@ -103,7 +103,7 @@ module.exports = class BalenaOS {
 		this.network = options.network;
 		this.image = {
 			input: options.image || config.get('leviathan.uploads').image,
-			path: join(config.get('leviathan.workdir'), `image-${id()}`)
+			path: join(config.get('leviathan.downloads'), `image-${id()}`)
 		};
 		this.configJson = options.configJson || {};
 		this.contract = {

--- a/core/lib/components/os/balenaos.js
+++ b/core/lib/components/os/balenaos.js
@@ -22,7 +22,7 @@ const mapValues = require('lodash/mapValues');
 const Bluebird = require('bluebird');
 const config = require('config');
 const imagefs = require('resin-image-fs');
-const fs = Bluebird.promisifyAll(require('fs'));
+const { fs } = require('mz');
 const { join } = require('path');
 const pipeline = Bluebird.promisify(require('stream').pipeline);
 const zlib = require('zlib');
@@ -46,7 +46,7 @@ const injectNetworkConfiguration = async (image, configuration) => {
 	}
 	if (configuration.wireless.ssid == null) {
 		throw new Error(
-			`Invalide wireless configuration: ${configuration.wireless}`,
+			`Invalid wireless configuration: ${configuration.wireless}`,
 		);
 	}
 
@@ -84,6 +84,16 @@ const injectNetworkConfiguration = async (image, configuration) => {
 	);
 };
 
+async function isGzip(filePath) {
+	const buf = Buffer.alloc(3);
+	await fs.read(await fs.open(filePath, 'r'), buf, 0, 3, 0);
+	return buf[0] === 0x1f && buf[1] === 0x8b && buf[2] === 0x08;
+}
+
+function id() {
+	return `${Math.random().toString(36).substring(2, 10)}`;
+}
+
 module.exports = class BalenaOS {
 	constructor(
 		options = {},
@@ -91,7 +101,10 @@ module.exports = class BalenaOS {
 	) {
 		this.deviceType = options.deviceType;
 		this.network = options.network;
-		this.image = { path: join(config.get('leviathan.workdir'), 'image') };
+		this.image = {
+			input: options.image || config.get('leviathan.uploads').image,
+			path: join(config.get('leviathan.workdir'), `image-${id()}`)
+		};
 		this.configJson = options.configJson || {};
 		this.contract = {
 			network: mapValues(this.network, value => {
@@ -99,89 +112,70 @@ module.exports = class BalenaOS {
 			}),
 		};
 		this.logger = logger;
+		this.releaseInfo = { version: null, variant: null };
 	}
 
-	unpack(download) {
-		const types = {
-			local: async () => {
-				await pipeline(
-					fs.createReadStream(download.source),
-					zlib.createGunzip(),
-					fs.createWriteStream(this.image.path),
+	// calling the fetch method will prepare the image to be used - either unzipping it or moving it to the working directory
+	async fetch() {
+		this.logger.log(`Unpacking the file: ${this.image.input}`);
+		const unpack = await isGzip(this.image.input);
+		if (unpack) {
+			await pipeline(
+				fs.createReadStream(this.image.input),
+				zlib.createGunzip(),
+				fs.createWriteStream(this.image.path),
+			);
+		} else {
+			// image is already unzipped, so no need to do anything
+			this.image.path = this.image.input;
+		}
+	}
+
+	async readOsRelease(image = this.image.path) {
+		const readVersion = async (pattern, field) => {
+			this.logger.log(`Checking ${field} in os-release`);
+			try {
+				const value = pattern.exec(
+					await imagefs.readFile({
+						image: image,
+						partition: 1,
+						path: '/os-release',
+					}),
 				);
-
-				const res = download.releaseInfo || { version: null, variant: null };
-
-				const readOsRelease = async (pattern, field) => {
-					this.logger.log(`Checking ${field} in os-release`);
-					try {
-						const value = pattern.exec(
-							await imagefs.readFile({
-								image: this.image.path,
-								partition: 1,
-								path: '/os-release',
-							}),
-						);
-						if (value) {
-							res[field] = value[1];
-							this.logger.log(
-								`Found ${field} in os-release file: ${res[field]}`,
-							);
-						}
-					} catch (e) {
-						// If os-release file isn't found, look inside the image to be flashed
-						// Especially in case of OS image inside flasher images. Example: Intel-NUC
-						try {
-							const value = pattern.exec(
-								await imagefs.readFile({
-									image: this.image.path,
-									partition: 2,
-									path: '/etc/os-release',
-								}),
-							);
-							if (value) {
-								res[field] = value[1];
-							}
-						} catch (err) {
-							this.logger.log(
-								`Cannot detect ${field} with os-release. Error: ${err}`,
-							);
-						}
+				if (value) {
+					this.releaseInfo[field] = value[1];
+					this.logger.log(
+						`Found ${field} in os-release file: ${this.releaseInfo[field]}`,
+					);
+				}
+			} catch (e) {
+				// If os-release file isn't found, look inside the image to be flashed
+				// Especially in case of OS image inside flasher images. Example: Intel-NUC
+				try {
+					const value = pattern.exec(
+						await imagefs.readFile({
+							image: image,
+							partition: 2,
+							path: '/etc/os-release',
+						}),
+					);
+					if (value) {
+						this.releaseInfo[field] = value[1];
 					}
-				};
-
-				if (!res.version) {
-					await readOsRelease(/VERSION="(.*)"/g, 'version');
+				} catch (err) {
+					this.logger.log(
+						`Cannot detect ${field} with os-release. Error: ${err}`,
+					);
 				}
-				if (!res.variant) {
-					await readOsRelease(/VARIANT="(.*)"/g, 'variant');
-				}
-
-				return res;
-			},
-
-			gunzip: async () => {
-				await pipeline(
-					fs.createReadStream(download.source),
-					zlib.createGunzip(),
-					fs.createWriteStream(this.image.path),
-				);
 			}
 		};
 
-		return types[download.type]();
-	}
-
-	async fetch(download) {
-		this.logger.log('Unpacking the operating system');
-		assignIn(
-			this.contract,
-			await this.unpack({
-				type: download.type,
-				source: config.get('leviathan.uploads').image,
-				releaseInfo: download.releaseInfo,
-			}),
-		);
+		await readVersion(/VERSION="(.*)"/g, 'version');
+		await readVersion(/VARIANT="(.*)"/g, 'variant');
+		assignIn(this.contract, {
+			version: this.releaseInfo.version,
+			variant: this.releaseInfo.variant,
+		});
 	}
 
 	addCloudConfig(configJson) {
@@ -189,7 +183,8 @@ module.exports = class BalenaOS {
 	}
 
 	async configure() {
-		this.logger.log(`Configuring balenaOS image: ${this.image.path}`);
+		this.readOsRelease();
+		this.logger.log(`Configuring balenaOS image: ${this.image.input}`);
 		if (this.configJson) {
 			await injectBalenaConfiguration(this.image.path, this.configJson);
 		}


### PR DESCRIPTION
Previously the `balenaOS` class was only usable with the image that is sent from a client. In cases where users want to download an image instead it wasn't simple to use. 

This PR allows users to provide a custom path to an OS image when creating an instance of the object.

For example, when using the OS image that is sent from the client: 
```js
this.suite.context.set({
      os: new BalenaOS(
        {
          deviceType: this.suite.deviceType.slug,
          network: this.suite.options.balenaOS.network,
          configJson: {
            uuid: this.suite.options.balenaOS.config.uuid,
            os: {
              sshKeys: [
                await this.context
                  .get()
                  .utils.createSSHKey(this.context.get().sshKeyPath),
              ],
            },
            // persistentLogging is managed by the supervisor and only read at first boot
            persistentLogging: true,
            // Set local mode so we can perform local pushes of containers to the DUT
            localMode: true,
          },
        },
        this.getLogger()
      ),
    });

 await this.context.get().os.fetch();
 await this.context.get().os.configure();
```

In the case of using an image downloaded via the sdk:
```js
this.suite.context.set({
      os: new BalenaOS(
        {
          image: `PATH_TO_IMAGE`,
          deviceType: this.suite.deviceType.slug,
          network: this.suite.options.balenaOS.network,
          configJson: {
            uuid: this.suite.options.balenaOS.config.uuid,
            os: {
              sshKeys: [
                await this.context
                  .get()
                  .utils.createSSHKey(this.context.get().sshKeyPath),
              ],
            },
            // persistentLogging is managed by the supervisor and only read at first boot
            persistentLogging: true,
            // Set local mode so we can perform local pushes of containers to the DUT
            localMode: true,
          },
        },
        this.getLogger()
      ),
    });

 await this.context.get().os.fetch();
 await this.context.get().os.configure();
```
