### PR TITLE
patch: Fix grouping of online testbots when selecting available workers

### DIFF
--- a/client/bin/multi-client.js
+++ b/client/bin/multi-client.js
@@ -60,7 +60,8 @@ class NonInteractiveState {
 	}
 
 	info(data) {
-		console.log(`INFO: ${data.toString()}`);
+		const timestamp = new Date().toISOString()
+		console.log(`[${timestamp}] INFO: ${data.toString()}`);
 	}
 
 	logForWorker(workerId, data) {
@@ -479,8 +480,8 @@ class State {
 								break
 							}
 						}
-					} catch(e) {
-						state.info(`Couldn't retrieve worker ${device.deviceId} state...`)
+					} catch(err) {
+						state.info(`Couldn't retrieve ${device.tags.DUT} worker's state. Querying ${deviceUrl} and received ${err.name}: ${err.statusCode}`)
 					}
 				}
 			}

--- a/client/lib/balena.ts
+++ b/client/lib/balena.ts
@@ -57,6 +57,7 @@ export class BalenaCloudInteractor {
 		appName: string,
 		dutType: string,
 	): Promise<DeviceInfo[]> {
+		let selectedDevices = []
 		const tags = await this.sdk.models.device.tags.getAllByApplication(appName);
 		const taggedDevices = groupTagsData(tags).filter(
 			device => device.tags['DUT'] === dutType,
@@ -65,9 +66,9 @@ export class BalenaCloudInteractor {
 			const online = await this.sdk.models.device.isOnline(
 				taggedDevice.deviceId,
 			);
-			if (!online) taggedDevices.splice(taggedDevices.indexOf(taggedDevice), 1);
+			if (online) selectedDevices.push(taggedDevice);
 		}
-		return taggedDevices;
+		return selectedDevices;
 	}
 
 	/**


### PR DESCRIPTION
Previously, when selecting available workers by the DUT tag and the list contained 2 or more workers. The logic was only testing one testbot if it was online or not. If it wasn't online that that testbot was removed from the list, and other testbots weren't being checked which lead to 503 errors when those testbots were being reached for jobs. 

We debugged and fixed that by identifying that we were hot-fixing/modifying the array while iterating through it as well. This was the reason behind inconsistencies which were fixed creating a new array for selectedDevices and returning that as the list of viable workers. 

The PR also includes:
1. Adding an ISO timestamps to INFO messages and not just workerLog messages.
2. Improving the error thrown when state can't be retrieved from testbots with the addition of WorkerURL that was used and the error code received.  

﻿Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
