### PR TITLE
fix preload helper

### DIFF
--- a/core/config/default.js
+++ b/core/config/default.js
@@ -12,7 +12,7 @@ module.exports = {
   },
   leviathan: {
     artifacts: '/tmp/artifacts',    // To store artifacts meant to be reported as results at the end of the suite
-    downloads: '/tmp/downloads',    // To store/download assets needed for the suite (non-persistent) 
+    downloads: '/data/downloads',    // To store/download assets needed for the suite (non-persistent) 
     workdir: '/data',
     uploads: defer(function() {
       return mapValues({ image: 'os.img', config: 'config.json', suite: 'suite' }, value => {

--- a/core/lib/components/balena/cli.js
+++ b/core/lib/components/balena/cli.js
@@ -52,15 +52,11 @@ module.exports = class CLI {
 				: false;
 		});
 
-		if (Mount == null || dirname(image) !== Mount.Destination) {
-			throw new Error(
-				'OS image not found in the expected volume, cannot preload.',
-			);
-		}
-
+		image = image.replace(Mount.Destination, "")
+		
 		// We have to deal with the fact that our image exist on the fs the preloader runs in a different
 		// path than where our docker daemon runs. Until we fix the issue on the preloader
-		await ensureFile(join(Mount.Source, basename(image)));
+		await ensureFile(join(Mount.Source, image));
 
 		this.logger.log('Preloading image');
 		await new Promise((resolve, reject) => {
@@ -70,7 +66,7 @@ module.exports = class CLI {
 				[
 					`preload ${join(
 						Mount.Source,
-						basename(image),
+						image,
 					)} --docker ${socketPath} --app ${options.app} --commit ${
 						options.commit
 					} ${options.pin ? '--pin-device-to-release ' : ''}`,


### PR DESCRIPTION
In PR #433 we made the unpacking functions unpack the image to a directory that is automatically deleted at the end of a test suite. This broke the preload helper function, which required the image to be in a volume to work


Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>