### PR TITLE
add worker contract

### DIFF
--- a/compose/balena.yml
+++ b/compose/balena.yml
@@ -28,3 +28,4 @@ services:
     labels:
       io.balena.features.dbus: '1'
       io.balena.features.balena-socket: '1'
+      io.balena.features.balena-api: '1'

--- a/core/lib/common/suite.js
+++ b/core/lib/common/suite.js
@@ -136,7 +136,7 @@ class Suite {
 
 		// Recursive DFS
 		const treeExpander = async ([
-			{ interactive, os, skip, deviceType, title, run, tests },
+			{ interactive, os, skip, deviceType, title, workerContract, run, tests },
 			testNode,
 		]) => {
 			// Check our contracts
@@ -146,7 +146,10 @@ class Suite {
 				(deviceType != null && !ajv.compile(deviceType)(this.deviceType)) ||
 				(os != null &&
 					this.context.get().os != null &&
-					!ajv.compile(os)(this.context.get().os.contract))
+					!ajv.compile(os)(this.context.get().os.contract) ||
+				(workerContract != null &&
+					this.context.get().workerContract != null) &&
+					!ajv.compile(workerContract)(this.context.get().workerContract))
 			) {
 				return;
 			}

--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -191,6 +191,10 @@ module.exports = class Worker {
 		await rp.post({ uri: `${this.url}/teardown`, json: true });
 	}
 
+	async getContract(){
+		return rp.get({ uri: `${this.url}/contract`, json: true });
+	}
+
 	capture(action) {
 		switch (action) {
 			case 'start':

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -153,6 +153,20 @@
 				}
 			}
 		},
+		"@balena/es-version": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@balena/es-version/-/es-version-1.0.0.tgz",
+			"integrity": "sha512-o3/sRDyrXC75BUUziMAs+W5C02aVST0YqY5Ny31Ot3a+7CzK2XDRinMGywvK93tm2QVdL83HGkN483S62Xo9Dw=="
+		},
+		"@balena/node-web-streams": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/@balena/node-web-streams/-/node-web-streams-0.2.4.tgz",
+			"integrity": "sha512-Q9By3GPzANMZuf1i5i7Agyh6BUe6tTa+VCCZzsFzU32iXMcuDRXYHbNIKESrcjVXxiZScPB4u++WPw4LRyK1Gg==",
+			"requires": {
+				"is-stream": "^1.1.0",
+				"web-streams-polyfill": "^3.1.0"
+			}
+		},
 		"@balena/testbot": {
 			"version": "1.9.2",
 			"resolved": "https://registry.npmjs.org/@balena/testbot/-/testbot-1.9.2.tgz",
@@ -319,6 +333,16 @@
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/@nornagon/put/-/put-0.0.8.tgz",
 			"integrity": "sha512-ugvXJjwF5ldtUpa7D95kruNJ41yFQDEKyF5CW4TgKJnh+W/zmlBzXXeKTyqIgwMFrkePN2JqOBqcF0M0oOunow=="
+		},
+		"@resin.io/types-hidepath": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@resin.io/types-hidepath/-/types-hidepath-1.0.1.tgz",
+			"integrity": "sha1-EMf3vOGJgZFsK+DEzNxMNMTDxHo="
+		},
+		"@resin.io/types-home-or-tmp": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@resin.io/types-home-or-tmp/-/types-home-or-tmp-3.0.0.tgz",
+			"integrity": "sha1-PsiRM0Nv7msb7jkC8fluJgXXnU0="
 		},
 		"@serialport/binding-abstract": {
 			"version": "8.0.6",
@@ -636,11 +660,25 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/js-yaml": {
+			"version": "3.11.1",
+			"resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.11.1.tgz",
+			"integrity": "sha512-M5qhhfuTt4fwHGqqANNQilp3Htb5cHwBxlMHDUw/TYRVkEp3s3IIFSH3Fe9HIAeEtnO4p3SSowLmCVavdRYfpw=="
+		},
+		"@types/jwt-decode": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@types/jwt-decode/-/jwt-decode-2.2.1.tgz",
+			"integrity": "sha512-aWw2YTtAdT7CskFyxEX2K21/zSDStuf/ikI3yBqmwpwJF0pS+/IX5DWv+1UFffZIbruP6cnT9/LAJV1gFwAT1A=="
+		},
 		"@types/lodash": {
 			"version": "4.14.149",
 			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
-			"integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
-			"dev": true
+			"integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ=="
+		},
+		"@types/memoizee": {
+			"version": "0.4.6",
+			"resolved": "https://registry.npmjs.org/@types/memoizee/-/memoizee-0.4.6.tgz",
+			"integrity": "sha512-qJezGqoi3pW9Pset2w1Gfv8jATvmHHHnpO9Dq8x8pJGyYIpiUZJqRU0NM7xenmN0AcXEe7vqshI8H98KeFLYcg=="
 		},
 		"@types/mime": {
 			"version": "2.0.1",
@@ -713,6 +751,11 @@
 				"@types/bluebird": "*",
 				"@types/request": "*"
 			}
+		},
+		"@types/semver": {
+			"version": "7.3.9",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
+			"integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ=="
 		},
 		"@types/serialport": {
 			"version": "4.0.11",
@@ -819,6 +862,11 @@
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
 			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
 		},
+		"abortcontroller-polyfill": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.3.tgz",
+			"integrity": "sha512-zetDJxd89y3X99Kvo4qFx8GKlt6GsvN3UcRZHwU6iFA/0KiOmhkTVhe8oRoTBiTVPZu09x3vCra47+w8Yz1+2Q=="
+		},
 		"abstract-socket": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/abstract-socket/-/abstract-socket-2.1.1.tgz",
@@ -910,7 +958,6 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
 			}
@@ -1105,6 +1152,284 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+		},
+		"balena-auth": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/balena-auth/-/balena-auth-4.1.0.tgz",
+			"integrity": "sha512-weKEmWnlb2cYNLr8pqaVdCP+uTfxBLQU2oHzn6M9mlF6+mqIaQTmkj+/8fMilEnm32qhYYdOyz4y3H+7kLIcIw==",
+			"requires": {
+				"@types/jwt-decode": "^2.2.1",
+				"balena-errors": "^4.7.1",
+				"balena-settings-storage": "^7.0.0",
+				"jwt-decode": "^2.2.0",
+				"tslib": "^2.0.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+				}
+			}
+		},
+		"balena-errors": {
+			"version": "4.7.1",
+			"resolved": "https://registry.npmjs.org/balena-errors/-/balena-errors-4.7.1.tgz",
+			"integrity": "sha512-g21kf6N5tMZYDietZNLHCbqhmAxPX9gRmJQgMuIjMZWvjzCQxcqaELNYTtDwXwEbXLhbhF6QV2IJDZul+5X6nQ==",
+			"requires": {
+				"tslib": "^2.0.0",
+				"typed-error": "^3.0.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+				}
+			}
+		},
+		"balena-hup-action-utils": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/balena-hup-action-utils/-/balena-hup-action-utils-4.0.3.tgz",
+			"integrity": "sha512-PdHMpSjaQriB4y4zmeAmm0Mxudencc/BVjI3jHVH3/SCZ6OqIIGlyFJU2tS0vsghED8PiEyQSjUdDCGzv7zUiQ==",
+			"requires": {
+				"balena-semver": "^2.0.0",
+				"tslib": "^2.0.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+				}
+			}
+		},
+		"balena-pine": {
+			"version": "12.4.0",
+			"resolved": "https://registry.npmjs.org/balena-pine/-/balena-pine-12.4.0.tgz",
+			"integrity": "sha512-ap4WvIwwEsLl5rh7badxiu/4pDqbgT3DdeSkKl03T9U4XQ8fgFuqcl//lvpUG1jzhSe/ExQfkv1ZebrUd/kvqA==",
+			"requires": {
+				"@balena/es-version": "^1.0.0",
+				"balena-errors": "^4.2.1",
+				"pinejs-client-core": "^6.9.0",
+				"tslib": "^2.0.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+				}
+			}
+		},
+		"balena-register-device": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/balena-register-device/-/balena-register-device-7.2.0.tgz",
+			"integrity": "sha512-Uo8iceob2Zg8gBedZKzSZWTyr5XoDkUN+2oSyyuKVuhZYcZS623Lsj/+I8QdJQutlObgVHjD2k3mM1Pa6loFxA==",
+			"requires": {
+				"@types/uuid": "^8.3.0",
+				"tslib": "^2.2.0",
+				"typed-error": "^3.2.1",
+				"uuid": "^8.3.2"
+			},
+			"dependencies": {
+				"@types/uuid": {
+					"version": "8.3.1",
+					"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.1.tgz",
+					"integrity": "sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg=="
+				},
+				"tslib": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+				},
+				"typed-error": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/typed-error/-/typed-error-3.2.1.tgz",
+					"integrity": "sha512-XlUv4JMrT2dpN0c4Vm3lOm88ga21Z6pNJUmjejRz/mkh6sdBtkMwyRf4fF+yhRGZgfgWam31Lkxu11GINKiBTQ=="
+				},
+				"uuid": {
+					"version": "8.3.2",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+					"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+				}
+			}
+		},
+		"balena-request": {
+			"version": "11.4.2",
+			"resolved": "https://registry.npmjs.org/balena-request/-/balena-request-11.4.2.tgz",
+			"integrity": "sha512-J4SrFBUR4AB2Y3afsX2QAMZ7H/zjysXjOyEhEqvjNTsBfe5ReCmf17vzRQ8q2URCm00nUhQgfQtlJUq6miB1/g==",
+			"requires": {
+				"@balena/node-web-streams": "^0.2.3",
+				"balena-errors": "^4.7.1",
+				"fetch-ponyfill": "^7.1.0",
+				"fetch-readablestream": "^0.2.0",
+				"progress-stream": "^2.0.0",
+				"qs": "^6.9.4",
+				"tslib": "^2.0.0"
+			},
+			"dependencies": {
+				"qs": {
+					"version": "6.10.1",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+					"integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+					"requires": {
+						"side-channel": "^1.0.4"
+					}
+				},
+				"tslib": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+				}
+			}
+		},
+		"balena-sdk": {
+			"version": "15.54.2",
+			"resolved": "https://registry.npmjs.org/balena-sdk/-/balena-sdk-15.54.2.tgz",
+			"integrity": "sha512-kZLpZvhPZoZv3ALv9IqNe/ABqfW3totzv4SGCbTB/z96mjcUrSIDL7+iGq+3S2NsLqdDNkQ0GFX/LBDAvk80Yw==",
+			"requires": {
+				"@balena/es-version": "^1.0.0",
+				"@types/lodash": "^4.14.168",
+				"@types/memoizee": "^0.4.5",
+				"@types/node": "^10.17.55",
+				"abortcontroller-polyfill": "^1.7.1",
+				"balena-auth": "^4.1.0",
+				"balena-errors": "^4.7.1",
+				"balena-hup-action-utils": "~4.0.2",
+				"balena-pine": "^12.4.0",
+				"balena-register-device": "^7.1.0",
+				"balena-request": "^11.4.2",
+				"balena-semver": "^2.3.0",
+				"balena-settings-client": "^4.0.6",
+				"lodash": "^4.17.21",
+				"memoizee": "^0.4.15",
+				"moment": "^2.29.1",
+				"ndjson": "^2.0.0",
+				"semver": "^7.3.4",
+				"tslib": "^2.1.0"
+			},
+			"dependencies": {
+				"@types/lodash": {
+					"version": "4.14.176",
+					"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.176.tgz",
+					"integrity": "sha512-xZmuPTa3rlZoIbtDUyJKZQimJV3bxCmzMIO2c9Pz9afyDro6kr7R79GwcB6mRhuoPmV2p1Vb66WOJH7F886WKQ=="
+				},
+				"@types/node": {
+					"version": "10.17.60",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+					"integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+				},
+				"lodash": {
+					"version": "4.17.21",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+					"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+				},
+				"lru-cache": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				},
+				"semver": {
+					"version": "7.3.5",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
+				"tslib": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+				}
+			}
+		},
+		"balena-semver": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/balena-semver/-/balena-semver-2.3.0.tgz",
+			"integrity": "sha512-dlUBaYz22ZxHh3umciI/87aLcwX+HRlT1RjkpuiClO8wjkuR8U/2ZvtS16iMNe30rm2kNgAV2myamQ5eA8SxVQ==",
+			"requires": {
+				"@types/lodash": "^4.14.149",
+				"@types/semver": "^7.1.0",
+				"lodash": "^4.17.15",
+				"semver": "^7.1.3"
+			},
+			"dependencies": {
+				"lru-cache": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				},
+				"semver": {
+					"version": "7.3.5",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+				}
+			}
+		},
+		"balena-settings-client": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/balena-settings-client/-/balena-settings-client-4.0.7.tgz",
+			"integrity": "sha512-1ncEgufbAbzcfcffsTpi20asNdsOEZxACiQhv8naQp1mgw6INe/0FvSNX6St+XlXtuk1FqCnYNINGIjMoStOrA==",
+			"requires": {
+				"@resin.io/types-hidepath": "1.0.1",
+				"@resin.io/types-home-or-tmp": "3.0.0",
+				"@types/js-yaml": "3.11.1",
+				"@types/lodash": "^4.14.150",
+				"hidepath": "^1.0.0",
+				"home-or-tmp": "^2.0.0",
+				"js-yaml": "^3.4.0",
+				"lodash": "^4.17.15"
+			},
+			"dependencies": {
+				"@types/lodash": {
+					"version": "4.14.176",
+					"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.176.tgz",
+					"integrity": "sha512-xZmuPTa3rlZoIbtDUyJKZQimJV3bxCmzMIO2c9Pz9afyDro6kr7R79GwcB6mRhuoPmV2p1Vb66WOJH7F886WKQ=="
+				}
+			}
+		},
+		"balena-settings-storage": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/balena-settings-storage/-/balena-settings-storage-7.0.0.tgz",
+			"integrity": "sha512-gufzVJznyt9e1CvpBuLe2caU5KcEwl1YHCbK5OMz09zXDA2OMAICPXsLlViK+KiuZwZrBx3tyU2FZjAzRZFgwQ==",
+			"requires": {
+				"@types/node": "^10.17.26",
+				"balena-errors": "^4.7.1",
+				"tslib": "^2.0.0"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "10.17.60",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+					"integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+				},
+				"tslib": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+				}
+			}
 		},
 		"base64-js": {
 			"version": "1.3.1",
@@ -1347,6 +1672,15 @@
 					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
 					"integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
 				}
+			}
+		},
+		"call-bind": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+			"requires": {
+				"function-bind": "^1.1.1",
+				"get-intrinsic": "^1.0.2"
 			}
 		},
 		"camelcase": {
@@ -1673,6 +2007,15 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/cyclic-32/-/cyclic-32-1.1.0.tgz",
 			"integrity": "sha512-q9T9oXaEthSZM3kCqGrx9BifMbEXZl8GYhcihbaSoSARSbx0Tcaf3U1owBJm9veidvAzH+CcUMoZS5p2zOEfpg=="
+		},
+		"d": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+			"integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+			"requires": {
+				"es5-ext": "^0.10.50",
+				"type": "^1.0.1"
+			}
 		},
 		"dashdash": {
 			"version": "1.14.1",
@@ -2143,6 +2486,53 @@
 				"is-arrayish": "^0.2.1"
 			}
 		},
+		"es5-ext": {
+			"version": "0.10.53",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+			"integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+			"requires": {
+				"es6-iterator": "~2.0.3",
+				"es6-symbol": "~3.1.3",
+				"next-tick": "~1.0.0"
+			},
+			"dependencies": {
+				"next-tick": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+					"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+				}
+			}
+		},
+		"es6-iterator": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+			"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+			"requires": {
+				"d": "1",
+				"es5-ext": "^0.10.35",
+				"es6-symbol": "^3.1.1"
+			}
+		},
+		"es6-symbol": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+			"integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+			"requires": {
+				"d": "^1.0.1",
+				"ext": "^1.1.2"
+			}
+		},
+		"es6-weak-map": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+			"integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+			"requires": {
+				"d": "1",
+				"es5-ext": "^0.10.46",
+				"es6-iterator": "^2.0.3",
+				"es6-symbol": "^3.1.1"
+			}
+		},
 		"escape-html": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -2156,8 +2546,7 @@
 		"esprima": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-			"dev": true
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 		},
 		"esutils": {
 			"version": "2.0.3",
@@ -2219,6 +2608,15 @@
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 				}
+			}
+		},
+		"event-emitter": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+			"integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+			"requires": {
+				"d": "1",
+				"es5-ext": "~0.10.14"
 			}
 		},
 		"event-stream": {
@@ -2298,6 +2696,21 @@
 				}
 			}
 		},
+		"ext": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
+			"integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
+			"requires": {
+				"type": "^2.5.0"
+			},
+			"dependencies": {
+				"type": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/type/-/type-2.5.0.tgz",
+					"integrity": "sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw=="
+				}
+			}
+		},
 		"ext-list": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
@@ -2368,6 +2781,19 @@
 			"requires": {
 				"pend": "~1.2.0"
 			}
+		},
+		"fetch-ponyfill": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/fetch-ponyfill/-/fetch-ponyfill-7.1.0.tgz",
+			"integrity": "sha512-FhbbL55dj/qdVO3YNK7ZEkshvj3eQ7EuIGV2I6ic/2YiocvyWv+7jg2s4AyS0wdRU75s3tA8ZxI/xPigb0v5Aw==",
+			"requires": {
+				"node-fetch": "~2.6.1"
+			}
+		},
+		"fetch-readablestream": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-readablestream/-/fetch-readablestream-0.2.0.tgz",
+			"integrity": "sha512-qu4mXWf4wus4idBIN/kVH+XSer8IZ9CwHP+Pd7DL7TuKNC1hP7ykon4kkBjwJF3EMX2WsFp4hH7gU7CyL7ucXw=="
 		},
 		"fifolock": {
 			"version": "1.0.0",
@@ -2537,6 +2963,11 @@
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+		},
 		"gauge": {
 			"version": "2.7.4",
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
@@ -2563,6 +2994,16 @@
 			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
 			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
 			"dev": true
+		},
+		"get-intrinsic": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+			"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+			"requires": {
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"has-symbols": "^1.0.1"
+			}
 		},
 		"get-proxy": {
 			"version": "2.1.0",
@@ -2686,6 +3127,14 @@
 				"har-schema": "^2.0.0"
 			}
 		},
+		"has": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"requires": {
+				"function-bind": "^1.1.1"
+			}
+		},
 		"has-ansi": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -2705,6 +3154,11 @@
 			"version": "1.4.2",
 			"resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
 			"integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
+		},
+		"has-symbols": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+			"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
 		},
 		"has-to-string-tag-x": {
 			"version": "1.4.1",
@@ -2729,6 +3183,20 @@
 			"version": "0.2.11",
 			"resolved": "https://registry.npmjs.org/hexy/-/hexy-0.2.11.tgz",
 			"integrity": "sha512-ciq6hFsSG/Bpt2DmrZJtv+56zpPdnq+NQ4ijEFrveKN0ZG1mhl/LdT1NQZ9se6ty1fACcI4d4vYqC9v8EYpH2A=="
+		},
+		"hidepath": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/hidepath/-/hidepath-1.0.1.tgz",
+			"integrity": "sha1-kksW7KqFDRAIahBjUR/UylSDF6A="
+		},
+		"home-or-tmp": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+			"requires": {
+				"os-homedir": "^1.0.0",
+				"os-tmpdir": "^1.0.1"
+			}
 		},
 		"hosted-git-info": {
 			"version": "2.8.5",
@@ -2893,6 +3361,11 @@
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
 			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
 		},
+		"is-promise": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+			"integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
+		},
 		"is-retry-allowed": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
@@ -2973,7 +3446,6 @@
 			"version": "3.13.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
 			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -3016,8 +3488,7 @@
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-			"dev": true
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
 		},
 		"json5": {
 			"version": "1.0.1",
@@ -3052,6 +3523,11 @@
 			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
 			"integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
 			"dev": true
+		},
+		"jwt-decode": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
+			"integrity": "sha1-fYa9VmefWM5qhHBKZX3TkruoGnk="
 		},
 		"keyv": {
 			"version": "3.0.0",
@@ -3149,6 +3625,14 @@
 				}
 			}
 		},
+		"lru-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+			"integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
+			"requires": {
+				"es5-ext": "~0.10.2"
+			}
+		},
 		"lzma-native": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/lzma-native/-/lzma-native-4.0.6.tgz",
@@ -3201,6 +3685,21 @@
 			"dev": true,
 			"requires": {
 				"mimic-fn": "^1.0.0"
+			}
+		},
+		"memoizee": {
+			"version": "0.4.15",
+			"resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
+			"integrity": "sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==",
+			"requires": {
+				"d": "^1.0.1",
+				"es5-ext": "^0.10.53",
+				"es6-weak-map": "^2.0.3",
+				"event-emitter": "^0.3.5",
+				"is-promise": "^2.2.2",
+				"lru-queue": "^0.1.0",
+				"next-tick": "^1.1.0",
+				"timers-ext": "^0.1.7"
 			}
 		},
 		"merge": {
@@ -3357,6 +3856,11 @@
 				}
 			}
 		},
+		"moment": {
+			"version": "2.29.1",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+			"integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+		},
 		"mountutils": {
 			"version": "1.3.19",
 			"resolved": "https://registry.npmjs.org/mountutils/-/mountutils-1.3.19.tgz",
@@ -3506,6 +4010,43 @@
 			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.1.tgz",
 			"integrity": "sha512-boQj1WFgQH3v4clhu3mTNfP+vOBxorDlE8EKiMjUlLG3C4qAESnn9AxIOkFgTR2c9LtzNjPrjS60cT27ZKBhaA=="
 		},
+		"ndjson": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ndjson/-/ndjson-2.0.0.tgz",
+			"integrity": "sha512-nGl7LRGrzugTtaFcJMhLbpzJM6XdivmbkdlaGcrk/LXg2KL/YBC6z1g70xh0/al+oFuVFP8N8kiWRucmeEH/qQ==",
+			"requires": {
+				"json-stringify-safe": "^5.0.1",
+				"minimist": "^1.2.5",
+				"readable-stream": "^3.6.0",
+				"split2": "^3.0.0",
+				"through2": "^4.0.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+				},
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				},
+				"through2": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+					"integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+					"requires": {
+						"readable-stream": "3"
+					}
+				}
+			}
+		},
 		"needle": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
@@ -3535,6 +4076,11 @@
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
 			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+		},
+		"next-tick": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+			"integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
 		},
 		"nise": {
 			"version": "1.5.3",
@@ -3581,6 +4127,14 @@
 			"integrity": "sha512-9HrZGFVTR5SOu3PZAnAY2hLO36aW1wmA+FDsVkr85BTST32TLCA1H/AEcatVRAsWLyXS3bqUDYCAjq5/QGuSTA==",
 			"requires": {
 				"semver": "^5.4.1"
+			}
+		},
+		"node-fetch": {
+			"version": "2.6.6",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+			"integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+			"requires": {
+				"whatwg-url": "^5.0.0"
 			}
 		},
 		"node-pre-gyp": {
@@ -4937,6 +5491,11 @@
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
+		"object-inspect": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+			"integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
+		},
 		"on-finished": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -5175,6 +5734,14 @@
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
 			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 		},
+		"pinejs-client-core": {
+			"version": "6.9.6",
+			"resolved": "https://registry.npmjs.org/pinejs-client-core/-/pinejs-client-core-6.9.6.tgz",
+			"integrity": "sha512-XUfHeYxT65PIxaV2SWZ7o/2nBUpTg9NaAcrfIRHgMkWQVlcUnh5EguHXoo2nKA4ocKds1fxIheuT29JqEg9SWQ==",
+			"requires": {
+				"@balena/es-version": "^1.0.0"
+			}
+		},
 		"pinkie": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
@@ -5247,6 +5814,22 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+		},
+		"progress-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-2.0.0.tgz",
+			"integrity": "sha1-+sY6Cz0R3qy7CWmrzJOyFLzhntU=",
+			"requires": {
+				"speedometer": "~1.0.0",
+				"through2": "~2.0.3"
+			},
+			"dependencies": {
+				"speedometer": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/speedometer/-/speedometer-1.0.0.tgz",
+					"integrity": "sha1-zWccsGdSwivKM3Di8zREC+T8YuI="
+				}
+			}
 		},
 		"proto-list": {
 			"version": "1.2.4",
@@ -5666,6 +6249,16 @@
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
 		},
+		"side-channel": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+			"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+			"requires": {
+				"call-bind": "^1.0.0",
+				"get-intrinsic": "^1.0.2",
+				"object-inspect": "^1.9.0"
+			}
+		},
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -5768,11 +6361,30 @@
 				"through": "2"
 			}
 		},
+		"split2": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+			"integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+			"requires": {
+				"readable-stream": "^3.0.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
+		},
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-			"dev": true
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"sshpk": {
 			"version": "1.16.1",
@@ -6020,6 +6632,15 @@
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
 		},
+		"through2": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+			"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+			"requires": {
+				"readable-stream": "~2.3.6",
+				"xtend": "~4.0.1"
+			}
+		},
 		"thunky": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz",
@@ -6029,6 +6650,15 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
 			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+		},
+		"timers-ext": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
+			"integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+			"requires": {
+				"es5-ext": "~0.10.46",
+				"next-tick": "1"
+			}
 		},
 		"tmp": {
 			"version": "0.1.0",
@@ -6082,6 +6712,11 @@
 					"dev": true
 				}
 			}
+		},
+		"tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
 		},
 		"traverse": {
 			"version": "0.3.9",
@@ -6200,6 +6835,11 @@
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
 			"dev": true
+		},
+		"type": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+			"integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
 		},
 		"type-detect": {
 			"version": "4.0.8",
@@ -6358,6 +6998,25 @@
 			"resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
 			"integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI=",
 			"dev": true
+		},
+		"web-streams-polyfill": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.1.1.tgz",
+			"integrity": "sha512-Czi3fG883e96T4DLEPRvufrF2ydhOOW1+1a6c3gNjH2aIh50DNFBdfwh2AKoOf1rXvpvavAoA11Qdq9+BKjE0Q=="
+		},
+		"webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+		},
+		"whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+			"requires": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
+			}
 		},
 		"which": {
 			"version": "1.3.1",

--- a/worker/package.json
+++ b/worker/package.json
@@ -20,6 +20,7 @@
 		"@types/bluebird": "^3.5.25",
 		"@types/config": "0.0.34",
 		"async-mutex": "^0.1.3",
+		"balena-sdk": "^15.54.2",
 		"bluebird": "^3.5.3",
 		"bluebird-retry": "^0.11.0",
 		"body-parser": "^1.18.3",

--- a/worker/tsconfig.json
+++ b/worker/tsconfig.json
@@ -13,7 +13,8 @@
 		"skipLibCheck": true,
 		"resolveJsonModule": true,
 		"strictNullChecks": true,
-		"noImplicitAny": true
+		"noImplicitAny": true,
+		"allowJs": true
 	},
 	"include": [
 		"./typings/*.d.ts",


### PR DESCRIPTION
This change creates a "contract" within the worker container - a json object that is populated based on tags placed on the worker device via the cloud. This contract is exposed via a http endpoint (`/contract`). At the moment, it only has 3 fields:

```json
{
"dut": "raspberrypi3",
"screencapture": true,
"modem": false
}
```
That can be set using tags on the device of the same name. (e.g setting a tag `screencapture: true` on the worker will set that in the contract. It can be extended by adding to the `supportedTags` array in `worker/lib/index.ts

##################


Within a test suite, a `workerContract` object can be created:

```js
  // Get worker setup info
  this.suite.context.set({
	  workerContract: await this.context.get().worker.getContract()
  })
```

And then at the top of a test, you can define the schema to use to evaluate whether or not to run the test - for example this will restrict the test only to run if the screencapture property is `true` (signalling that the worker has a hdmi capture device set up):

```js
module.exports = {
	title: 'Balena boot splash tests',
	workerContract: {
		type: 'object',
		required: ['screencapture'],
		properties: {
			screencapture: {
				type: 'boolean',
				const: true
			},
		},
	},
	tests: [
		{
			title: 'Reboot test',
			run: async function(test) { /* test function in here */ }
		},
	],
};

```

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>