### PR TITLE
patch: CLI helpers considerate of API environment

### DIFF
--- a/core/lib/components/balena/cli.js
+++ b/core/lib/components/balena/cli.js
@@ -52,9 +52,11 @@ const { basename, dirname, join } = require('path');
 
 module.exports = class CLI {
 	constructor(
+		apiUrl='balena-cloud.com',
 		logger = { log: console.log, status: console.log, info: console.log },
 	) {
 		this.logger = logger;
+		exec(`BALENARC_BALENA_URL=${apiUrl}`)
 	}
 
 	/**


### PR DESCRIPTION
In the constructor for the CLI class, we are now setting the `BALENARC_BALENA_URL=${API_ENVIRONMENT}` variable to set the API environment for the CLI. 

﻿Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
