### PR TITLE
remove redundant parts of worker dockerfile

### DIFF
--- a/worker/Dockerfile.template
+++ b/worker/Dockerfile.template
@@ -1,24 +1,3 @@
-FROM balenalib/%%BALENA_MACHINE_NAME%%-python:3.5.6-buster-build AS firmware
-
-RUN install_packages git libusb-dev
-
-WORKDIR /src
-
-RUN git clone https://github.com/PaulStoffregen/teensy_loader_cli.git -b 2.1
-RUN cd teensy_loader_cli && \
-  make && \
-  cd -
-
-RUN git clone https://github.com/balena-io-modules/usbsdmux.git
-RUN cd usbsdmux && \
-  virtualenv -p python3 venv && \
-  . venv/bin/activate && \
-  pip install pyinstaller && \
-  python setup.py install && \
-  pyinstaller --onefile venv/bin/usbsdmux-configure && \
-  deactivate && \
-  cd -
-
 FROM balenalib/%%BALENA_MACHINE_NAME%%-golang:1.15-buster-build AS go-build
 
 RUN GO111MODULE=on go get -u github.com/nadoo/glider@v0.12.2
@@ -43,7 +22,6 @@ FROM balenalib/%%BALENA_MACHINE_NAME%%-node:12-buster-run
 
 ENV UDEV=1
 
-WORKDIR /usr/app/firmware
 
 RUN install_packages \
   libusb-dev libdbus-1-dev \
@@ -55,10 +33,6 @@ RUN sed -i 's/^#cgroup_controllers =.*/cgroup_controllers = []/g' /etc/libvirt/q
 
 COPY --from=go-build /go/bin/glider /usr/local/bin
 
-COPY --from=firmware /src/usbsdmux/dist/usbsdmux-configure /usr/local/bin
-COPY --from=firmware /src/teensy_loader_cli/teensy_loader_cli /usr/local/bin
-COPY firmware/StandardFirmataPlus.ino.hex .
-COPY firmware/SDcardSwitch.ino.hex .
 
 WORKDIR /usr/app
 


### PR DESCRIPTION
This will reduce the size of the container, and will also remove an error we were getting when trying to create a new release

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>