### PR TITLE
fix parsing of os-release file for flasher images

### DIFF
--- a/core/lib/components/os/balenaos.js
+++ b/core/lib/components/os/balenaos.js
@@ -194,30 +194,29 @@ module.exports = class BalenaOS {
 						path: '/os-release',
 					}),
 				);
-				if (value) {
+				if (value !== null) {
 					this.releaseInfo[field] = value[1];
 					this.logger.log(
 						`Found ${field} in os-release file: ${this.releaseInfo[field]}`,
 					);
 				}
 			} catch (e) {
-				// If os-release file isn't found, look inside the image to be flashed
-				// Especially in case of OS image inside flasher images. Example: Intel-NUC
 				try {
-					const value = pattern.exec(
+					const value1 = pattern.exec(
 						await imagefs.readFile({
 							image: image,
 							partition: 2,
-							path: '/etc/os-release',
+							path: '/usr/lib/os-release',
 						}),
 					);
-					if (value) {
-						this.releaseInfo[field] = value[1];
+					if (value1 !== null) {
+						this.releaseInfo[field] = value1[1];
+						this.logger.log(
+							`Found ${field} in os-release file (flasher image): ${this.releaseInfo[field]}`,
+						);
 					}
 				} catch (err) {
-					this.logger.log(
-						`Cannot detect ${field} with os-release. Error: ${err}`,
-					);
+					this.logger.log(`Couldn't find os-release file`);
 				}
 			}
 		};
@@ -240,7 +239,7 @@ module.exports = class BalenaOS {
 	 * @category helper
 	 */
 	async configure() {
-		this.readOsRelease();
+		await this.readOsRelease();
 		this.logger.log(`Configuring balenaOS image: ${this.image.input}`);
 		if (this.configJson) {
 			await injectBalenaConfiguration(this.image.path, this.configJson);


### PR DESCRIPTION
Previously, we were unable to extract the variant and version of the OS from the image that we were about to use in the tests. This was because we were looking at the symbolic link to the os-release file, and not the file itself

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>