### PR TITLE
Use contrato to evaluate test contracts instead of json schema

### DIFF
--- a/core/lib/common/suite.js
+++ b/core/lib/common/suite.js
@@ -50,6 +50,7 @@ const State = require('./state');
 const Teardown = require('./teardown');
 const Test = require('./test');
 const utils = require('./utils');
+const contrato = require('@balena/contrato');
 
 function cleanObject(object) {
 	if (!isObject(object)) {
@@ -136,17 +137,19 @@ class Suite {
 
 		// Recursive DFS
 		const treeExpander = async ([
-			{ interactive, os, skip, deviceType, title, run, tests },
+			{ interactive, skip, title, run, tests, contract },
 			testNode,
 		]) => {
 			// Check our contracts
+			const suiteContract = new contrato.Contract({})
+			suiteContract.addChildren([
+				this.deviceType,
+				this.context.get().os.contract
+			])
+			const testContract = new contrato.Contract(contract);
+			let result = suiteContract.satisfiesChildContract(testContract)
 			if (
-				skip ||
-				(interactive && !this.options.interactiveTests) ||
-				(deviceType != null && !ajv.compile(deviceType)(this.deviceType)) ||
-				(os != null &&
-					this.context.get().os != null &&
-					!ajv.compile(os)(this.context.get().os.contract))
+				!result
 			) {
 				return;
 			}

--- a/core/lib/common/suite.js
+++ b/core/lib/common/suite.js
@@ -141,17 +141,18 @@ class Suite {
 			testNode,
 		]) => {
 			// Check our contracts
-			const suiteContract = new contrato.Contract({})
-			suiteContract.addChildren([
-				this.deviceType,
-				this.context.get().os.contract
-			])
-			const testContract = new contrato.Contract(contract);
-			let result = suiteContract.satisfiesChildContract(testContract)
-			if (
-				!result
-			) {
-				return;
+			if(contract != null){
+				const suiteContract = new contrato.Contract({})
+				const os = (this.context.get().os != null) ? this.context.get().os.contract : {}
+				suiteContract.addChildren([
+					new contrato.Contract(this.deviceType),
+					new contrato.Contract(os)
+				])
+				const testContract = new contrato.Contract(contract);
+				let result = suiteContract.satisfiesChildContract(testContract)
+				if (!result) {
+					return;
+				}
 			}
 
 			const test = new Test(title, this);

--- a/core/lib/components/os/balenaos.js
+++ b/core/lib/components/os/balenaos.js
@@ -64,6 +64,8 @@ const { fs } = require('mz');
 const { join } = require('path');
 const pipeline = Bluebird.promisify(require('stream').pipeline);
 const zlib = require('zlib');
+const contrato = require('@balena/contrato');
+const { contains } = require('lodash/fp');
 
 // TODO: This function should be implemented using Reconfix
 const injectBalenaConfiguration = (image, configuration) => {
@@ -146,13 +148,17 @@ module.exports = class BalenaOS {
 			path: join(config.get('leviathan.downloads'), `image-${id()}`),
 		};
 		this.configJson = options.configJson || {};
-		this.contract = {
-			network: mapValues(this.network, value => {
-				return typeof value === 'boolean' ? value : true;
-			}),
-		};
+		this.contract = new contrato.Contract({
+			type: 'test.os',
+			data: {
+				network: mapValues(this.network, value => {
+					return typeof value === 'boolean' ? value : true;
+				}),
+			}
+		});
 		this.logger = logger;
 		this.releaseInfo = { version: null, variant: null };
+		console.log(this.contract)
 	}
 
 	/**
@@ -223,10 +229,12 @@ module.exports = class BalenaOS {
 
 		await readVersion(/VERSION="(.*)"/g, 'version');
 		await readVersion(/VARIANT="(.*)"/g, 'variant');
-		assignIn(this.contract, {
+		/*assignIn(this.contract, {
 			version: this.releaseInfo.version,
 			variant: this.releaseInfo.variant,
-		});
+		});*/
+		this.contract.raw.data['version'] = this.releaseInfo.version;
+		this.contract.raw.data['variant'] = this.releaseInfo.variant;
 	}
 
 	addCloudConfig(configJson) {

--- a/core/lib/components/os/balenaos.js
+++ b/core/lib/components/os/balenaos.js
@@ -148,14 +148,14 @@ module.exports = class BalenaOS {
 			path: join(config.get('leviathan.downloads'), `image-${id()}`),
 		};
 		this.configJson = options.configJson || {};
-		this.contract = new contrato.Contract({
+		this.contract = {
 			type: 'test.os',
 			data: {
 				network: mapValues(this.network, value => {
 					return typeof value === 'boolean' ? value : true;
 				}),
 			}
-		});
+		};
 		this.logger = logger;
 		this.releaseInfo = { version: null, variant: null };
 		console.log(this.contract)
@@ -233,8 +233,8 @@ module.exports = class BalenaOS {
 			version: this.releaseInfo.version,
 			variant: this.releaseInfo.variant,
 		});*/
-		this.contract.raw.data['version'] = this.releaseInfo.version;
-		this.contract.raw.data['variant'] = this.releaseInfo.variant;
+		this.contract.data['version'] = this.releaseInfo.version;
+		this.contract.data['variant'] = this.releaseInfo.variant;
 	}
 
 	addCloudConfig(configJson) {

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -180,6 +180,71 @@
 				}
 			}
 		},
+		"@balena/contrato": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/@balena/contrato/-/contrato-0.6.5.tgz",
+			"integrity": "sha512-UAEIhmn0HI27HPd9SHkXXodIhqqIVsCBGvB6o4S++L8VfK1ZDRo4hzAWhQtRtH872gYdgArpABRVD7YLT+UIrw==",
+			"requires": {
+				"@types/debug": "^4.1.5",
+				"@types/js-combinatorics": "^0.5.32",
+				"@types/lodash": "^4.14.168",
+				"@types/node": "^15.0.1",
+				"@types/object-hash": "^2.1.0",
+				"@types/semver": "^7.3.5",
+				"debug": "^3.2.6",
+				"handlebars": "^4.7.6",
+				"js-combinatorics": "^0.5.5",
+				"lodash": "^4.17.19",
+				"memfs": "^3.2.2",
+				"object-hash": "^1.3.1",
+				"semver": "^5.7.1",
+				"skhema": "^5.3.2"
+			},
+			"dependencies": {
+				"@types/lodash": {
+					"version": "4.14.176",
+					"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.176.tgz",
+					"integrity": "sha512-xZmuPTa3rlZoIbtDUyJKZQimJV3bxCmzMIO2c9Pz9afyDro6kr7R79GwcB6mRhuoPmV2p1Vb66WOJH7F886WKQ=="
+				},
+				"@types/node": {
+					"version": "15.14.9",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
+					"integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
+				},
+				"@types/semver": {
+					"version": "7.3.9",
+					"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
+					"integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ=="
+				},
+				"handlebars": {
+					"version": "4.7.7",
+					"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+					"integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+					"requires": {
+						"minimist": "^1.2.5",
+						"neo-async": "^2.6.0",
+						"source-map": "^0.6.1",
+						"uglify-js": "^3.1.4",
+						"wordwrap": "^1.0.0"
+					}
+				},
+				"lodash": {
+					"version": "4.17.21",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+					"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+				},
+				"minimist": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+				},
+				"wordwrap": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+				}
+			}
+		},
 		"@resin.io/types-hidepath": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@resin.io/types-hidepath/-/types-hidepath-1.0.1.tgz",
@@ -218,10 +283,28 @@
 			"resolved": "https://registry.npmjs.org/@types/common-tags/-/common-tags-1.8.0.tgz",
 			"integrity": "sha512-htRqZr5qn8EzMelhX/Xmx142z218lLyGaeZ3YR8jlze4TATRU9huKKvuBmAJEW4LCC4pnY1N6JAm6p85fMHjhg=="
 		},
+		"@types/debug": {
+			"version": "4.1.7",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+			"integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+			"requires": {
+				"@types/ms": "*"
+			}
+		},
+		"@types/js-combinatorics": {
+			"version": "0.5.32",
+			"resolved": "https://registry.npmjs.org/@types/js-combinatorics/-/js-combinatorics-0.5.32.tgz",
+			"integrity": "sha512-rSdlsZTJla6sSMrYoXEDklQLDoXCnpHIwzvkTWhjIdk1S42GHQ/QNHRBAzKno0eZ+dORGoJ9tsgB1xH+4DozAA=="
+		},
 		"@types/js-yaml": {
 			"version": "3.11.1",
 			"resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.11.1.tgz",
 			"integrity": "sha512-M5qhhfuTt4fwHGqqANNQilp3Htb5cHwBxlMHDUw/TYRVkEp3s3IIFSH3Fe9HIAeEtnO4p3SSowLmCVavdRYfpw=="
+		},
+		"@types/json-schema": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-6.0.1.tgz",
+			"integrity": "sha512-vuL/tG01yKO//gmCmnV3OZhx2hs538t+7FpQq//sUV1sF6xiKi5V8F60dvAxe/HkC4+QaMCHqrm/akqlppTAkQ=="
 		},
 		"@types/jwt-decode": {
 			"version": "2.2.1",
@@ -233,10 +316,20 @@
 			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.121.tgz",
 			"integrity": "sha512-ORj7IBWj13iYufXt/VXrCNMbUuCTJfhzme5kx9U/UtcIPdJYuvPDUAlHlbNhz/8lKCLy9XGIZnGrqXOtQbPGoQ=="
 		},
+		"@types/ms": {
+			"version": "0.7.31",
+			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+			"integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
+		},
 		"@types/node": {
 			"version": "8.10.59",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.59.tgz",
 			"integrity": "sha512-8RkBivJrDCyPpBXhVZcjh7cQxVBSmRk9QM7hOketZzp6Tg79c0N8kkpAIito9bnJ3HCVCHVYz+KHTEbfQNfeVQ=="
+		},
+		"@types/object-hash": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@types/object-hash/-/object-hash-2.2.1.tgz",
+			"integrity": "sha512-i/rtaJFCsPljrZvP/akBqEwUP2y5cZLOmvO+JaYnz01aPknrQ+hB5MRcO7iqCUsFaYfTG8kGfKUyboA07xeDHQ=="
 		},
 		"@types/semver": {
 			"version": "5.5.0",
@@ -1151,6 +1244,11 @@
 				}
 			}
 		},
+		"call-me-maybe": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+		},
 		"caller-callsite": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
@@ -1415,6 +1513,27 @@
 			"integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
 			"dev": true
 		},
+		"compute-gcd": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/compute-gcd/-/compute-gcd-1.2.1.tgz",
+			"integrity": "sha512-TwMbxBNz0l71+8Sc4czv13h4kEqnchV9igQZBi6QUaz09dnz13juGnnaWWJTRsP3brxOoxeB4SA2WELLw1hCtg==",
+			"requires": {
+				"validate.io-array": "^1.0.3",
+				"validate.io-function": "^1.0.2",
+				"validate.io-integer-array": "^1.0.0"
+			}
+		},
+		"compute-lcm": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/compute-lcm/-/compute-lcm-1.1.2.tgz",
+			"integrity": "sha512-OFNPdQAXnQhDSKioX8/XYT6sdUlXwpeMjfd6ApxMJfyZ4GxmLR1xvMERctlYhlHwIiz6CSpBc2+qYKjHGZw4TQ==",
+			"requires": {
+				"compute-gcd": "^1.2.1",
+				"validate.io-array": "^1.0.3",
+				"validate.io-function": "^1.0.2",
+				"validate.io-integer-array": "^1.0.0"
+			}
+		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1566,6 +1685,11 @@
 			"requires": {
 				"mimic-response": "^2.0.0"
 			}
+		},
+		"deep-copy": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/deep-copy/-/deep-copy-1.4.2.tgz",
+			"integrity": "sha512-VxZwQ/1+WGQPl5nE67uLhh7OqdrmqI1OazrraO9Bbw/M8Bt6Mol/RxzDA6N6ZgRXpsG/W9PgUj8E1LHHBEq2GQ=="
 		},
 		"deep-equal": {
 			"version": "1.1.1",
@@ -2672,6 +2796,11 @@
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
 		},
+		"fast-memoize": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
+			"integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw=="
+		},
 		"fatfs": {
 			"version": "0.10.7",
 			"resolved": "https://registry.npmjs.org/fatfs/-/fatfs-0.10.7.tgz",
@@ -2861,6 +2990,11 @@
 				"mime-types": "^2.1.12"
 			}
 		},
+		"format-util": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.5.tgz",
+			"integrity": "sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg=="
+		},
 		"forwarded": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -2895,6 +3029,11 @@
 				"jsonfile": "^3.0.0",
 				"universalify": "^0.1.0"
 			}
+		},
+		"fs-monkey": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.3.tgz",
+			"integrity": "sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q=="
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
@@ -3885,6 +4024,11 @@
 			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
 			"integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw=="
 		},
+		"js-combinatorics": {
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/js-combinatorics/-/js-combinatorics-0.5.5.tgz",
+			"integrity": "sha512-WglFY9EQvwndNhuJLxxyjnC16649lfZly/G3M3zgQMwcWlJDJ0Jn9niPWeYjnLXwWOEycYVxR2Tk98WLeFkrcw=="
+		},
 		"js-tokens": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -3925,6 +4069,43 @@
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
 			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
 		},
+		"json-schema-compare": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
+			"integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
+			"requires": {
+				"lodash": "^4.17.4"
+			}
+		},
+		"json-schema-faker": {
+			"version": "0.5.0-rcv.40",
+			"resolved": "https://registry.npmjs.org/json-schema-faker/-/json-schema-faker-0.5.0-rcv.40.tgz",
+			"integrity": "sha512-BczZvu03jKrGh3ovCWrHusiX6MwiaKK2WZeyomKBNA8Nm/n7aBYz0mub1CnONB6cgxOZTNxx4afNmLblbUmZbA==",
+			"requires": {
+				"json-schema-ref-parser": "^6.1.0",
+				"jsonpath-plus": "^5.1.0"
+			}
+		},
+		"json-schema-merge-allof": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.6.0.tgz",
+			"integrity": "sha512-LEw4VMQVRceOPLuGRWcxW5orTTiR9ZAtqTAe4rQUjNADTeR81bezBVFa0MqIwp0YmHIM1KkhSjZM7o+IQhaPbQ==",
+			"requires": {
+				"compute-lcm": "^1.1.0",
+				"json-schema-compare": "^0.2.2",
+				"lodash": "^4.17.4"
+			}
+		},
+		"json-schema-ref-parser": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-6.1.0.tgz",
+			"integrity": "sha512-pXe9H1m6IgIpXmE5JSb8epilNTGsmTb2iPohAXpOdhqGFbQjNeHHsZxU+C8w6T81GZxSPFLeUoqDJmzxx5IGuw==",
+			"requires": {
+				"call-me-maybe": "^1.0.1",
+				"js-yaml": "^3.12.1",
+				"ono": "^4.0.11"
+			}
+		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -3961,6 +4142,11 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
 			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
+		},
+		"jsonpath-plus": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-5.1.0.tgz",
+			"integrity": "sha512-890w2Pjtj0iswAxalRlt2kHthi6HKrXEfZcn+ZNZptv7F3rUGIeDuZo+C+h4vXBHLEsVjJrHeCm35nYeZLzSBQ=="
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -4167,6 +4353,14 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
 			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+		},
+		"memfs": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/memfs/-/memfs-3.3.0.tgz",
+			"integrity": "sha512-BEE62uMfKOavX3iG7GYX43QJ+hAeeWnwIAuJ/R6q96jaMtiLzhsxHJC8B1L7fK7Pt/vXDRwb3SG/yBpNGDPqzg==",
+			"requires": {
+				"fs-monkey": "1.0.3"
+			}
 		},
 		"memoizee": {
 			"version": "0.4.14",
@@ -7613,6 +7807,11 @@
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
+		"object-hash": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
+			"integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA=="
+		},
 		"object-inspect": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
@@ -7699,6 +7898,14 @@
 					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 					"dev": true
 				}
+			}
+		},
+		"ono": {
+			"version": "4.0.11",
+			"resolved": "https://registry.npmjs.org/ono/-/ono-4.0.11.tgz",
+			"integrity": "sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==",
+			"requires": {
+				"format-util": "^1.0.3"
 			}
 		},
 		"opener": {
@@ -8901,6 +9108,53 @@
 				}
 			}
 		},
+		"skhema": {
+			"version": "5.3.4",
+			"resolved": "https://registry.npmjs.org/skhema/-/skhema-5.3.4.tgz",
+			"integrity": "sha512-2xYL0EwAjqFfbr414RP/wKfM1fRd30kJAS2RsOA+UDq/vvszZeLXZWK9yTPYrr31rQzrczLMvLuD4z74EC3VBw==",
+			"requires": {
+				"@types/json-schema": "^6.0.1",
+				"ajv": "^6.5.1",
+				"ajv-keywords": "^3.2.0",
+				"deep-copy": "^1.4.2",
+				"fast-memoize": "^2.5.1",
+				"json-schema-faker": "^0.5.0-rc16",
+				"json-schema-merge-allof": "^0.6.0",
+				"lodash": "^4.17.19",
+				"lru-cache": "^5.1.1",
+				"typed-error": "^3.2.0"
+			},
+			"dependencies": {
+				"ajv-keywords": {
+					"version": "3.5.2",
+					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+					"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+				},
+				"lodash": {
+					"version": "4.17.21",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+					"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+				},
+				"lru-cache": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+					"requires": {
+						"yallist": "^3.0.2"
+					}
+				},
+				"typed-error": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/typed-error/-/typed-error-3.2.1.tgz",
+					"integrity": "sha512-XlUv4JMrT2dpN0c4Vm3lOm88ga21Z6pNJUmjejRz/mkh6sdBtkMwyRf4fF+yhRGZgfgWam31Lkxu11GINKiBTQ=="
+				},
+				"yallist": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+				}
+			}
+		},
 		"slash": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -9969,6 +10223,38 @@
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
 			}
+		},
+		"validate.io-array": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
+			"integrity": "sha1-W1osr9j4uFq7L4hroVPy2Tond00="
+		},
+		"validate.io-function": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
+			"integrity": "sha1-NDoZgC7TsZaCaceA5VjpNBHAutc="
+		},
+		"validate.io-integer": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
+			"integrity": "sha1-FoSWSAuVviJH7EQ/IjPeT4mHgGg=",
+			"requires": {
+				"validate.io-number": "^1.0.3"
+			}
+		},
+		"validate.io-integer-array": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz",
+			"integrity": "sha1-LKveAzKTpry+Bj/q/pHq9GsToIk=",
+			"requires": {
+				"validate.io-array": "^1.0.3",
+				"validate.io-integer": "^1.0.4"
+			}
+		},
+		"validate.io-number": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
+			"integrity": "sha1-9j/+2iSL8opnqNSODjtGGhZluvg="
 		},
 		"vary": {
 			"version": "1.1.2",

--- a/core/package.json
+++ b/core/package.json
@@ -6,6 +6,7 @@
 		"docs": "rimraf ../docs/ && npx typedoc --tsconfig tsconfig.json"
 	},
 	"dependencies": {
+		"@balena/contrato": "^0.6.5",
 		"ajv": "^6.5.0",
 		"ajv-semver": "git+https://github.com/balena-io-modules/ajv-semver.git#resin-semver",
 		"any-promise": "^1.3.0",


### PR DESCRIPTION
Previously, you could define several json schemas for each test that could be used to determine whether or not a test should be ran. For example, you could do this, to make sure a test only ran for devices with HDMI:

```js
module.exports = {
	title: 'Balena boot splash tests',
	deviceType: {
		type: 'object',
		required: ['data'],
		properties: {
			data: {
				type: 'object',
				required: ['hdmi'],
				properties: {
					hdmi: {
						type: 'boolean',
						const: true,
					},
				},
			},
		},
	},
        run: async() function { /* test code */}
```

This is quite unwieldly to write and is not simple to extend. This PR lets you instead add a contract to a test using our contract syntax, and then uses contrato to evaluate the tests contract and determine whether or not to do the test. This makes it easier to use, and in the future I think it will be quite useful as we extend the use of contracts (e.g os contracts etc)

You can re write the above syntax as:
```js
module.exports = {
	title: 'Balena boot splash tests',
	contract: {
		type: 'test.test',
		requires: [
			{
				type: 'hw.device-type',
				data: {
					hdmi: false
				}
			}
        ]
	},
        run: ////
```