### PR TITLE
Disable dev variant substitution as they have merged

### DIFF
--- a/core/lib/components/balena/sdk.js
+++ b/core/lib/components/balena/sdk.js
@@ -612,8 +612,6 @@ module.exports = class BalenaSDK {
 			const versions = await this.balena.models.os.getSupportedVersions(
 				deviceType,
 			);
-			// make sure we always flash the development variant
-			version = versions.latest.replace('prod', 'dev');
 		}
 
 		const path = join(


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
See: https://github.com/balena-os/meta-balena/pull/2227

Although we are still publishing both .dev and .prod variants for now, they are actually the same image going forward.

Opening as DRAFT for a couple reasons:
1. this change may be breaking, not sure yet
2. this helper may be in the process of being moved to another repo entirely
