### PR TITLE
patch: Update waitUntil helper's rejection condition to default false

### DIFF
--- a/core/lib/common/utils.js
+++ b/core/lib/common/utils.js
@@ -84,7 +84,7 @@ module.exports = {
 	},
 	waitUntil: async (
 		promise,
-		rejectionFail = true,
+		rejectionFail = false,
 		_times = 20,
 		_delay = 30000,
 	) => {


### PR DESCRIPTION
waitUntil is a helper that runs a function for a designated number of times till it satisfies a particular condition to break out of the loop. In the current implementation, if `rejectionFail` is `true` and if the command fails to satisfy the condition in an iteration then the `waitUntil` helper returns an error which isn't quite helpful for a function that is meant to continuously wait until something is complete. Hence, the change to make `rejectionFail` as default to `false` in the `waitUntil` helper