### PR TITLE
Restructure teardown order to prevent dependency issues

### DIFF
--- a/core/lib/common/suite.js
+++ b/core/lib/common/suite.js
@@ -181,10 +181,14 @@ class Suite {
 		try {
 			await treeExpander([this.rootTree, tap]);
 		} finally {
+			// Teardown all running test suites before removing assets & dependencies
+			this.state.log(`Test suite completed. Tearing down now.`);
+			await this.teardown.runAll();
 			await this.removeDependencies();
 			await this.removeDownloads();
-			await this.teardown.runAll();
+			this.state.log(`Teardown complete.`);
 			tap.end();
+			this.state.log(`Test Finished`);
 		}
 	}
 


### PR DESCRIPTION
The archiverLogs helper doesn't work at the moment, will need some discussion on how we need to implement it. IF we want to implement it. 