### PR TITLE
client: log error message when image does not exist

### DIFF
--- a/client/lib/index.js
+++ b/client/lib/index.js
@@ -87,7 +87,11 @@ module.exports = class Client extends PassThrough {
 
 		// Sanity checks + sanity checks
 		if (artifact.path != null) {
-			const stat = await fs.stat(artifact.path);
+			try {
+				const stat = await fs.stat(artifact.path);
+			} catch (err) {
+				console.log(err);
+			}
 
 			if (!stat[artifact.type]()) {
 				throw new Error(`${artifact.path} does not satisfy ${artifact.type}`);


### PR DESCRIPTION
When the image specified in config.js does not exist, the
single-client.js script exits with no failures, and no logged errors.
    
Catch this error and log it to the console.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>