### PR TITLE
add message when suite exits to client

### DIFF
--- a/client/lib/index.js
+++ b/client/lib/index.js
@@ -322,7 +322,10 @@ module.exports = class Client extends PassThrough {
 							break;
 						case 'status':
 							if (!data.success) {
+								this.log(`Test suite has exited with: FAIL`)
 								process.exitCode = 2;
+							} else {
+								this.log(`Test suite has exited with: PASS`)
 							}
 							break;
 						case 'error':


### PR DESCRIPTION
This is to help us debug when the client hangs after a suite is supposedly finish 

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>