### PR TITLE
core: handle promise rejection in state

### DIFF
--- a/core/lib/state.js
+++ b/core/lib/state.js
@@ -24,12 +24,7 @@ class BalenaFinLed {
 	}
 
 	safeWrite(path, value) {
-		try {
-			return fs.writeFile(path, value);
-		} catch (e) {
-			// Ignore.
-			return Promise.resolve();
-		}
+		return fs.writeFile(path, value).catch(e => {});
 	}
 
 	async color(color) {


### PR DESCRIPTION
Existing code attempts to ignore failures opening LED file paths in
safeWrite(). However, there's an unhandled promise rejection in a couple
of places as a result of mishandling the rejection. Catch the error to
prevent this warning.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>