### PR TITLE
have test suite bail after first failure

### DIFF
--- a/core/lib/common/suite.js
+++ b/core/lib/common/suite.js
@@ -145,7 +145,10 @@ class Suite {
 				template(title)({
 					options: this.context.get(),
 				}),
-				{ buffered: false },
+				{
+					buffered: false,
+					bail: true,
+				},
 				async t => {
 					if (run != null) {
 						try {


### PR DESCRIPTION
When tests fail the test suite continues, even though the PR will be blocked anyway, wasting a lot of time. In this PR I use the bail flag to signal that the tests should bail after the first failure.

Discussed here: https://www.flowdock.com/app/rulemotion/r-resinos/threads/oBsi97NTPDBl5iiRPq_MaleiV4A

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>