### PR TITLE
patch: Reduce helpers delays and retries

### DIFF
--- a/core/lib/common/utils.js
+++ b/core/lib/common/utils.js
@@ -112,8 +112,8 @@ module.exports = {
 	waitUntil: async (
 		promise,
 		rejectionFail = false,
-		_times = 20,
-		_delay = 30000,
+		_times = 7,
+		_delay = 15000,
 	) => {
 		const _waitUntil = async timesR => {
 			if (timesR === 0) {

--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -227,8 +227,8 @@ module.exports = class Worker {
 		command,
 		target,
 		timeout = {
-			interval: 10000,
-			tries: 10,
+			interval: 3000,
+			tries: 3,
 		},
 	) {
 		const ip = /.*\.local/.test(target) ? await this.ip(target) : target;

--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -165,8 +165,8 @@ module.exports = class Worker {
 	ip(
 		target,
 		timeout = {
-			interval: 10000,
-			tries: 60,
+			interval: 5000,
+			tries: 10,
 		},
 	) {
 		return /.*\.local/.test(target)
@@ -278,7 +278,7 @@ module.exports = class Worker {
 				);
 			},
 			{
-				max_tries: 10,
+				max_tries: 5,
 				interval: 5000,
 			},
 		);

--- a/core/lib/components/balena/sdk.js
+++ b/core/lib/components/balena/sdk.js
@@ -85,8 +85,8 @@ module.exports = class BalenaSDK {
 		command,
 		device,
 		timeout = {
-			interval: 10000,
-			tries: 60,
+			interval: 3000,
+			tries: 3,
 		},
 	) {
 		const sshPort = 22;

--- a/workspace/.gitignore
+++ b/workspace/.gitignore
@@ -2,6 +2,7 @@
 *.img
 *.js
 *.conf
+*.docker
 
 reports/
 saved-images/


### PR DESCRIPTION
Reduce retries counters and timeouts on waitUntil and executeCommandIntoHostOS for faster outcomes and less waiting. 

﻿Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
