### PR TITLE
Document Leviathan Helpers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@ workspace/
 documentation/
 
 .balena/secrets/
+core/docs

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 > A distributed testing framework for hardware 
 ## Getting Started
 
-To set up Leviathan both hardware and software need to be configured. If you are setting up your standalone testbot, then please follow the instructions given below carefully before running tests on the Device Under Test (DUT). 
+To set up Leviathan both hardware and software need to be configured. If you are setting up your standalone testbot, then please follow the instructions given below carefully before running tests on the Device Under Test (DUT).
 
 ### Clone the repository
 
@@ -43,6 +43,15 @@ balena push <appname>
 ```
 
 To monitior leviathan tests connected to its pipeline for the rigs, you would need to request Jenkins access.
+
+## Documentation for Leviathan Helpers
+
+Documentation for Leviathan helpers can be found on https://balena-os.github.io/leviathan
+To generate the documentation, run the following command from either the root of the repository or the `core` directory.
+
+```
+npm run docs
+```
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -47,12 +47,19 @@ To monitior leviathan tests connected to its pipeline for the rigs, you would ne
 ## Documentation for Leviathan Helpers
 
 Documentation for Leviathan helpers can be found on https://balena-os.github.io/leviathan
-To generate the documentation, run the following command from either the root of the repository or the `core` directory.
+To generate the documentation, run the following command from either the root of the repository or the `core` directory. 
 
 ```
 npm run docs
 ```
 
+If the docs are generated successfully, you will be getting the success line as:
+
+```
+Info: Documentation generated at /path/to/documentation
+```
+
+Head there to find the documentation by double clicking the index.html page
 ## Support
 
 If you're having any problem, please [raise an issue][newissue] on GitHub and the balena team will be happy to help.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Documentation for Leviathan helpers can be found on https://balena-os.github.io/
 To generate the documentation, run the following command from either the root of the repository or the `core` directory. 
 
 ```
+npm install
 npm run docs
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To set up Leviathan both hardware and software need to be configured. If you are
 ### Configuration needed
 
 - Start building your standalone testbot by [following the guide](https://github.com/balena-io/testbot/blob/master/documentation/getting-started.md#quick-start-guide-for-testbot). 
-- Create your test configuration, by creating a `config.json` file in the `workspace` directory, following instructions mentioned in the [leviathan docs](https://github.com/balena-io/testbot/blob/master/documentation/getting-started.md#run-your-first-test).
+- Create your test configuration, by creating a `config.json` file in the `workspace` directory, following instructions mentioned in the [leviathan docs](https://github.com/balena-io/testbot/blob/master/documentation/quickstart.md).
 - Extract the image you want to test to `./leviathan/workspace` and rename it to `balena.img` 
 
 ### Running tests

--- a/README.md
+++ b/README.md
@@ -5,88 +5,40 @@
 [![node](https://img.shields.io/badge/node-v9.0.0-green.svg)](https://nodejs.org/download/release/v9.0.0/)
 [![License](https://img.shields.io/badge/license-APACHE%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-> A distributed testing framework 
-
+> A distributed testing framework for hardware 
 ## Getting Started
 
 To set up Leviathan both hardware and software need to be configured. If you are setting up your standalone testbot, then please follow the instructions given below carefully before running tests on the Device Under Test (DUT). 
-
 
 ### Clone the repository
 
 - Clone this repository with `git clone --recursive` or   
 - Run `git clone` and then `git submodule update --init --recursive` to install submodules.
-
-
+- 
 ### Prerequisites needed
 
 - Install node and npm in your system. We recommend installing [LTS versions from NVM](https://github.com/nvm-sh/nvm#install--update-script).
 - Download the image you want to test on your DUT from [balena.io/os](https://balena.io/os#download).
 
-
 ### Configuration needed
 
 - Start building your standalone testbot by [following the guide](https://github.com/balena-io/testbot/blob/master/documentation/getting-started.md#quick-start-guide-for-testbot). 
-- Create your test configuration, by creating a `config.json` file in the `workspace` directory, following instructions mentioned in the [testbot docs](https://github.com/balena-io/testbot/blob/master/documentation/getting-started.md#run-your-first-test).
-- Move the image zip file you want to test with inside the `workspace` directory in Leviathan.
-- Extract the image, rename it to balena.img, and recompress the image into the `.gz` format. The final file would look like `balena.img.gz` file and has to be in the `./leviathan/workspace` directory. 
+- Create your test configuration, by creating a `config.json` file in the `workspace` directory, following instructions mentioned in the [leviathan docs](https://github.com/balena-io/testbot/blob/master/documentation/getting-started.md#run-your-first-test).
+- Extract the image you want to test to `./leviathan/workspace` and rename it to `balena.img` 
 
+### Running tests
 
-### Packages needed for installation
-
-(Taken from `Dockerfile.template` of each service, so might be incomplete or properly overkill)
-
-1. Install OS packages
-
-```
-sudo apt-get install qemu-kvm pkg-config libvirt-daemon-system bridge-utils libvirt-clients build-essential g++ python git make gcc gcc-multilib node-gyp libusb-dev libdbus-1-dev libvirt-dev qemu-system-x86
-```
-
-2. Install NPM packages
-
-```
-npm install node-pre-gyp node-gyp -g
-npm install
-```
-
-Make sure the `npm install` goes without errors (other than the optional dependencies), as it recursively installs packages for all 3 services. If it fails, you can follow the commands below for troubleshooting. 
-
-
-3. Run the tests by navigating to the workspace directory and running 
+Run the tests by navigating to the workspace directory and running 
 
 ```
 ./run-tests.sh
 ```
+## Instructions for rig-owners 
 
-## Helpful commands for troubleshooting
-
-At times, when `npm install` leads to errors. Use the commands below before trying again to start with a clean slate.
-
-```
-rm core/package-lock.json worker/package-lock.json client/package-lock.json package-lock.json
-rm -rf node_modules/ core/node_modules/ worker/node_modules/ client/node_modules/
-rm -rf ~/.node-gyp
-npm cache clear --force
-```
-
-## [Not Needed] Instructions for rig-owners 
-
-- If you are pushing new releases of Leviathan to balenaCloud, then place the `.npmrc` file over with NPM token at the location `leviathan/.balena/secrets/.npmrc`
-- Next, create a [build time only secret file](https://www.balena.io/docs/learn/deploy/deployment/#build-time-secrets-and-variables), `.balena.yml` will be needed. Create a `balena.yml` in the `.balena` directory with the following configuration. 
+To push a new release to balenaCloud, run `npm install` and then push to the balenaCloud application.
 
 ```
-build-secrets:
-  services:
-    worker:
-      - source: .npmrc
-        dest: .npmrc
-```
-
-**To push a new release to balenaCloud**
-
-- Run the command with the <appname> as the name of your application.
-
-```
+npm install
 balena push <appname>
 ```
 

--- a/core/lib/common/archiver.js
+++ b/core/lib/common/archiver.js
@@ -1,3 +1,23 @@
+/**
+ * # Send reports/artifacts from testbot back to client
+ *
+ * By default, serial logs (given that the hardware is set up correctly), and the
+ * logs from the tests will be sent back to the client that started the test, upon
+ * the test finishing. Other artifacts can be sent back to the client using the
+ * `archiver` method. This method is available within any test:
+ *
+ * @example
+ * ```js
+ * this.archiver.add(`path/of/FILE`)
+ * ```
+ *
+ * Using this method, at the end of the test, any artifacts added to the archive are compressed and
+ * downloaded by the client. These are available in the `workspace/reports` directory at the end of
+ * the test. This can also be helpful when storing diagigggddddd
+ *
+ * @module Archiver
+ */
+
 /*
  * Copyright 2019 balena
  *

--- a/core/lib/common/archiver.js
+++ b/core/lib/common/archiver.js
@@ -13,7 +13,7 @@
  *
  * Using this method, at the end of the test, any artifacts added to the archive are compressed and
  * downloaded by the client. These are available in the `workspace/reports` directory at the end of
- * the test. This can also be helpful when storing diagigggddddd
+ * the test. This can also be helpful when storing artifacts/reports/logs after a test suite run.
  *
  * @module Archiver
  */

--- a/core/lib/common/context.js
+++ b/core/lib/common/context.js
@@ -60,12 +60,17 @@ module.exports = class Context {
 	 *    }
 	 * })
 	 *
-	 * @param {*} obj
+	 * @param {object} obj
+	 * @category helper
 	 */
 	set(obj) {
 		merge(this.ctx, obj);
 	}
 
+	/**
+	 * Method to fetch objects added to the context from suites and tests.
+	 * @category helper
+	 */
 	get() {
 		if (this.global != null) {
 			return { ...this.global.get(), ...this.ctx };

--- a/core/lib/common/context.js
+++ b/core/lib/common/context.js
@@ -1,3 +1,25 @@
+/**
+ * # Context
+ *
+ * The context class lets you share instances of objects across different tests. For example, if we
+ * made an instance of the worker class in a suite, as above, other tests would not be able to see
+ * it. An instance of the context class has a `set()` and a `get()` method, to both add or fetch
+ * objects from the context. An example can be seen below:
+ *
+ * @example
+ * ```js
+ * const Worker = this.require('common/worker');
+ * this.suite.context.set({
+ *     worker: new Worker(DEVICE_TYPE_SLUG, this.getLogger()), // Add an instance of worker to context
+ * });
+ * await this.context.get().worker.flash() // Flash the DUT with the worker instance from context
+ * ```
+ *
+ * The context can be used to share anything between tests - device uuids, app names and so on.
+ *
+ * @module Context
+ */
+
 /*
  * Copyright 2018 balena
  *
@@ -24,6 +46,22 @@ module.exports = class Context {
 		this.ctx = {};
 	}
 
+	/**
+	 * Method use to add new objects to the context
+	 *
+	 * @example
+	 * this.suite.context.set({
+	 *    hup: {
+	 *      doHUP: doHUP,
+	 *      getOSVersion: getOSVersion,
+	 *      initDUT: initDUT,
+	 *      runRegistry: runRegistry,
+	 *      archiveLogs: archiveLogs,
+	 *    }
+	 * })
+	 *
+	 * @param {*} obj
+	 */
 	set(obj) {
 		merge(this.ctx, obj);
 	}

--- a/core/lib/common/graphics.js
+++ b/core/lib/common/graphics.js
@@ -1,3 +1,27 @@
+/**
+ * # Screen Capture
+ *
+ * If screen capture is supported and appropriate hardware is attached, the video output of the DUT
+ * can be captured. For the testbot, this requires a compatible video capture device to be connected
+ * that works with v4L2 and enumerates on the `/dev/video0` interface. If that is the case, then
+ * capture can be started using the `Worker` class `capture()` method, for example:
+ *
+ * @example
+ * ```js
+ * const Worker = this.require('common/worker');
+ * const worker = new Worker('DEVICE_TYPE_SLUG', this.getLogger())
+ * await worker.capture('start');
+ * ```
+ *
+ * This will trigger video capture to start, and frames will be saved as `jpg` files in the `/data/capture` directory (which is a shared volume). Capture will continue until stopped with:
+ *
+ * ```js
+ * await worker.capture('stop');
+ * ```
+ *
+ * @module Graphics
+ */
+
 /*
  * Copyright 2019 balena
  *
@@ -16,7 +40,6 @@
 
 'use strict';
 
-// Helper funciton for blockhash
 function median(data) {
 	const mdarr = data.slice(0);
 	mdarr.sort(function(a, b) {

--- a/core/lib/common/state.js
+++ b/core/lib/common/state.js
@@ -1,3 +1,12 @@
+/**
+ * # Tests State Logging
+ *
+ * Includes methods to capture different types of message and send them back to the client.
+ * 3 types of messages, log, status, info.
+ *
+ * @module State
+ */
+
 module.exports = class State {
 	constructor() {
 		this._log = [];

--- a/core/lib/common/state.js
+++ b/core/lib/common/state.js
@@ -1,5 +1,5 @@
 /**
- * # Tests State Logging
+ * # Test State Logging
  *
  * Includes methods to capture different types of message and send them back to the client.
  * 3 types of messages, log, status, info.

--- a/core/lib/common/suite.js
+++ b/core/lib/common/suite.js
@@ -1,3 +1,12 @@
+/**
+ * # The test suites lifecycle including node-tap
+ *
+ * Contains code to parse, prepare, execute, monitor and teardown test suites and their tests that
+ * are queued up for testing as per the configuration.
+ *
+ * @module Suite
+ */
+
 /*
  * Copyright 2018 balena
  *
@@ -95,9 +104,9 @@ class Suite {
 		await Bluebird.try(async () => {
 			await this.installDependencies();
 			await fs.ensureDir(config.get('leviathan.downloads'));
-			if(fs.existsSync(config.get('leviathan.artifacts'))){
+			if (fs.existsSync(config.get('leviathan.artifacts'))) {
 				this.state.log(`Removing artifacts from previous tests...`);
-				fs.emptyDirSync(config.get('leviathan.artifacts'))
+				fs.emptyDirSync(config.get('leviathan.artifacts'));
 			}
 			this.rootTree = this.resolveTestTree(
 				path.join(config.get('leviathan.uploads.suite'), 'suite'),
@@ -252,10 +261,10 @@ class Suite {
 		);
 	}
 
-	async removeDownloads(){
+	async removeDownloads() {
 		if (fs.existsSync(config.get('leviathan.downloads'))) {
 			this.state.log(`Removing downloads directory...`);
-			fs.emptyDirSync(config.get('leviathan.downloads'))
+			fs.emptyDirSync(config.get('leviathan.downloads'));
 		}
 	}
 }

--- a/core/lib/common/suite.js
+++ b/core/lib/common/suite.js
@@ -1,5 +1,5 @@
 /**
- * # The test suites lifecycle including node-tap
+ * # Test suites lifecycle (with node-tap)
  *
  * Contains code to parse, prepare, execute, monitor and teardown test suites and their tests that
  * are queued up for testing as per the configuration.

--- a/core/lib/common/teardown.js
+++ b/core/lib/common/teardown.js
@@ -1,5 +1,5 @@
 /**
- * # Teardowns
+ * # Teardown
  *
  * You can register functions to be carried out upon "teardown" of the suite or test. These will
  * execute when the test ends, regardless of passing or failing:

--- a/core/lib/common/teardown.js
+++ b/core/lib/common/teardown.js
@@ -1,3 +1,49 @@
+/**
+ * # Teardowns
+ *
+ * You can register functions to be carried out upon "teardown" of the suite or test. These will
+ * execute when the test ends, regardless of passing or failing:
+ *
+ * ```js
+ * this.suite.teardown.register(() => {
+ *    this.log('Worker teardown');
+ *    return this.context.get().worker.teardown();
+ * });
+ * ```
+ *
+ * If registered in the suite, this will be carried out upon the suite (the collection of tests
+ * ending. You can also add individual teardowns within tests, that will execute when the individual
+ * test has ended. In this example here, within the test, we create an applciation, and after the
+ * test, we wish to remove that application:
+ *
+ * @example
+ * ```js
+ *  module.exports = {
+ * 	 title: 'Example',
+ * 		 tests: [
+ * 			 {
+ * 				 title: 'Move device to another application',
+ * 				 run: async function(test) {
+ * 					 // create an app
+ * 					 await this.context.get().balena.sdk.models.application.create({
+ * 						 name: APP,
+ * 						 deviceType: DEVICE_TYPE,
+ * 						 organization: ORG,
+ * 					 });
+ * 					 // Register a teardown that will remove the test when the test ends
+ * 					 this.teardown.register(() => {
+ * 						 return this.context.get().balena.sdk.models.application.remove(APP);
+ * 					 });
+ * 					 // THE REST OF THE TEST CODE
+ * 				 }
+ * 			 }
+ * 		 ]
+ *  }
+ * ```
+ *
+ * @module Teardown
+ */
+
 /*
  * Copyright 2018 balena
  *

--- a/core/lib/common/test.js
+++ b/core/lib/common/test.js
@@ -1,3 +1,9 @@
+/**
+ * balenaOS helpers involve something loren ipsum
+ *
+ * @module Test
+ */
+
 /*
  * Copyright 2018 balena
  *

--- a/core/lib/common/test.js
+++ b/core/lib/common/test.js
@@ -1,5 +1,5 @@
 /**
- * # Basic Test logic for Leviathan tests
+ * # Test logic for Leviathan tests
  *
  * @module Test
  */

--- a/core/lib/common/test.js
+++ b/core/lib/common/test.js
@@ -1,5 +1,5 @@
 /**
- * balenaOS helpers involve something loren ipsum
+ * # Basic Test logic for Leviathan tests
  *
  * @module Test
  */

--- a/core/lib/common/utils.js
+++ b/core/lib/common/utils.js
@@ -1,3 +1,9 @@
+/**
+ * Utility helpers involve something loren ipsum
+ *
+ * @module Leviathan Utility helpers
+ */
+
 /*
  * Copyright 2017 balena
  *

--- a/core/lib/common/utils.js
+++ b/core/lib/common/utils.js
@@ -82,6 +82,7 @@ module.exports = {
 	 *
 	 * @param {string} command The command to be executed over SSH
 	 * @param {*} config
+	 *
 	 * @category helper
 	 */
 	executeCommandOverSSH: async (command, config) => {
@@ -101,13 +102,11 @@ module.exports = {
 
 	/**
 	 * @param {string} promise The command you need to wait for
-	 * @param {boolean} rejectionFail Whether the `waitUntil()` function error out, if a iteration fails once.
-	 * Defaults to `false`, which results in `waitUntil()` not failing as it iterates and wait for the condition
-	 * to satisfy.
+	 * @param {boolean} rejectionFail Whether the `waitUntil()` function error out, if a iteration fails once. Defaults to `false`, which results in `waitUntil()` not failing as it iterates and wait for the condition to satisfy.
 	 * @param {number} _times Specify how many times should the command be executed
 	 * @param {number} _delay Specify the delay between each iteration of the command execution
-	 * @throws error on first iteration if`rejectionFail` is true. Otherwise throws error after iterating through
-	 * the specified `_times` parameter
+	 * @throws error on first iteration if`rejectionFail` is true. Otherwise throws error after iterating through the specified `_times` parameter
+	 *
 	 * @category helper
 	 */
 	waitUntil: async (

--- a/core/lib/common/utils.js
+++ b/core/lib/common/utils.js
@@ -1,5 +1,7 @@
 /**
- * Utility helpers involve something loren ipsum
+ * # Utility helpers
+ *
+ * The module contains helpers to better write tests.
  *
  * @module Leviathan Utility helpers
  */
@@ -74,6 +76,14 @@ const getSSHClientDisposer = config => {
 };
 
 module.exports = {
+	/**
+	 * This is the base hostOS execution command used by many other functions like `executeCommandIntoHostOs` to
+	 * execute commands on the DUT being passed through SSH.
+	 *
+	 * @param {string} command The command to be executed over SSH
+	 * @param {*} config
+	 * @category helper
+	 */
 	executeCommandOverSSH: async (command, config) => {
 		return Bluebird.using(getSSHClientDisposer(config), client => {
 			return new Bluebird(async (resolve, reject) => {
@@ -88,6 +98,18 @@ module.exports = {
 			});
 		});
 	},
+
+	/**
+	 * @param {string} promise The command you need to wait for
+	 * @param {boolean} rejectionFail Whether the `waitUntil()` function error out, if a iteration fails once.
+	 * Defaults to `false`, which results in `waitUntil()` not failing as it iterates and wait for the condition
+	 * to satisfy.
+	 * @param {number} _times Specify how many times should the command be executed
+	 * @param {number} _delay Specify the delay between each iteration of the command execution
+	 * @throws error on first iteration if`rejectionFail` is true. Otherwise throws error after iterating through
+	 * the specified `_times` parameter
+	 * @category helper
+	 */
 	waitUntil: async (
 		promise,
 		rejectionFail = false,

--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -55,9 +55,10 @@ module.exports = class Worker {
 	}
 
 	/**
-	 * Flash the provided OS image onto the DUT
-	 * 
-	 * @param {*} imagePath path of the image to be flashed onto the DUT
+	 * Flash the provided OS image onto the connected DUT
+	 *
+	 * @param {string} imagePath path of the image to be flashed onto the DUT
+	 *
 	 * @category helper
 	 */
 	async flash(imagePath) {
@@ -114,6 +115,8 @@ module.exports = class Worker {
 
 	/**
 	 * Turn the DUT on
+	 *
+	 * @category helper
 	 */
 	async on() {
 		this.logger.log('Powering on DUT');
@@ -123,6 +126,8 @@ module.exports = class Worker {
 
 	/**
 	 * Turn the DUT off
+	 *
+	 * @category helper
 	 */
 	async off() {
 		this.logger.log('Powering off DUT');
@@ -180,7 +185,7 @@ module.exports = class Worker {
 	}
 
 	/**
-	 * Executes command-line operations in the host OS of the DUT. Assuming the DUT is 
+	 * Executes command-line operations in the host OS of the DUT. Assuming the DUT is
 	 * connected to the access point broadcasted by the testbot:
 	 *
 	 * @example
@@ -189,12 +194,13 @@ module.exports = class Worker {
 	 * const worker = new Worker(DEVICE_TYPE_SLUG, this.getLogger())
 	 * await worker.executeCommandInHostOS('cat /etc/hostname', `${UUID}.local`);
 	 * ```
-	 * 
+	 *
 	 * @param {string} command command to be executed on the DUT
 	 * @param {string} target local UUID of the DUT, example:`${UUID}.local`
-	 * @param {{"interval": number, "tries": number}} timeout object containing details of how many times the 
+	 * @param {{"interval": number, "tries": number}} timeout object containing details of how many times the
 	 * command needs to be retried and the intervals between each command execution
 	 * @returns {string} Output of the command that was exected on hostOS of the DUT
+	 *
 	 * @category helper
 	 */
 	async executeCommandInHostOS(
@@ -240,7 +246,8 @@ module.exports = class Worker {
 	 * @param {string} target  the <UUID> for the target device
 	 * @param {string} source The path to the directory containing the docker-compose/Dockerfile for the containers
 	 * @param {string} containerName The name of the container to verify is push has succeeded.
-	 * @returns {string} returns state of the device 
+	 * @returns {string} returns state of the device
+	 *
 	 * @category helper
 	 */
 	async pushContainerToDUT(target, source, containerName) {
@@ -295,7 +302,7 @@ module.exports = class Worker {
 
 	/**
 	 * Triggers a reboot on the target device and waits until the device comes back online
-	 * 
+	 *
 	 * @param {string} target
 	 * @category helper
 	 */
@@ -318,7 +325,7 @@ module.exports = class Worker {
 
 	/**
 	 * Fetches OS version available on the DUT's `/etc/os-release` file
-	 *  
+	 *
 	 * @param {string} target
 	 * @returns {string} returns OS version
 	 * @category helper

--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -55,8 +55,10 @@ module.exports = class Worker {
 	}
 
 	/**
-	 *
-	 * @param {*} imagePath
+	 * Flash the provided OS image onto the DUT
+	 * 
+	 * @param {*} imagePath path of the image to be flashed onto the DUT
+	 * @category helper
 	 */
 	async flash(imagePath) {
 		this.logger.log('Preparing to flash');
@@ -127,9 +129,6 @@ module.exports = class Worker {
 		await rp.post(`${this.url}/dut/off`);
 	}
 
-	/**
-	 * @internal
-	 */
 	async network(network) {
 		await rp.post({
 			uri: `${this.url}/dut/network`,
@@ -181,14 +180,22 @@ module.exports = class Worker {
 	}
 
 	/**
-	 * Another helpful method of the worker is `executeCommandInHostOs`, which lets you execute command line
-	 * operations in the host OS of the DUT. Assuming that the DUT is connected to the AP of the testbot:
+	 * Executes command-line operations in the host OS of the DUT. Assuming the DUT is 
+	 * connected to the access point broadcasted by the testbot:
 	 *
+	 * @example
 	 * ```js
 	 * const Worker = this.require('common/worker');
 	 * const worker = new Worker(DEVICE_TYPE_SLUG, this.getLogger())
 	 * await worker.executeCommandInHostOS('cat /etc/hostname', `${UUID}.local`);
 	 * ```
+	 * 
+	 * @param {string} command command to be executed on the DUT
+	 * @param {string} target local UUID of the DUT, example:`${UUID}.local`
+	 * @param {{"interval": number, "tries": number}} timeout object containing details of how many times the 
+	 * command needs to be retried and the intervals between each command execution
+	 * @returns {string} Output of the command that was exected on hostOS of the DUT
+	 * @category helper
 	 */
 	async executeCommandInHostOS(
 		command,
@@ -228,12 +235,13 @@ module.exports = class Worker {
 	}
 
 	/**
-	 * Use cli to push container
+	 * Pushes a release to an application from a given directory for unmanaged devices
 	 *
-	 * @param {*} target
-	 * @param {*} source
-	 * @param {*} containerName
-	 * @returns
+	 * @param {string} target  the <UUID> for the target device
+	 * @param {string} source The path to the directory containing the docker-compose/Dockerfile for the containers
+	 * @param {string} containerName The name of the container to verify is push has succeeded.
+	 * @returns {string} returns state of the device 
+	 * @category helper
 	 */
 	async pushContainerToDUT(target, source, containerName) {
 		await retry(
@@ -263,11 +271,12 @@ module.exports = class Worker {
 	}
 
 	/**
-	 *
-	 * @param {*} command
-	 * @param {*} containerName
-	 * @param {*} target
-	 * @returns
+	 * Executes the command in the targeted container of a device
+	 * @param {string} command The command to be executed
+	 * @param {string} containerName The name of the service/container to run the command in
+	 * @param {*} target The `<UUID.local>` of the target device
+	 * @returns {string} output of the command that is executed on the targetted container of the device
+	 * @category helper
 	 */
 	async executeCommandInContainer(command, containerName, target) {
 		// get container ID
@@ -285,8 +294,10 @@ module.exports = class Worker {
 	}
 
 	/**
-	 *
-	 * @param {*} target
+	 * Triggers a reboot on the target device and waits until the device comes back online
+	 * 
+	 * @param {string} target
+	 * @category helper
 	 */
 	async rebootDut(target) {
 		this.logger.log(`Rebooting the DUT`);
@@ -306,9 +317,11 @@ module.exports = class Worker {
 	}
 
 	/**
-	 *
-	 * @param {*} target
-	 * @returns
+	 * Fetches OS version available on the DUT's `/etc/os-release` file
+	 *  
+	 * @param {string} target
+	 * @returns {string} returns OS version
+	 * @category helper
 	 */
 	async getOSVersion(target) {
 		// maybe https://github.com/balena-io/leviathan/blob/master/core/lib/components/balena/sdk.js#L210

--- a/core/lib/components/balena/cli.js
+++ b/core/lib/components/balena/cli.js
@@ -1,5 +1,30 @@
 /**
- * balenaCLI helpers involve something loren ipsum
+ * # balenaCLI helpers
+ *
+ * balenaCLI helpers performs frequently executed tasks in order to keep things DRY.
+ * For one-off commands, it's recommended to not use the helpers and instead directly use the
+ * balenaCLI with the example explained below.
+ *
+ * @example The core service where the test suites run already has balenaCLI installed. There is no need to
+ * initalise the `CLI` class to run/execute any CLI command inside the tests. Instead use
+ *
+ * ```js
+ * const { exec } = require("child_process");
+ * await exec(`balena push joystart --source .`)
+ * ```
+ *
+ * To get output from the commands being exectued, use the callback
+ *
+ * ```js
+ * const { exec } = require("child_process");
+ * await exec(`balena logs alliance-fleet --service "normandy-sr0"`, (error, stdout, stderr) => {
+ *   if (error) {
+ *     throw new error
+ *   }
+ *   console.log(stdout)
+ * })
+ * ```
+ *
  * @module balenaCLI helpers
  */
 
@@ -33,10 +58,10 @@ module.exports = class CLI {
 	}
 
 	/**
-	 * Preload the image
+	 * Preload the image onto the target image
 	 *
-	 * @param {*} image
-	 * @param {*} options
+	 * @param {string} image path to the image
+	 * @param {*} options options to be executed with balena preload command
 	 *
 	 * @category helper
 	 */
@@ -120,11 +145,10 @@ module.exports = class CLI {
 	}
 
 	/**
-	 * pushes stuff to the balenaCloud app
+	 * Pushes application to local device locally
 	 *
-	 * @param {*} target
-	 * @param {*} options
-	 * @returns
+	 * @param {string} target The address/uuid of the device
+	 * @param {*} options Options to be executed with balena preload command
 	 *
 	 * @category helper
 	 */
@@ -136,10 +160,7 @@ module.exports = class CLI {
 	}
 
 	/**
-	 * asdsadasd
-	 *
-	 * @param {*} token
-	 * @returns
+	 * @param {string} token Session key or API token required for the authentication of balena-cli session
 	 *
 	 * @category helper
 	 */
@@ -149,11 +170,9 @@ module.exports = class CLI {
 	}
 
 	/**
-	 *
-	 *
-	 * @param {*} target
-	 * @param {*} service
-	 * @returns
+	 * @param {string} target The address/UUID of the target device
+	 * @param {string} service The container/service for which logs are needed
+	 * @returns {string} logs of the service/container running on the target device
 	 *
 	 * @category helper
 	 */

--- a/core/lib/components/balena/cli.js
+++ b/core/lib/components/balena/cli.js
@@ -1,3 +1,8 @@
+/**
+ * balenaCLI helpers involve something loren ipsum
+ * @module balenaCLI helpers
+ */
+
 /* Copyright 2019 balena
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +32,14 @@ module.exports = class CLI {
 		this.logger = logger;
 	}
 
+	/**
+	 * Preload the image
+	 *
+	 * @param {*} image
+	 * @param {*} options
+	 *
+	 * @category helper
+	 */
 	async preload(image, options) {
 		const socketPath = (await pathExists('/var/run/balena.sock'))
 			? '/var/run/balena.sock'
@@ -106,6 +119,15 @@ module.exports = class CLI {
 		});
 	}
 
+	/**
+	 * pushes stuff to the balenaCloud app
+	 *
+	 * @param {*} target
+	 * @param {*} options
+	 * @returns
+	 *
+	 * @category helper
+	 */
 	push(target, options) {
 		this.logger.log('Performing local push');
 		return exec(
@@ -113,11 +135,28 @@ module.exports = class CLI {
 		);
 	}
 
+	/**
+	 * asdsadasd
+	 *
+	 * @param {*} token
+	 * @returns
+	 *
+	 * @category helper
+	 */
 	loginWithToken(token) {
 		this.logger.log('Login CLI');
 		return exec(`balena login --token ${token}`);
 	}
 
+	/**
+	 *
+	 *
+	 * @param {*} target
+	 * @param {*} service
+	 * @returns
+	 *
+	 * @category helper
+	 */
 	logs(target, service) {
 		return exec(
 			`balena logs ${target} ${service ? '--service' + service : ''}`,

--- a/core/lib/components/balena/sdk.js
+++ b/core/lib/components/balena/sdk.js
@@ -1,4 +1,6 @@
 /**
+ * # balenaSDK helpers
+ *
  * The `BalenaSDK` class contains an instance of the balena sdk, as well as some helper methods to interact with a device via the cloud.
  * The `balena` attribute of the class contains the sdk,and can be used as follows in a test suite:
  *
@@ -71,11 +73,13 @@ module.exports = class BalenaSDK {
 
 	/**
 	 * Executes command-line operations in the host OS of the DUT. Assuming the DUT is a managed device.
-	 * 
+	 *
 	 * @param {string} command command to be executed on the DUT
 	 * @param {string} device local UUID of the DUT, example:`${UUID}.local`
 	 * @param {{"interval": number, "tries": number}} timeout object containing details of how many times the command needs to be retried and the intervals between each command execution
 	 * @returns {string} Output of the command that was exected on hostOS of the DUT
+	 *
+	 * @category helper
 	 */
 	async executeCommandInHostOS(
 		command,
@@ -118,10 +122,17 @@ module.exports = class BalenaSDK {
 		);
 	}
 
+	/**
+	 * @param {string} deviceType The devicetype you need supported OS versions for
+	 * @returns Supported balenaOS version for the provided device type
+	 *
+	 * @category helper
+	 */
 	getAllSupportedOSVersions(deviceType) {
 		return this.balena.models.os.getSupportedVersions(deviceType);
 	}
 
+	// Deprecated - Use fetchOS method instead
 	async getDownloadStream(deviceType, version) {
 		const stream = await this.balena.models.os.download(deviceType, version);
 
@@ -183,6 +194,13 @@ module.exports = class BalenaSDK {
 		return this.balena.models.application.remove(application);
 	}
 
+	/**
+	 * @param {string} name Name of the application that needs to be created
+	 * @param {string} deviceType The device type for which application needs to be created
+	 * @param {object} config specify configuration needed for the application
+	 *
+	 * @category helper
+	 */
 	async createApplication(name, deviceType, config) {
 		this.logger.log(
 			`Creating application: ${name} with device type ${deviceType}`,
@@ -456,11 +474,13 @@ module.exports = class BalenaSDK {
 		);
 	}
 
-	/** 
+	/**
 	 * Pushes a release to an application from a given directory for managed devices
 	 * @param {string} application The balena application name to push the release to
 	 * @param {string} directory The path to the directory containing the docker-compose/Dockerfile for the application and the source files
 	 * @returns {string} returns release commit after `balena push` is complete
+	 *
+	 * @category helper
 	 */
 	async pushReleaseToApp(application, directory) {
 		await exec(`balena push ${application} --source ${directory}`);
@@ -479,6 +499,8 @@ module.exports = class BalenaSDK {
 	 * @param {string} commit The release commit hash that services should be on
 	 * @param {number} __times (optional) The number of attemps to retry. Retries are spaced 30s apart
 	 * @returns {boolean} returns true if all services in the release commit are running on the device
+	 *
+	 * @category helper
 	 */
 	async waitUntilServicesRunning(uuid, services, commit, __times = 50) {
 		await utils.waitUntil(
@@ -506,6 +528,8 @@ module.exports = class BalenaSDK {
 	 * @param {string} containerName The name of the service/container to run the command in
 	 * @param {string} uuid The UUID of the target device
 	 * @returns {string} output of the command that is executed on the targetted container of the device
+	 *
+	 * @category helper
 	 */
 	async executeCommandInContainer(command, containerName, uuid) {
 		// get the container ID of container through balena engine
@@ -528,6 +552,8 @@ module.exports = class BalenaSDK {
 	 * @param {number} _start (optional) start the search from this log
 	 * @param {number} _end (optional) end the search at this log
 	 * @returns {boolean} If device logs contain the string
+	 *
+	 * @category helper
 	 */
 	async checkLogsContain(uuid, contains, _start = null, _end = null) {
 		let logs = await this.balena.logs.history(uuid).map(log => {
@@ -551,6 +577,8 @@ module.exports = class BalenaSDK {
 	/**
 	 * @param {string} uuid UUID of the device
 	 * @returns {Promise<string>} Returns the supervisor version on a device
+	 *
+	 * @category helper
 	 */
 	async getSupervisorVersion(uuid) {
 		let checkName = await this.executeCommandInHostOS(
@@ -569,13 +597,15 @@ module.exports = class BalenaSDK {
 		return supervisor;
 	}
 
-	/** 
+	/**
 	 * Downloads provided version of balenaOS for the provided deviceType using balenaSDK
-	 * 
+	 *
 	 * @param version The semver compatible balenaOS version that will be downloaded, example: `2.80.3+rev1.dev`. Default value: `latest` where latest development variant of balenaOS will be downloaded.
 	 * @param deviceType The device type for which balenaOS needs to be downloaded
 	 * @remark Stores the downloaded image in `leviathan.downloads` directory,
 	 * @throws Rejects promise if download fails. Retries thrice to download an image before giving up.
+	 *
+	 * @category helper
 	 */
 	async fetchOS(version = 'latest', deviceType) {
 		if (version === 'latest') {

--- a/core/lib/components/balena/sdk.js
+++ b/core/lib/components/balena/sdk.js
@@ -1,37 +1,3 @@
-/*
- * Copyright 2017 balena
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-'use strict';
-
-const map = require('lodash/map');
-const pick = require('lodash/pick');
-const find = require('lodash/find');
-const flatMapDeep = require('lodash/flatMapDeep');
-const fs = require('fs')
-const { join } = require("path");
-const Bluebird = require('bluebird');
-const retry = require('bluebird-retry');
-const utils = require('../../common/utils');
-const exec = Bluebird.promisify(require('child_process').exec);
-const config = require('config');
-
-// const fse = require('fs-extra')
-// const semver = require('balena-semver')
-// var glob = require("glob")
-
 /**
  * The `BalenaSDK` class contains an instance of the balena sdk, as well as some helper methods to interact with a device via the cloud.
  * The `balena` attribute of the class contains the sdk,and can be used as follows in a test suite:
@@ -55,10 +21,40 @@ const config = require('config');
  * 	deviceType: `DEVICE_TYPE`,
  *  organization: `ORG`,
  * });
- *
  * ```
+ *
+ * @module balenaSDK helpers
  */
 
+/*
+ * Copyright 2017 balena
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const map = require('lodash/map');
+const pick = require('lodash/pick');
+const find = require('lodash/find');
+const flatMapDeep = require('lodash/flatMapDeep');
+const fs = require('fs');
+const { join } = require('path');
+const Bluebird = require('bluebird');
+const retry = require('bluebird-retry');
+const utils = require('../../common/utils');
+const exec = Bluebird.promisify(require('child_process').exec);
+const config = require('config');
 module.exports = class BalenaSDK {
 	constructor(
 		apiUrl,
@@ -455,113 +451,123 @@ module.exports = class BalenaSDK {
 	/** Pushes a release to an application, from a given directory
 	 * @param The balena application name to push the release to
 	 * @param The path to the directory containing the docker-compose/Dockerfile for the application and the source files
-	*/
-	async pushReleaseToApp(application, directory){
-		await exec(
-			`balena push ${application} --source ${directory}`
-		  );
+	 */
+	async pushReleaseToApp(application, directory) {
+		await exec(`balena push ${application} --source ${directory}`);
 		//check new commit of app
-		let commit = await this.balena.models.application.get(application).get("commit");
+		let commit = await this.balena.models.application
+			.get(application)
+			.get('commit');
 
-		return commit
+		return commit;
 	}
 	/** Waits until given services are all running on a device, on a given commit
 	 * @param The UUID of the device
 	 * @param An array of the service names
 	 * @param The release commit hash that services should be on
 	 * @param (optional) The number of attemps to retry. Retries are spaced 30s apart
-	*/
-	async waitUntilServicesRunning(uuid, services, commit, __times = 50){
-		await utils.waitUntil(async () => {
-			let deviceServices = await this.balena.models.device.getWithServiceDetails(
-				uuid
-			  );
-			let running = false
-			running = services.every((service) => {
-				return (deviceServices.current_services[service][0].status === "Running") && (deviceServices.current_services[service][0].commit === commit)
-			})
-			return running;
-		}, false, __times)
+	 */
+	async waitUntilServicesRunning(uuid, services, commit, __times = 50) {
+		await utils.waitUntil(
+			async () => {
+				let deviceServices = await this.balena.models.device.getWithServiceDetails(
+					uuid,
+				);
+				let running = false;
+				running = services.every(service => {
+					return (
+						deviceServices.current_services[service][0].status === 'Running' &&
+						deviceServices.current_services[service][0].commit === commit
+					);
+				});
+				return running;
+			},
+			false,
+			__times,
+		);
 	}
 
 	/** Executes the command in the targetted container of a device
 	 * @param The command to be run
 	 * @param The name of the service/container to run the command in
 	 * @param The UUID of the device
-	*/
-	async executeCommandInContainer(command, containerName, uuid){
+	 */
+	async executeCommandInContainer(command, containerName, uuid) {
 		// get the container ID of container through balena engine
 		const containerId = await this.executeCommandInHostOS(
 			`balena ps --format "{{.Names}}" | grep ${containerName}`,
-			uuid
+			uuid,
 		);
 
 		const stdout = await this.executeCommandInHostOS(
 			`balena exec ${containerId} ${command}`,
-			uuid
+			uuid,
 		);
 
-		return stdout
+		return stdout;
 	}
 	/** Checks if device logs contain a string
 	 * @param The UUID of the device
 	 * @param The string to look for in the logs
 	 * @param (optional) start the search from this log
 	 * @param (optional) end the search at this log
-	*/
-	async checkLogsContain(uuid, contains, _start=null, _end=null){
-		let logs = await this.balena.logs.history(uuid)
-          .map((log) => {
-            return log.message;
-          });
+	 */
+	async checkLogsContain(uuid, contains, _start = null, _end = null) {
+		let logs = await this.balena.logs.history(uuid).map(log => {
+			return log.message;
+		});
 
-		let startIndex = (_start != null)? logs.indexOf(_start) : 0
-		let endIndex = (_end != null)? logs.indexOf(_end) : (logs.length)
+		let startIndex = _start != null ? logs.indexOf(_start) : 0;
+		let endIndex = _end != null ? logs.indexOf(_end) : logs.length;
 		let slicedLogs = logs.slice(startIndex, endIndex);
 
 		let pass = false;
-		slicedLogs.forEach((element) => {
+		slicedLogs.forEach(element => {
 			if (element.includes(contains)) {
-			pass = true;
+				pass = true;
 			}
 		});
 
-		return pass
+		return pass;
 	}
 
 	/** Returns the supervisor version on a device
 	 * @param The UUID of the device
-	*/
-	async getSupervisorVersion(uuid){
-		let checkName =  await this.executeCommandInHostOS(
+	 */
+	async getSupervisorVersion(uuid) {
+		let checkName = await this.executeCommandInHostOS(
 			`balena ps | grep balena_supervisor`,
 			uuid
 		  );
 		let supervisorName = (checkName !== "") ? `balena_supervisor` : `resin_supervisor`
-
 		let supervisor = await this.executeCommandInHostOS(
-		  `balena exec ${supervisorName} cat package.json | grep version`,
-		  uuid
+			`balena exec ${supervisorName} cat package.json | grep version`,
+			uuid,
 		);
 		// The result takes the form - `"version": "12.3.5"` - so we must extract the version number
-		supervisor = supervisor.split(" ");
-		supervisor = supervisor[1].replace(`"`,``);
+		supervisor = supervisor.split(' ');
+		supervisor = supervisor[1].replace(`"`, ``);
 		supervisor = supervisor.replace(`",`, ``);
-		return supervisor
+		return supervisor;
 	}
 
 	/** Downloads provided version of balenaOS using balenaSDK
-	 * @param The semver compatible balenaOS version that will be downloaded, example: `2.80.3+rev1.dev`. Default value: `latest` where latest development variant of balenaOS will be downloaded.
-	 * @param The device type for which balenaOS needs to be downloaded
-	*/
-	async fetchOS(version = "latest", deviceType) {
-		if (version === "latest") {
-			const versions = await this.balena.models.os.getSupportedVersions(deviceType);
+	 * @param version The semver compatible balenaOS version that will be downloaded, example: `2.80.3+rev1.dev`. Default value: `latest` where latest development variant of balenaOS will be downloaded.
+	 * @param deviceType The device type for which balenaOS needs to be downloaded
+	 */
+	async fetchOS(version = 'latest', deviceType) {
+		if (version === 'latest') {
+			const versions = await this.balena.models.os.getSupportedVersions(
+				deviceType,
+			);
 			// make sure we always flash the development variant
 			version = versions.latest.replace('prod', 'dev');
 		}
 
-		const path = join(config.get('leviathan.downloads'), `balenaOs-${version}.img`);
+		const path = join(
+			config.get('leviathan.downloads'),
+			`balenaOs-${version}.img`,
+		);
 
 		// Caching implmentation in progress - Not yet complete
 		// glob("/data/images/balenaOs-*.img", (err, files) => {
@@ -599,28 +605,33 @@ module.exports = class BalenaSDK {
 		let attempt = 0;
 		const downloadLatestOS = async () => {
 			attempt++;
-			this.logger.log(`Fetching balenaOS version ${version}, attempt ${attempt}...`);
+			this.logger.log(
+				`Fetching balenaOS version ${version}, attempt ${attempt}...`,
+			);
 			return await new Promise(async (resolve, reject) => {
-				await this.balena.models.os.download(deviceType, version, function (error, stream) {
+				await this.balena.models.os.download(deviceType, version, function(
+					error,
+					stream,
+				) {
 					if (error) {
 						fs.unlink(path, () => {
 							// Ignore.
-						})
-						reject(`Image download failed: ${error}`)
+						});
+						reject(`Image download failed: ${error}`);
 					}
 					// Shows progress of image download for debugging purposes
 					// Commented, because too noisy for normal use
 					// stream.on('progress', data => {
 					//   console.log(`Downloading Image: ${data.percentage}`);
 					// });
-					stream.pipe(fs.createWriteStream(path))
+					stream.pipe(fs.createWriteStream(path));
 					stream.on('finish', () => {
-						console.log(`Download Successful: ${path}`)
-						resolve(path)
-					})
-				})
-			})
-		}
+						console.log(`Download Successful: ${path}`);
+						resolve(path);
+					});
+				});
+			});
+		};
 		return retry(downloadLatestOS, { max_retries: 3, interval: 500 });
-	};
+	}
 };

--- a/core/lib/components/balena/sync.js
+++ b/core/lib/components/balena/sync.js
@@ -1,5 +1,5 @@
 /**
- * Utility helpers involve something loren ipsum
+ * ## [Deprecated] Sync functionality
  *
  * @module Sync helper
  */

--- a/core/lib/components/balena/sync.js
+++ b/core/lib/components/balena/sync.js
@@ -1,5 +1,5 @@
 /**
- * ## [Deprecated] Sync functionality
+ * ## [Deprecated] Helpers for Sync functionality
  *
  * @module Sync helper
  */

--- a/core/lib/components/balena/sync.js
+++ b/core/lib/components/balena/sync.js
@@ -1,3 +1,9 @@
+/**
+ * Utility helpers involve something loren ipsum
+ *
+ * @module Sync helper
+ */
+
 /*
  * Copyright 2018 balena
  *

--- a/core/lib/components/balena/utils.js
+++ b/core/lib/components/balena/utils.js
@@ -1,3 +1,9 @@
+/**
+ * # Helpers to test balena git workflows 
+ * 
+ * @module balena git helpers 
+ */
+
 /*
  * Copyright 2019 balena
  *

--- a/core/lib/components/balena/utils.js
+++ b/core/lib/components/balena/utils.js
@@ -1,7 +1,9 @@
 /**
- * # Helpers to test balena git workflows 
- * 
- * @module balena git helpers 
+ * # Helpers to test balena git workflows
+ *
+ * git workflows are considered legacy and not tested.
+ *
+ * @module balena git helpers
  */
 
 /*

--- a/core/lib/components/os/balenaos.js
+++ b/core/lib/components/os/balenaos.js
@@ -1,4 +1,6 @@
 /**
+ * # balenaOS helpers
+ * 
  * The `BalenaOS` helper class can be used to configure and unpack the OS image that you will use in the test. This allows you to inject config options and network credentials into your image.
  *
  * ```js
@@ -153,7 +155,11 @@ module.exports = class BalenaOS {
 		this.releaseInfo = { version: null, variant: null };
 	}
 
-	// calling the fetch method will prepare the image to be used - either unzipping it or moving it to the working directory
+	/**
+	 * Prepares the received image/artifact to be used - either unzipping it or moving it to the Leviathan working directory
+	 * 
+	 * @remark Leviathan creates a temporary working directory that can referenced using `config.get('leviathan.downloads')`
+	 */
 	async fetch() {
 		this.logger.log(`Unpacking the file: ${this.image.input}`);
 		const unpack = await isGzip(this.image.input);
@@ -169,6 +175,10 @@ module.exports = class BalenaOS {
 		}
 	}
 
+	/**
+	 * Parses version and variant from balenaOS images
+	 * @param {string} image 
+	 */
 	async readOsRelease(image = this.image.path) {
 		const readVersion = async (pattern, field) => {
 			this.logger.log(`Checking ${field} in os-release`);
@@ -220,6 +230,10 @@ module.exports = class BalenaOS {
 		assignIn(this.configJson, configJson);
 	}
 
+	/**
+	 * Configures balenaOS image with specifc configuration (if provided), and injects required network configuration
+	 * @category helper
+	 */
 	async configure() {
 		this.readOsRelease();
 		this.logger.log(`Configuring balenaOS image: ${this.image.input}`);

--- a/core/lib/components/os/balenaos.js
+++ b/core/lib/components/os/balenaos.js
@@ -1,3 +1,39 @@
+/**
+ * The `BalenaOS` helper class can be used to configure and unpack the OS image that you will use in the test. This allows you to inject config options and network credentials into your image.
+ *
+ * ```js
+ * const network_conf = {
+ *    ssid: SSID,
+ *    psk: PASSWORD,
+ *    nat: true,
+ * }
+ *
+ * const os = new BalenaOS(
+ *   {
+ *      deviceType: DEVICE_TYPE_SLUG,
+ *      network: network_conf,
+ *      configJson: {
+ *          uuid: UUID,
+ *          persistentLogging: true
+ *      }
+ *   },
+ *   this.getLogger()
+ * );
+ * await os.fetch()
+ * await os.configure()
+ * ```
+ *
+ * Alternatively, you can use the CLI to perform these functions - the CLI is imported in the testing environment:
+ *
+ * ```js
+ * await exec(`balena login --token ${API_KEY}`)
+ * await exec(`balena os configure ${PATH_TO_IMAGE} --config-network wifi --config-wifi-key ${PASSWORD}
+ * --config-wifi-ssid ${SSID}`);
+ * ```
+ *
+ * @module balenaOS helpers
+ */
+
 /*
  * Copyright 2017 balena
  *
@@ -91,7 +127,9 @@ async function isGzip(filePath) {
 }
 
 function id() {
-	return `${Math.random().toString(36).substring(2, 10)}`;
+	return `${Math.random()
+		.toString(36)
+		.substring(2, 10)}`;
 }
 
 module.exports = class BalenaOS {
@@ -103,7 +141,7 @@ module.exports = class BalenaOS {
 		this.network = options.network;
 		this.image = {
 			input: options.image || config.get('leviathan.uploads').image,
-			path: join(config.get('leviathan.downloads'), `image-${id()}`)
+			path: join(config.get('leviathan.downloads'), `image-${id()}`),
 		};
 		this.configJson = options.configJson || {};
 		this.contract = {

--- a/core/lib/components/os/balenaos.js
+++ b/core/lib/components/os/balenaos.js
@@ -1,6 +1,6 @@
 /**
  * # balenaOS helpers
- * 
+ *
  * The `BalenaOS` helper class can be used to configure and unpack the OS image that you will use in the test. This allows you to inject config options and network credentials into your image.
  *
  * ```js
@@ -157,8 +157,10 @@ module.exports = class BalenaOS {
 
 	/**
 	 * Prepares the received image/artifact to be used - either unzipping it or moving it to the Leviathan working directory
-	 * 
+	 *
 	 * @remark Leviathan creates a temporary working directory that can referenced using `config.get('leviathan.downloads')`
+	 *
+	 * @category helper
 	 */
 	async fetch() {
 		this.logger.log(`Unpacking the file: ${this.image.input}`);
@@ -177,7 +179,9 @@ module.exports = class BalenaOS {
 
 	/**
 	 * Parses version and variant from balenaOS images
-	 * @param {string} image 
+	 * @param {string} image
+	 *
+	 * @category helper
 	 */
 	async readOsRelease(image = this.image.path) {
 		const readVersion = async (pattern, field) => {
@@ -232,6 +236,7 @@ module.exports = class BalenaOS {
 
 	/**
 	 * Configures balenaOS image with specifc configuration (if provided), and injects required network configuration
+	 *
 	 * @category helper
 	 */
 	async configure() {

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -3803,6 +3803,14 @@
 						"shebang-command": "^1.2.0",
 						"which": "^1.2.9"
 					}
+				},
+				"rimraf": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"requires": {
+						"glob": "^7.1.3"
+					}
 				}
 			}
 		},
@@ -3844,6 +3852,14 @@
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"requires": {
 						"ms": "^2.1.1"
+					}
+				},
+				"rimraf": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"requires": {
+						"glob": "^7.1.3"
 					}
 				}
 			}
@@ -7576,6 +7592,14 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+				},
+				"rimraf": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"requires": {
+						"glob": "^7.1.3"
+					}
 				}
 			}
 		},
@@ -8629,9 +8653,10 @@
 			"integrity": "sha1-/yzEz3zHxjhaxxAXgnbm280Ddi8="
 		},
 		"rimraf": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
 			}
@@ -8950,6 +8975,16 @@
 				"rimraf": "^2.6.2",
 				"signal-exit": "^3.0.2",
 				"which": "^1.3.0"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				}
 			}
 		},
 		"spdx-correct": {
@@ -9329,6 +9364,14 @@
 				"yapool": "^1.0.0"
 			},
 			"dependencies": {
+				"rimraf": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
 				"tap-parser": {
 					"version": "9.3.3",
 					"resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-9.3.3.tgz",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1409,6 +1409,12 @@
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
 			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
 		},
+		"compare-versions": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
+			"integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
+			"dev": true
+		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4096,6 +4102,12 @@
 				"es5-ext": "~0.10.2"
 			}
 		},
+		"lunr": {
+			"version": "2.3.9",
+			"resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+			"integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+			"dev": true
+		},
 		"make-dir": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -4114,6 +4126,12 @@
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
 			"integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg="
+		},
+		"marked": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
+			"integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==",
+			"dev": true
 		},
 		"mbr": {
 			"version": "1.1.3",
@@ -7633,6 +7651,32 @@
 				"mimic-fn": "^1.0.0"
 			}
 		},
+		"onigasm": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/onigasm/-/onigasm-2.2.5.tgz",
+			"integrity": "sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==",
+			"dev": true,
+			"requires": {
+				"lru-cache": "^5.1.1"
+			},
+			"dependencies": {
+				"lru-cache": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+					"dev": true,
+					"requires": {
+						"yallist": "^3.0.2"
+					}
+				},
+				"yallist": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+					"dev": true
+				}
+			}
+		},
 		"opener": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
@@ -8766,6 +8810,34 @@
 			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
 			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
 		},
+		"shiki": {
+			"version": "0.9.5",
+			"resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.5.tgz",
+			"integrity": "sha512-XFn+rl3wIowDjzdr5DlHoHgQphXefgUTs2bNp/bZu4WF9gTrTLnKwio3f28VjiFG6Jpip7yQn/p4mMj6OrjrtQ==",
+			"dev": true,
+			"requires": {
+				"json5": "^2.2.0",
+				"onigasm": "^2.2.5",
+				"vscode-textmate": "5.2.0"
+			},
+			"dependencies": {
+				"json5": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+					"integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.5"
+					}
+				},
+				"minimist": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+					"dev": true
+				}
+			}
+		},
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -9267,6 +9339,11 @@
 						"tap-yaml": "^1.0.0"
 					}
 				},
+				"typescript": {
+					"version": "3.9.10",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+					"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q=="
+				},
 				"write-file-atomic": {
 					"version": "2.4.3",
 					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
@@ -9666,10 +9743,102 @@
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
 		},
+		"typedoc": {
+			"version": "0.21.2",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.21.2.tgz",
+			"integrity": "sha512-SR1ByJB3USg+jxoxwzMRP07g/0f/cQUE5t7gOh1iTUyjTPyJohu9YSKRlK+MSXXqlhIq+m0jkEHEG5HoY7/Adg==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.7",
+				"handlebars": "^4.7.7",
+				"lodash": "^4.17.21",
+				"lunr": "^2.3.9",
+				"marked": "^2.1.1",
+				"minimatch": "^3.0.0",
+				"progress": "^2.0.3",
+				"shiki": "^0.9.3",
+				"typedoc-default-themes": "^0.12.10"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.7",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+					"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"handlebars": {
+					"version": "4.7.7",
+					"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+					"integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.5",
+						"neo-async": "^2.6.0",
+						"source-map": "^0.6.1",
+						"uglify-js": "^3.1.4",
+						"wordwrap": "^1.0.0"
+					}
+				},
+				"lodash": {
+					"version": "4.17.21",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+					"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+					"dev": true
+				},
+				"minimist": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+					"dev": true
+				},
+				"typedoc-default-themes": {
+					"version": "0.12.10",
+					"resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.12.10.tgz",
+					"integrity": "sha512-fIS001cAYHkyQPidWXmHuhs8usjP5XVJjWB8oZGqkTowZaz3v7g3KDZeeqE82FBrmkAnIBOY3jgy7lnPnqATbA==",
+					"dev": true
+				},
+				"wordwrap": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+					"dev": true
+				}
+			}
+		},
+		"typedoc-plugin-pages-fork": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/typedoc-plugin-pages-fork/-/typedoc-plugin-pages-fork-0.0.1.tgz",
+			"integrity": "sha512-WZoTOSarUL1CPO7LJOpsltP6B8Qrx3Tc0/hjZVNRe5mwvZnU1/LAz12ERyKzA/TsR1iIpiaixzkbhIwYkICGiQ==",
+			"dev": true,
+			"requires": {
+				"compare-versions": "^3.6.0",
+				"typedoc-default-themes": "^0.10.1"
+			},
+			"dependencies": {
+				"typedoc-default-themes": {
+					"version": "0.10.2",
+					"resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.10.2.tgz",
+					"integrity": "sha512-zo09yRj+xwLFE3hyhJeVHWRSPuKEIAsFK5r2u47KL/HBKqpwdUSanoaz5L34IKiSATFrjG5ywmIu98hPVMfxZg==",
+					"dev": true,
+					"requires": {
+						"lunr": "^2.3.8"
+					}
+				}
+			}
+		},
 		"typescript": {
-			"version": "3.7.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.3.tgz",
-			"integrity": "sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw=="
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
+			"integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
+			"dev": true
 		},
 		"uglify-js": {
 			"version": "3.7.2",
@@ -9772,6 +9941,12 @@
 				"core-util-is": "1.0.2",
 				"extsprintf": "^1.2.0"
 			}
+		},
+		"vscode-textmate": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+			"integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+			"dev": true
 		},
 		"wcwidth": {
 			"version": "1.0.1",

--- a/core/package.json
+++ b/core/package.json
@@ -3,7 +3,7 @@
 		"prettify": "prettier --config ../.prettierrc --write \"{lib,tests}/**/*.js\"",
 		"lint": "eslint -c ../.eslintrc.* lib tests",
 		"start": "node lib/main.js",
-		"docs": "npx typedoc --tsconfig tsconfig.json"
+		"docs": "rimraf docs/ && npx typedoc --tsconfig tsconfig.json"
 	},
 	"dependencies": {
 		"ajv": "^6.5.0",
@@ -50,6 +50,7 @@
 		"eslint-plugin-promise": "^3.6.0",
 		"eslint-plugin-standard": "^3.0.1",
 		"prettier": "^1.19.1",
+		"rimraf": "^3.0.2",
 		"typedoc": "^0.21.2",
 		"typedoc-plugin-pages-fork": "0.0.1",
 		"typescript": "^4.3.4"

--- a/core/package.json
+++ b/core/package.json
@@ -2,7 +2,8 @@
 	"scripts": {
 		"prettify": "prettier --config ../.prettierrc --write \"{lib,tests}/**/*.js\"",
 		"lint": "eslint -c ../.eslintrc.* lib tests",
-		"start": "node lib/main.js"
+		"start": "node lib/main.js",
+		"docs": "npx typedoc --tsconfig tsconfig.json"
 	},
 	"dependencies": {
 		"ajv": "^6.5.0",
@@ -48,6 +49,9 @@
 		"eslint-plugin-prettier": "^3.0.1",
 		"eslint-plugin-promise": "^3.6.0",
 		"eslint-plugin-standard": "^3.0.1",
-		"prettier": "^1.19.1"
+		"prettier": "^1.19.1",
+		"typedoc": "^0.21.2",
+		"typedoc-plugin-pages-fork": "0.0.1",
+		"typescript": "^4.3.4"
 	}
 }

--- a/core/pagesconfig.json
+++ b/core/pagesconfig.json
@@ -1,7 +1,7 @@
 {
     "groups": [
         {
-            "title": "Getting Started",
+            "title": "Getting-Started",
             "pages": [
                 {
                     "title": "Quickstart",
@@ -16,7 +16,7 @@
                     "source": "../documentation/writing-tests.md"
                 },
                 {
-                    "title": "Tips & Reference",
+                    "title": "Tips and Reference",
                     "source": "../documentation/reference-tips.md"
                 },
                 {

--- a/core/pagesconfig.json
+++ b/core/pagesconfig.json
@@ -18,6 +18,10 @@
                 {
                     "title": "Tips & Reference",
                     "source": "../documentation/reference-tips.md"
+                },
+                {
+                    "title": "Links, and more links",
+                    "source": "../documentation/learn-more.md"
                 }
             ]
         }

--- a/core/pagesconfig.json
+++ b/core/pagesconfig.json
@@ -1,0 +1,28 @@
+{
+    "groups": [
+        {
+            "title": "Getting Started",
+            "pages": [
+                {
+                    "title": "Quickstart",
+                    "source": "../documentation/quickstart.md"
+                },
+                {
+                    "title": "Config.js Reference",
+                    "source": "../documentation/config-reference.md"
+                },
+                {
+                    "title": "Writing tests",
+                    "source": "../documentation/writing-tests.md"
+                },
+                {
+                    "title": "Tips & Reference",
+                    "source": "../documentation/reference-tips.md"
+                }
+            ]
+        }
+    ],
+    "output": "pages",
+    "listInvalidSymbolLinks": false,
+    "reflectionNavigationTitle": "Helper Methods"
+}

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -1,0 +1,39 @@
+{
+  "compilerOptions": {
+    "typeRoots": [
+      "typings",
+      "node_modules/@types"
+    ],
+    "module": "commonjs",
+    "target": "es2019",
+    "allowJs": true,
+    "outDir": "build",
+    "strict": true,
+    "preserveConstEnums": true,
+    "declaration": true,
+    "pretty": true,
+    "sourceMap": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "strictNullChecks": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "exclude": [
+    "node_modules/**",
+  ],
+  "typedocOptions": {
+    "name": "Leviathan Helpers",
+    "entryPoints": ["lib/common", "lib/components"],
+    "out": "docs",
+    "theme": "pages-plugin",
+    "excludeExternals": true,
+    "excludePrivate": true,
+    "excludeProtected": true,
+    // "excludeNotDocumented": true,
+    "categorizeByGroup": true,
+    "categoryOrder": ["helper", "*"],
+    "highlightTheme": "dark-plus",
+  }
+}

--- a/documentation/config-reference.md
+++ b/documentation/config-reference.md
@@ -7,6 +7,7 @@ module.exports = {
         networkWired: false,
         networkWireless: true,
         interactiveTests: false,
+        downloadVersion: 'latest',
         balenaApiKey: process.env.BALENACLOUD_API_KEY,
         balenaApiUrl: 'balena-cloud.com',
         organization: process.env.BALENACLOUD_ORG
@@ -29,6 +30,7 @@ Information on properties in `config.js`:
 - `organization` is the balenaCloud organizations where test applications are created. Ideally, you can add it as an environment variable and reference it with `process.env.BALENACLOUD_ORG`.
 - `image` is the absolute path to the balenaOS image that is flashed onto the Device Under Test (DUT). The image should be kept under the `workspace` directory. The path after `__dirname` in the config is a path relative to the workspace directory. Make sure to rename the image to balena.img. If you provide `balena.img` as your balenaOS image, then Leviathan will compress it for you in `gz` format. We recommend compressing beforehand, as it saves time.  
 - `workers` is the property where we specify precisely on which testbots the test suites will be executed on. You can specify this in multiple ways as per the requirement. 
+- `downloadVersion`: If you intend to download a balenaOS version for your tests, then you can use this property to specify the balenaOS version semver. The `fetchOS` helper will find and download the balenaOS image. To find the implementation, check https://github.com/balena-os/leviathan/blob/556ae5b52aacc28e72c42ca20413ed0e742126b3/core/lib/components/balena/sdk.js#L557 
 
 *Deprecated Properties*
 
@@ -60,9 +62,7 @@ workers: {
 ### `config.js` Examples
 
 Following is an exhaustive list of config.js examples which can be used for reference
-
-<details>
-  <summary>Running 3 test suites using workers objects (Click to expand)</summary>
+#### Running 3 test suites using workers objects
 
 ```js
 module.exports = [{
@@ -88,6 +88,7 @@ module.exports = [{
         config: {
             networkWired: false,
             networkWireless: true,
+            downloadVersion: 'latest',
             interactiveTests: false,
             balenaApiKey: process.env.BALENACLOUD_API_KEY,
             balenaApiUrl: 'balena-cloud.com',
@@ -101,7 +102,7 @@ module.exports = [{
     },
     {
         deviceType: "raspberrypi3",
-        suite: `${__dirname}/../suites/release`,
+        suite: `${__dirname}/../suites/cloud`,
         config: {
             networkWired: false,
             networkWireless: true,
@@ -117,10 +118,9 @@ module.exports = [{
         }
     }]
 ```
-</details>
 
-<details>
-  <summary>Running 2 test suites on workers array containing Public URLs (Click to expand)</summary>
+
+#### Running 2 test suites on workers array containing Public URLs
 
 ```js
 module.exports = [{
@@ -152,6 +152,5 @@ module.exports = [{
         workers: ['https://123213bda32048sgd5dfw223423723324.balena-devices.com/']
     }]
 ```
-</details>
 
 `config.js` files are validated using this [schema](https://github.com/balena-os/leviathan/blob/master/client/lib/schemas/multi-client-config.js). Some properties are optional with the ability to add new properties as required. After adding data to config.js, the properties will be available throughout the execution of the test suite.

--- a/documentation/config-reference.md
+++ b/documentation/config-reference.md
@@ -1,0 +1,157 @@
+# Config.js Reference
+```js
+module.exports = {
+    deviceType: '<DUT device type, for example "raspberrypi3-64">',
+    suite: `${__dirname}/../suites/os`,
+    config: {
+        networkWired: false,
+        networkWireless: true,
+        interactiveTests: false,
+        balenaApiKey: process.env.BALENACLOUD_API_KEY,
+        balenaApiUrl: 'balena-cloud.com',
+        organization: process.env.BALENACLOUD_ORG
+    },
+    image: `${__dirname}/balena.img.gz`,
+    workers: ['http://<short UUID of your testbot in balenaCloud>.local'],
+};
+```
+
+- Run the `run-tests.sh` script from the `workspace` directory and watch the logs. At the end of the run, reports and logs about the test will be stored in `workspace/reports` directory.
+
+Information on properties in `config.js`:
+
+- `deviceType` is the Device Under Test (DUT) attached to the testbot. Example: Raspberrypi3 64-bit device, the `deviceType` property needs to be `raspberrypi3-64`.
+- `suite` is the absolute path to the test suite directory that you want to execute. The path after `__dirname` in the config is a path relative to the workspace directory.
+- `networkWired` and `networkWireless` properties for configuration of Network Manager. Used to configure the right mode of connection for the DUT to connect to the Access Point (AP) created by the testbot.
+- `interactiveTests` If it's a semi-auto test or not.
+- `balenaApiKey` is the balenaCloud API key used when running the release suite. Ideally, you can add it as an environment variable and reference it with `process.env.BALENACLOUD_API_KEY`.
+- `balenaApiUrl` is the balenaCloud environment you are targetting for your test suite. Production is `'balena-cloud.com'` and staging is `'balena-staging.com'`.
+- `organization` is the balenaCloud organizations where test applications are created. Ideally, you can add it as an environment variable and reference it with `process.env.BALENACLOUD_ORG`.
+- `image` is the absolute path to the balenaOS image that is flashed onto the Device Under Test (DUT). The image should be kept under the `workspace` directory. The path after `__dirname` in the config is a path relative to the workspace directory. Make sure to rename the image to balena.img. If you provide `balena.img` as your balenaOS image, then Leviathan will compress it for you in `gz` format. We recommend compressing beforehand, as it saves time.  
+- `workers` is the property where we specify precisely on which testbots the test suites will be executed on. You can specify this in multiple ways as per the requirement. 
+
+*Deprecated Properties*
+
+- `downloadType` configures where the OS will be staged for upload to testbot. `local` is the only available value for it at the moment
+
+### Different `workers` configurations available
+
+1. **Using <UUID>.local** - The last line in the `config.json` above assumes you are on the same network with the testbot. Note: that on some Linux distributions, the container will not be able to resolve `.local` addresses. If you face this problem until we find a proper solution, you can replace this address with your device's local IP (copy it from the device summary page on balenaCloud).
+
+```js
+workers: ['http://<short UUID of your testbot in balenaCloud>.local'],
+```
+
+2. **Using public URLs** - If the testbot is not on the same network as you, please enable the public URL in balenaCloud and use that in the `workers` array. If multiple URLs are provided, then each testbot in the array would be running the same test suite listed in the `config.js`. Queueing support is WIP, where two or more test suites can be run on the same worker using public URLs.
+
+```js
+workers: ['Public URL of your testbot'],
+```
+
+3. **Using a balenaCloud application** - Using a workers object, you can specify a balenaCloud application containing testbots (connected to DUTs) and a balenaCloud API key. All testbots inside that balenaCloud application can be used to run test suites. These testbots need to be online and contain a `DUT` tag with the value being the `deviceType` to be selected for testing. Leviathan looks for all devices inside that balenaCloud application with `DUT` tag and pushes test jobs to available testbots. This method is often used for testbot rigs in production use cases, with several testbots available as workers to run the tests. Multiple tests can be queued and made to run in parallel on compatible workers.
+
+```js
+workers: {
+   balenaApplication: process.env.BALENACLOUD_APPLICATION_NAME,
+   apiKey: process.env.BALENACLOUD_API_KEY
+}
+```
+
+### `config.js` Examples
+
+Following is an exhaustive list of config.js examples which can be used for reference
+
+<details>
+  <summary>Running 3 test suites using workers objects (Click to expand)</summary>
+
+```js
+module.exports = [{
+        deviceType: "raspberrypi3",
+        suite: `${__dirname}/../suites/os`,
+        config: {
+            networkWired: false,
+            networkWireless: true,
+            interactiveTests: false,
+            balenaApiKey: process.env.BALENACLOUD_API_KEY,
+            balenaApiUrl: 'balena-cloud.com',
+            organization: process.env.BALENACLOUD_ORG,
+        },
+        image: `${__dirname}/balena.img.gz`,
+        workers: {
+            balenaApplication: 'testbot-vipul',
+            apiKey: "blah-blah-blah",
+        },
+    },
+    {
+        deviceType: "raspberrypi3",
+        suite: `${__dirname}/../suites/hup`,
+        config: {
+            networkWired: false,
+            networkWireless: true,
+            interactiveTests: false,
+            balenaApiKey: process.env.BALENACLOUD_API_KEY,
+            balenaApiUrl: 'balena-cloud.com',
+            organization: process.env.BALENACLOUD_ORG
+        },
+        image: `${__dirname}/balena.img.gz`,
+        workers: {
+            balenaApplication: 'testbot-vipul',
+            apiKey: "blah-blah-blah",
+        }
+    },
+    {
+        deviceType: "raspberrypi3",
+        suite: `${__dirname}/../suites/release`,
+        config: {
+            networkWired: false,
+            networkWireless: true,
+            interactiveTests: false,
+            balenaApiKey: process.env.BALENACLOUD_API_KEY,
+            balenaApiUrl: 'balena-cloud.com',
+            organization: process.env.BALENACLOUD_ORG
+        },
+        image: `${__dirname}/balena.img.gz`,
+        workers: {
+            balenaApplication: 'testbot-vipul',
+            apiKey: "blah-blah-blah",
+        }
+    }]
+```
+</details>
+
+<details>
+  <summary>Running 2 test suites on workers array containing Public URLs (Click to expand)</summary>
+
+```js
+module.exports = [{
+        deviceType: "raspberrypi3",
+        suite: `${__dirname}/../suites/os`,
+        config: {
+            networkWired: false,
+            networkWireless: true,
+            interactiveTests: false,
+            balenaApiKey: process.env.BALENACLOUD_API_KEY,
+            balenaApiUrl: 'balena-cloud.com',
+            organization: process.env.BALENACLOUD_ORG,
+        },
+        image: `${__dirname}/balena.img.gz`,
+        workers: ['https://6ad523252f8288bdff15bda320485237.balena-devices.com/']
+    },
+    {
+        deviceType: "raspberrypi3",
+        suite: `${__dirname}/../suites/hup`,
+        config: {
+            networkWired: false,
+            networkWireless: true,
+            interactiveTests: false,
+            balenaApiKey: process.env.BALENACLOUD_API_KEY,
+            balenaApiUrl: 'balena-cloud.com',
+            organization: process.env.BALENACLOUD_ORG
+        },
+        image: `${__dirname}/balena.img.gz`,
+        workers: ['https://123213bda32048sgd5dfw223423723324.balena-devices.com/']
+    }]
+```
+</details>
+
+`config.js` files are validated using this [schema](https://github.com/balena-os/leviathan/blob/master/client/lib/schemas/multi-client-config.js). Some properties are optional with the ability to add new properties as required. After adding data to config.js, the properties will be available throughout the execution of the test suite.

--- a/documentation/getting-started.md
+++ b/documentation/getting-started.md
@@ -17,7 +17,6 @@ module.exports = {
     config: {
         networkWired: false,
         networkWireless: true,
-        downloadType: 'local',
         interactiveTests: false,
         balenaApiKey: process.env.BALENACLOUD_API_KEY,
         balenaApiUrl: 'balena-cloud.com',
@@ -35,13 +34,16 @@ Information on properties in `config.js`:
 - `deviceType` is the Device Under Test (DUT) attached to the testbot. Example: Raspberrypi3 64-bit device, the `deviceType` property needs to be `raspberrypi3-64`.
 - `suite` is the absolute path to the test suite directory that you want to execute. The path after `__dirname` in the config is a path relative to the workspace directory.
 - `networkWired` and `networkWireless` properties for configuration of Network Manager. Used to configure the right mode of connection for the DUT to connect to the Access Point (AP) created by the testbot.
-- `downloadType` configures where the OS will be staged for upload to testbot. `local` is the only available value for it at the moment.
 - `interactiveTests` If it's a semi-auto test or not.
 - `balenaApiKey` is the balenaCloud API key used when running the release suite. Ideally, you can add it as an environment variable and reference it with `process.env.BALENACLOUD_API_KEY`.
 - `balenaApiUrl` is the balenaCloud environment you are targetting for your test suite. Production is `'balena-cloud.com'` and staging is `'balena-staging.com'`.
 - `organization` is the balenaCloud organizations where test applications are created. Ideally, you can add it as an environment variable and reference it with `process.env.BALENACLOUD_ORG`.
 - `image` is the absolute path to the balenaOS image that is flashed onto the Device Under Test (DUT). The image should be kept under the `workspace` directory. The path after `__dirname` in the config is a path relative to the workspace directory. Make sure to rename the image to balena.img. If you provide `balena.img` as your balenaOS image, then Leviathan will compress it for you in `gz` format. We recommend compressing beforehand, as it saves time.  
 - `workers` is the property where we specify precisely on which testbots the test suites will be executed on. You can specify this in multiple ways as per the requirement. 
+
+*Deprecated Properties*
+
+- - `downloadType` configures where the OS will be staged for upload to testbot. `local` is the only available value for it at the moment
 
 ### Different `workers` configurations available
 
@@ -80,7 +82,6 @@ module.exports = [{
         config: {
             networkWired: false,
             networkWireless: true,
-            downloadType: 'local',
             interactiveTests: false,
             balenaApiKey: process.env.BALENACLOUD_API_KEY,
             balenaApiUrl: 'balena-cloud.com',
@@ -98,7 +99,6 @@ module.exports = [{
         config: {
             networkWired: false,
             networkWireless: true,
-            downloadType: 'local',
             interactiveTests: false,
             balenaApiKey: process.env.BALENACLOUD_API_KEY,
             balenaApiUrl: 'balena-cloud.com',
@@ -116,7 +116,6 @@ module.exports = [{
         config: {
             networkWired: false,
             networkWireless: true,
-            downloadType: 'local',
             interactiveTests: false,
             balenaApiKey: process.env.BALENACLOUD_API_KEY,
             balenaApiUrl: 'balena-cloud.com',
@@ -141,7 +140,6 @@ module.exports = [{
         config: {
             networkWired: false,
             networkWireless: true,
-            downloadType: 'local',
             interactiveTests: false,
             balenaApiKey: process.env.BALENACLOUD_API_KEY,
             balenaApiUrl: 'balena-cloud.com',
@@ -156,7 +154,6 @@ module.exports = [{
         config: {
             networkWired: false,
             networkWireless: true,
-            downloadType: 'local',
             interactiveTests: false,
             balenaApiKey: process.env.BALENACLOUD_API_KEY,
             balenaApiUrl: 'balena-cloud.com',
@@ -341,11 +338,7 @@ const os = new BalenaOS(
 	this.getLogger(),
 );
 
-await os.fetch({
-	type: this.suite.options.balenaOS.download.type,
-	version: this.suite.options.balenaOS.download.version,
-	releaseInfo: this.suite.options.balenaOS.releaseInfo,
-});
+await os.fetch();
 
 await os.configure()
 ```
@@ -359,7 +352,7 @@ await exec(
 	} --config-network wifi --config-wifi-key ${
 		PASSWORD
 	}  --config-wifi-ssid ${
-		PASSWORD
+		SSID
 	}  `,
 ); 
 ```

--- a/documentation/getting-started.md
+++ b/documentation/getting-started.md
@@ -1,4 +1,6 @@
-# Quick start guide for leviathan
+# [Deprecated] Quick start guide for leviathan
+
+> This guide has been split into multiple pages in the same folder. You can read more about Leviathan from there. 
 
 This is a quick start guide for using the leviathan remote testing framework, with a testbot. As a prerequisite for this guide, you will have to prepare your testbot, using the following [guide](https://github.com/balena-io/testbot-hardware/blob/master/documentation/getting-started.md).
 

--- a/documentation/learn-more.md
+++ b/documentation/learn-more.md
@@ -3,8 +3,9 @@
 1. Watch the primer of the automated testing project presented by the team in balena Summit 2021: https://drive.google.com/drive/u/0/folders/1Jjw76PoimYC9H8LAMcXGp106ezxWT35Q
 
 2. For reference, you can read about Leviathan and testbots from:
-- Tutorial to run balenaOS tests on testbot: https://docs.google.com/document/d/18TojJ_hLT8ZtX9DEKXKa3I1458xGh32lqt-OU0j6FnM
-- A old deep dive into Leviathan - https://docs.google.com/document/d/1UiKDVHHp9HUZrBW2kE9FjKwSLb8BTtlDw_FEqyTWHLY/edit?usp=sharing
-- If you are looking for testbot block, it's WIP here - https://github.com/balena-io-playground/testblockbot
 
-3. You would need hardware for running a testbot and for that reach out to us on the [Testbot](https://www.flowdock.com/app/rulemotion/p-testbot) flow. For any queries or questions, this is the place to discuss it. 
+   - Tutorial to run balenaOS tests on testbot: https://docs.google.com/document/d/18TojJ_hLT8ZtX9DEKXKa3I1458xGh32lqt-OU0j6FnM
+   - A old deep dive into Leviathan - https://docs.google.com/document/d/1UiKDVHHp9HUZrBW2kE9FjKwSLb8BTtlDw_FEqyTWHLY/edit?usp=sharing
+   - If you are looking for testbot block, it's WIP here - https://github.com/balena-io-playground/testblockbot
+
+3. You would need hardware for running a testbot and for that reach out to us on the [Testbot](https://www.flowdock.com/app/rulemotion/p-testbot) flow. For any queries or questions, this is the place to discuss it.

--- a/documentation/learn-more.md
+++ b/documentation/learn-more.md
@@ -1,0 +1,10 @@
+# Learn More
+
+1. Watch the primer of the automated testing project presented by the team in balena Summit 2021: https://drive.google.com/drive/u/0/folders/1Jjw76PoimYC9H8LAMcXGp106ezxWT35Q
+
+2. For reference, you can read about Leviathan and testbots from:
+- Tutorial to run balenaOS tests on testbot: https://docs.google.com/document/d/18TojJ_hLT8ZtX9DEKXKa3I1458xGh32lqt-OU0j6FnM
+- A old deep dive into Leviathan - https://docs.google.com/document/d/1UiKDVHHp9HUZrBW2kE9FjKwSLb8BTtlDw_FEqyTWHLY/edit?usp=sharing
+- If you are looking for testbot block, it's WIP here - https://github.com/balena-io-playground/testblockbot
+
+3. You would need hardware for running a testbot and for that reach out to us on the [Testbot](https://www.flowdock.com/app/rulemotion/p-testbot) flow. For any queries or questions, this is the place to discuss it. 

--- a/documentation/quickstart.md
+++ b/documentation/quickstart.md
@@ -1,0 +1,34 @@
+# Quick start 
+
+This is a quick start guide for using the leviathan remote testing framework, with a testbot. As a prerequisite for this guide, you will have to prepare your testbot, using the following [guide](https://github.com/balena-io/testbot-hardware/blob/master/documentation/getting-started.md).
+
+## Run your first test suite
+Once you have set up a testbot, you can run your first tests.
+
+- Ensure you have `docker` and node installed on your machine.
+- Clone the [leviathan](https://github.com/balena-io/leviathan) repository and then `git submodule update --init --recursive` to install submodules.
+- Navigate to the `workspace` directory in the project using `cd workspace/`
+- Create a `config.js` file in the `workspace` directory using the following template:
+
+```js
+module.exports = {
+    deviceType: '<DUT device type, for example "raspberrypi3-64">',
+    suite: `${__dirname}/../suites/os`,
+    config: {
+        networkWired: false,
+        networkWireless: true,
+        downloadVersion: 'latest',
+        interactiveTests: false,
+        balenaApiKey: process.env.BALENACLOUD_API_KEY,
+        balenaApiUrl: 'balena-cloud.com',
+        organization: process.env.BALENACLOUD_ORG
+    },
+    image: `${__dirname}/balena.img`,
+    workers: ['http://<short UUID of your testbot in balenaCloud>.local'],
+};
+```
+
+- The tests in Leviathan are deprecated, hence use the tests from [meta-balena](https://github.com/balena-os/meta-balena/tree/master/tests/suites) instead. OS test suite is recommended as it works with the least configuration.
+- If you are running the OS test suite, downloading the image you want to test on your DUT from [balena.io/os](balena.io/os).Extract the image to `./leviathan/workspace` and rename it to `balena.img`. 
+- Run the `run-tests.sh` script from the `workspace` directory and watch the logs. 
+- At the end of the run, reports and logs about the test will be stored in `workspace/reports` directory.

--- a/documentation/quickstart.md
+++ b/documentation/quickstart.md
@@ -28,7 +28,15 @@ module.exports = {
 };
 ```
 
-- The tests in Leviathan are deprecated, hence use the tests from [meta-balena](https://github.com/balena-os/meta-balena/tree/master/tests/suites) instead. OS test suite is recommended as it works with the least configuration.
-- If you are running the OS test suite, downloading the image you want to test on your DUT from [balena.io/os](balena.io/os).Extract the image to `./leviathan/workspace` and rename it to `balena.img`. 
+- Use the tests from [meta-balena](https://github.com/balena-os/meta-balena/tree/master/tests/suites) instead. OS test suite is recommended as it works with the least configuration. Either copy the OS test suite to the `suite` property path as mentioned in config.js or point the `suite` property to the path of the OS test suite.
+- Extract the image you want to test to `./leviathan/workspace` and rename it to `balena.img`. You can downloaded unmanaged image from [balena.io/os](balena.io/os).
 - Run the `run-tests.sh` script from the `workspace` directory and watch the logs. 
 - At the end of the run, reports and logs about the test will be stored in `workspace/reports` directory.
+- With that, you have successfully completed your first test run.
+
+## Where do you go from here?
+
+1. Start by {@page Writing tests | writing your first test}.
+2. To know more about the config.js and it's properties, refer to {@page Config.js Reference | Config.js reference}.
+3. To understand the bigger picture about the project read/watch these {@page Links, and more links | resources}.
+4. Some tips and references for {@page Tips and Reference | writing better tests} with Leviathan.

--- a/documentation/reference-tips.md
+++ b/documentation/reference-tips.md
@@ -1,0 +1,214 @@
+# Tips for writing tests and reference guide
+
+### Worker
+The worker class can be used to control the testbot hardware. In the `suite.js` file, you can create an instance of it, and then use its methods to flash the DUT, power it on/off, and set up a network AP for the DUT to connect to. 
+
+```js		
+const Worker = this.require('common/worker');
+this.suite.context.set({
+	worker: new Worker(DEVICE_TYPE_SLUG, this.getLogger()), // Add an instance of worker to the context
+});
+const Worker = this.require('common/worker');
+const worker = new Worker(DEVICE_TYPE_SLUG, this.getLogger())
+```
+
+The `this.getLogger()` method gets the logger that can be used from any suite.
+Once you have an instance of the`Worker class, you can use its methods like this:
+
+```js
+const Worker = this.require('common/worker');
+const worker = new Worker(DEVICE_TYPE_SLUG, this.getLogger())
+
+await worker.network(network: {
+	ssid: SSID,
+	psk: PASSWORD,
+	nat: true,
+})
+await worker.off() // turn off the power to the DUT
+await worker.flash() // flash the DUT
+await worker.on()
+```
+
+Another helpful method of the worker is `executeCommandInHostOs`, which lets you execute command line operations in the host OS of the DUT.
+Assuming that the DUT is connected to the AP of the testbot:
+```js
+const Worker = this.require('common/worker');
+const worker = new Worker(DEVICE_TYPE_SLUG, this.getLogger())
+await worker.executeCommandInHostOS('cat /etc/hostname', `${UUID}.local`);
+```
+
+### Context
+The context class lets you share instances of objects across different tests. For example, if we made an instance of the worker class in a suite, as above, other tests would not be able to see it. An instance of the context class has a `set()` and a `get()` method, to both add or fetch objects from the context. An example can be seen below:
+
+```js
+const Worker = this.require('common/worker');
+
+this.suite.context.set({
+	worker: new Worker(DEVICE_TYPE_SLUG, this.getLogger()), // Add an instance of worker to the context
+});
+
+await this.context.get().worker.flash() // flash the DUT with the worker instance thats in the context
+```
+
+The context can be used to share anything between tests - device uuids, app names and so on.
+
+### OS helpers
+The `BalenaOS` helper class can be used to configure and unpack the OS image that you will use in the test. This allows you to inject config options and network credentials into your image.
+
+```js
+const network_conf = {
+	ssid: SSID,
+	psk: PASSWORD,
+	nat: true,
+}
+
+const os = new BalenaOS(
+	{
+		deviceType: DEVICE_TYPE_SLUG,
+		network: network_conf,
+		configJson: {
+			uuid: UUID,
+			persistentLogging: true,
+		},
+	},
+	this.getLogger(),
+);
+
+await os.fetch();
+
+await os.configure()
+```
+
+Alternatively, you can use the CLI to perform these functions - the CLI is imported in the testing environment:
+```js
+await exec(`balena login --token ${API_KEY}`);
+
+await exec(
+	`balena os configure ${PATH_TO_IMAGE}-a ${
+	} --config-network wifi --config-wifi-key ${
+		PASSWORD
+	}  --config-wifi-ssid ${
+		SSID
+	}  `,
+); 
+```
+
+### Cloud helpers
+The `BalenaSDK` class, defined in [`core/components/balena/sdk`](https://github.com/balena-os/leviathan/blob/master/core/lib/components/balena/sdk.js), contains an instance of the balena sdk, as well as some helper methods. The `balena` attribute of the class contains the sdk, which can then be used as follows:
+```js
+const Cloud = this.require("components/balena/sdk");
+
+this.suite.context.set({
+	cloud: new Balena(`https://api.balena-cloud.com/`, this.getLogger())
+});
+
+
+// login
+await this.context
+	.get()
+	.cloud.balena.auth.loginWithToken(this.suite.options.balena.apiKey);
+
+// create a balena application
+await this.context.get().cloud.balena.models.application.create({
+	name: `NAME`,
+	deviceType: `DEVICE_TYPE`,
+	organization: `ORG`,
+});
+
+```
+
+Alternatively, Balena SDK is imported into the testing environment by default, so you can create an instance of the SDK and use it without the cloud helpers class:
+
+```js
+this.suite.context.set({
+	balena: {
+		sdk: getSdk({
+			apiUrl: 'https://api.balena-cloud.com/',
+		}),
+		sshKey: { label: LABEL},
+	}
+});
+
+await this.context.get().balena.sdk.auth.loginWithToken(TOKEN);
+await this.context.get().balena.sdk.models.application.create({
+	name: APP_NAME,
+	deviceType: DEVICE_TYPE_SLUG,
+	organization: ORG,
+})
+```
+
+### Suite node dependencies
+Each suite also has its own `package.json` that can be used to list dependencies for any tests in that suite, if those packages aren'y already present within the testing environment.
+
+### Teardowns
+You can register functions to be carried out upon "teardown" of the suite or test. These will execute when the test ends, regardless of passing or failing:
+
+```js
+this.suite.teardown.register(() => {
+	this.log('Worker teardown');
+	return this.context.get().worker.teardown();
+});
+```
+
+If registered in the suite, this will be carried out upon the suite (the collection of tests) ending. You can also add individual teardowns within tests, that will execute when the individual test has ended. In this example here, within the test, we create an applciation, and after the test, we wish to remove that application:
+
+```js
+module.exports = {
+	title: 'Example',
+		tests: [
+			{
+				title: 'Move device to another application',
+				run: async function(test) {
+					// create an app
+					await this.context.get().balena.sdk.models.application.create({
+						name: APP,
+						deviceType: DEVICE_TYPE,
+						organization: ORG,
+					});
+					// Register a teardown that will remove the test when the test ends
+					this.teardown.register(() => {
+						return this.context.get().balena.sdk.models.application.remove(APP);
+					});
+
+					// THE REST OF THE TEST CODE
+				}
+			}
+		]
+}
+```
+
+
+### Screen capture
+If screen capture is supported and appropriate hardware is attached, the video output of the DUT can be captured. For the testbot, this requires a compatible video capture device to be connected, that works with v4L2 and enumerates on the `/dev/video0` interface.
+
+If that is the case, then capture can be started using the `Worker` class `capture()` method, for example:
+```js
+const Worker = this.require('common/worker');
+const worker = new Worker('DEVICE_TYPE_SLUG', this.getLogger())
+await worker.capture('start');
+```
+
+This will trigger video capture to start, and frames will be saved as `jpg` files in the `/data/capture` directory (which is a shared volume). Capture will continue until stopped with:
+
+```js
+await worker.capture('stop');
+```
+### Sending reports and artifacts back to the client from the testbot
+By default, serial logs (given that the hardware is set up correctly), and the logs from the tests will be sent back to the client that started the test, upon the test finishing. Other artifacts can be sent back to the client using the `archiver` method. This method is available within any test:
+
+```js
+this.archiver.add(`FILE OR DIRECTORY`)
+```
+
+Using this method, at the end of the test, any artifacts added to the archive are compressed and downloaded by the client. These are available in the `workspace/reports` directory at the end of the test.
+
+
+### What should go in the suite.js of a suite
+The recommended pattern is to put the code that gets the device into the state ready for the tests, into the suite. 
+Usually, this will include:
+- creating an instance of the worker class
+- configuring the OS image with the correct configuration and network settings
+- setting up the network of the testbot (using `Worker.network()`)
+- flashing the DUT (using `Worker.flash()`)
+- Checking that the device is online
+- listing the tests

--- a/documentation/writing-tests.md
+++ b/documentation/writing-tests.md
@@ -1,0 +1,91 @@
+# Writing new tests in Leviathan
+
+The leviathan framework runs 'suites'. A suite is a collection of tests and a configuration for the environment. The current suite that runs on meta-balena & balena-raspberrypi PRs can be found [here on GitHub](https://github.com/balena-os/meta-balena/tree/master/tests/suites/os).
+
+Leviathan comprises a client, which sends test suites, and a testbot, which will listen for and execute suites. The client is a container that you can run on your laptop, or within an automated workflow to send tests to a testbot.
+
+As you can see from the linked meta-balena directory, we can set up a directory containing a test suite as follows:
+- `tests` - Folder containing actual tests
+- `conf.js` - File assigning configuration options
+- `package.json` - File containing the node dependencies to install for the test suite
+- `suite.js` - File where you can select what tests are run as part of the suite, and define your setup code to run before the tests start.
+
+Inside the tests folder, you can add the actual test logic. The recommended approach is to add a folder for each test (with an appropriate name), and inside, keep any assets associated with the test. The test can be written within a file called `index.js`. The tests folder will look something like:
+
+```bash
+- tests
+    - test-1
+        - assets
+        - index.js - the test is written in this file
+    - test-2
+        - assets
+        - index.js
+    - .
+    - .
+    - etc 
+```
+
+## How do I add a new test?
+
+To add a new test, you could either create a new suite, or a add a test to an existing suite.
+For reference, an old PR [adding a test](https://github.com/balena-os/leviathan/commit/0ec26632881ef2c262e67d30ebccaaf0611b01ad#diff-df7b8717d54947445c5900174e15e5cf) to the OS test suite in Leviathan.
+
+### Adding a test/tests to an existing suite
+
+1. Navigate to the suite folder where the test needs to be added (for example https://github.com/balena-os/meta-balena/tree/master/tests/suites/os). 
+2. Navigate to the `/tests` directory inside that suite.
+3. Create a new directory `<MY_NEw_TEST>`, with an appropriate name for your test.
+4. Inside this new directory, create an `index.js` file
+5. Inside `index.js`, test logic lives (details about writing the test logic are explained in the next section)
+6. Going back to the suite directory, navigate to `suite.js`
+7. Inside `suite.js`, towards the botton of the file, there will be an array named `tests`, add your new test to it like this:
+```js
+tests: [
+    './tests/fingerprint',
+    './tests/led',
+    './tests/config-json',
+    './tests/connectivity',
+    './tests/<MY_NEw_TEST>',
+    ],
+```
+8. Ensure that any new dependencies used in your test are added to the `package.json`
+
+
+### Writing the test logic
+
+Tests must be written in node, and are ingested by a framework called [node-tap](https://node-tap.org/docs/api/asserts/). 
+To write a new test, inside `tests/<MY_NEw_TEST>/index.js` , we can use the following template (note that this file can contain a set of tests - you just have to have multiple objects in the `tests` array!)
+
+Each test is an asychnronous function, assigned to the `run` attribute of a test.
+
+```js
+'use strict';
+
+module.exports = {
+    title: 'Your name for the collection of tests in this file goes here',
+    tests: [
+        {
+            title: 'The test name goes here',
+            run: async function(test) { 
+                // put your test within an async function
+                // For example, we want to test this addition function
+                // let addition = (a,b) =>  a + b
+
+                // Here you can use an assertion to determine the result of the test for example:
+                // the `.is` assertion checks if result is === 42
+                // test.is(addition(4,5), 42, 'Message');  The test fails with Message!
+                
+                // the `.is` assertion checks that result === 8
+                // test.is(addition(4,4), 8, 'Message');  The test passes!
+            },
+        },
+    ],
+};
+```
+The supported assertions can be found here: https://node-tap.org/docs/api/asserts/
+
+More examples of test logic can be seen here: https://github.com/balena-os/meta-balena/blob/master/tests/suites/os/tests/fingerprint/index.js for a very simple test, and here: https://github.com/balena-os/meta-balena/blob/master/tests/suites/os/tests/connectivity/index.js for more complex tests. 
+
+### Writing a new suite
+
+A new test suite can be created using the folder structure described at the start of this document. A new folder in the suites folder will be the start of the new suite. After you are finished writing the test suite, add the path of the test suite to the `suite` property in your `workspace/config.js`

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "prettify": "for component in 'suites' 'worker' 'core' 'client'; do npm --prefix $component run prettify; done",
     "lint": "for component in 'suites' 'worker' 'core' 'client'; do npm --prefix $component run lint; done",
-    "preinstall": "for component in 'suites' 'worker' 'core' 'client'; do npm --prefix $component install; done"
+    "preinstall": "for component in 'suites' 'worker' 'core' 'client'; do npm --prefix $component install; done",
+    "docs": "npm --prefix core run docs"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Took time and head banging but I have successfully, 

- Redocuments helpers 
- Rearranges already written documentation
- Create helper specific documentation pages
- Setup Typedoc for documenting future helpers

![Screenshot from 2021-07-08 04-29-11](https://user-images.githubusercontent.com/22801822/124838747-1c295200-dfa5-11eb-9274-44448143eed7.png)


The only thing left to do

- [x] Write more documentation

Almost there on this one

- [ ] The search doesn't work (No solution found)

Explanation: We are using a typedoc plugin that lets us have the sidebar the way it is but the plugin hasn't been updated for quite a while. So if losing search isn't okay then we might be losing the sidebar. This is the plugin - https://github.com/mipatterson/typedoc-plugin-pages, already pinged on open issues there. 

- [x] Verify what already has been written because a lot of things went out of date (Deprecated some documents, and rewrote whatever I saw)

- [x]  See how we will build, update and show this documentation

Added these instructions on the README + the documentation would be available on GitHub pages