### PR TITLE
add log timestamping

### DIFF
--- a/client/bin/multi-client.js
+++ b/client/bin/multi-client.js
@@ -65,7 +65,7 @@ class NonInteractiveState {
 
 	logForWorker(workerId, data) {
 		const str = data.toString().trimEnd();
-		const timestamp = new Date().toUTCString()
+		const timestamp = new Date().toISOString()
 		console.log(`[${timestamp}][${workerId}] ${str}`);
 		this.workersData[workerId].workerLog.write(`${str}\n`, 'utf8');
 	}

--- a/client/bin/multi-client.js
+++ b/client/bin/multi-client.js
@@ -65,7 +65,8 @@ class NonInteractiveState {
 
 	logForWorker(workerId, data) {
 		const str = data.toString().trimEnd();
-		console.log(`[${workerId}] ${str}`);
+		const timestamp = new Date().toUTCString()
+		console.log(`[${timestamp}][${workerId}] ${str}`);
 		this.workersData[workerId].workerLog.write(`${str}\n`, 'utf8');
 	}
 


### PR DESCRIPTION
This adds timestamps to logs recieved by the client. Example output:

```
[2021-06-18T15:36:18.953Z][af82ff1-os] found 0 vulnerabilities
[2021-06-18T15:36:19.004Z][af82ff1-os] Removing artifacts from previous tests...
[2021-06-18T15:36:20.066Z][af82ff1-os] Run queue summary:
[2021-06-18T15:36:20.067Z][af82ff1-os]  Unmanaged BalenaOS release suite
[2021-06-18T15:36:20.067Z][af82ff1-os]   OS corruption tests
[2021-06-18T15:36:20.068Z][af82ff1-os]           resinos.fingerprint file test
[2021-06-18T15:36:20.068Z][af82ff1-os]   OS-release tests
[2021-06-18T15:36:20.068Z][af82ff1-os]           OS-release file check
[2021-06-18T15:36:20.068Z][af82ff1-os]   chrony tests
```

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>