### PR TITLE
patch: Disable Dependabot from Leviathan

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 0
+  commit-message:
+    prefix: patch
+  rebase-strategy: disabled

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode/
 node_modules
 build
 coverage

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "eslint.enable": true
-}


### PR DESCRIPTION
Atm, with the helpers moving out to a new NPM package and some architecture changes due. Dependabot is causing more noise than help with the pull requests. Hence, disabling it temporarily until we reach a stable state as far as our packages situation is considered. 

﻿Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
