### PR TITLE
increase ssh keepalive interval time

### DIFF
--- a/core/lib/common/utils.js
+++ b/core/lib/common/utils.js
@@ -62,7 +62,7 @@ const getSSHClientDisposer = config => {
 				assignIn(
 					{
 						agent: process.env.SSH_AUTH_SOCK,
-						keepaliveInterval: 20000,
+						keepaliveInterval: 10000 * 60 * 5, // 5 minute interval
 					},
 					conf,
 				),


### PR DESCRIPTION
During some hup tests we are getting a keepAlive timeout while waiting for a HUP to finish - so this is an attempt to stop that from happening

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>