### PR TITLE
stop testbotsdk build breaking local make

### DIFF
--- a/compose/generic-x86.yml
+++ b/compose/generic-x86.yml
@@ -14,7 +14,10 @@ services:
       share: 'core-storage'
   worker:
     privileged: true
-    build: ./worker
+    build: 
+      context: ./worker
+      args:
+        - SKIP_INSTALL_BINARY=true
     pid: 'host'
     network_mode: 'host'
     ipc: 'host'

--- a/worker/Dockerfile.template
+++ b/worker/Dockerfile.template
@@ -8,6 +8,8 @@ WORKDIR /tmp/node
 
 RUN install_packages libdbus-1-dev libvirt-dev python
 
+ARG SKIP_INSTALL_BINARY
+
 COPY package*.json ./
 RUN npm ci
 


### PR DESCRIPTION
When trying to use `make local`, used when running the framework with a QEMU worker, the worker container fails to build because it tries to install a uhubctl binary thats packged with the testbotsdk npm package - that's not available for x86.

This npm package allows for skipping that binary installation using an env variable - so I added this as a build time env var for local builds

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>