### PR TITLE
allow option to keep image post test

### DIFF
--- a/core/lib/common/suite.js
+++ b/core/lib/common/suite.js
@@ -199,7 +199,10 @@ class Suite {
 			await this.teardown.runAll();
 			await this.createJsonSummary();
 			await this.removeDependencies();
-			await this.removeDownloads();
+			// This env variable can be used to keep a configured, unpacked image for use when developing tests
+			if(process.env.DEBUG_KEEP_IMG !== true){
+				await this.removeDownloads();
+			}
 			this.state.log(`Teardown complete.`);
 			this.passing = tap.passing();
 			tap.end();


### PR DESCRIPTION
This enables you to set an env variable on the worker called `DEBUG_KEEP_IMAGE=true`, and then the test suite won't delete the unpacked and configured image at the end of the tests.

This allows you to then comment out the flash + configure steps in your test suite to quickly run the tests again without flashing

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>