### PR TITLE
add balena-os-in-container worker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,13 @@ ifndef DRY
 	@${COMPOSE} up $(SERVICES)
 endif
 
+container: Dockerfile
+	@ln -sf ./compose/balena-os-in-container.yml ./docker-compose.yml
+ifndef DRY
+	@${COMPOSE} build $(SERVICES)
+	@${COMPOSE} up $(SERVICES)
+endif
+
 balena:
 	@ln -sf ./compose/balena.yml ./docker-compose.yml
 ifndef DRY

--- a/compose/balena-os-in-container.yml
+++ b/compose/balena-os-in-container.yml
@@ -1,0 +1,29 @@
+version: '2'
+volumes:
+  core-storage:
+  reports-storage:
+services:
+  core:
+    privileged: true
+    build: ./core
+    network_mode: 'host'
+    volumes:
+      - 'core-storage:/data'
+      - 'reports-storage:/reports'
+    labels:
+      share: 'core-storage'
+  worker:
+    privileged: true
+    build: 
+      context: ./worker
+      args:
+        - SKIP_INSTALL_BINARY=true
+        - INSTALL_DOCKER=true
+    pid: 'host'
+    environment:
+      - WORKER_TYPE=container
+    network_mode: 'host'
+    ipc: 'host'
+    volumes:
+      - 'core-storage:/data'
+      - 'reports-storage:/reports'

--- a/worker/Dockerfile.template
+++ b/worker/Dockerfile.template
@@ -10,6 +10,7 @@ RUN install_packages libdbus-1-dev libvirt-dev python
 
 ARG SKIP_INSTALL_BINARY
 
+
 COPY package*.json ./
 RUN npm ci
 
@@ -29,6 +30,10 @@ RUN install_packages \
   libusb-dev libdbus-1-dev \
   gstreamer1.0-tools gstreamer1.0-plugins-base gstreamer1.0-plugins-bad gstreamer1.0-plugins-good \
   qemu-system-x86 libvirt-daemon-system bridge-utils iproute2 dnsmasq iptables ebtables
+
+ARG INSTALL_DOCKER
+
+RUN if [ $INSTALL_DOCKER ]; then install_packages docker.io docker-compose git; fi;
 
 # Disable all cgroup controls as we do not use them
 RUN sed -i 's/^#cgroup_controllers =.*/cgroup_controllers = []/g' /etc/libvirt/qemu.conf

--- a/worker/lib/index.ts
+++ b/worker/lib/index.ts
@@ -11,9 +11,11 @@ import {
 	resolveLocalTarget,
 } from './helpers';
 import { TestBotWorker } from './workers/testbot';
+import Container from './workers/container';
 
-const workersDict: Dictionary<typeof TestBotWorker> = {
+const workersDict: Dictionary<typeof TestBotWorker | typeof Container> = {
 	testbot_hat: TestBotWorker,
+	container: Container
 };
 
 async function setup(): Promise<express.Application> {

--- a/worker/lib/workers/container.ts
+++ b/worker/lib/workers/container.ts
@@ -1,0 +1,136 @@
+import * as Bluebird from 'bluebird';
+import * as retry from 'bluebird-retry';
+import { exec, ChildProcess, spawn } from 'child_process';
+import * as sdk from 'etcher-sdk';
+import { EventEmitter } from 'events';
+import * as libvirt from 'libvirt';
+import { assignIn } from 'lodash';
+import { fs } from 'mz';
+import { dirname, join } from 'path';
+import * as Stream from 'stream';
+import * as xml from 'xml-js';
+import { manageHandlers } from '../helpers';
+import ScreenCapture from '../helpers/graphics';
+import { promisify } from 'util';
+import { ensureFile } from 'fs-extra';
+const execP = promisify(exec)
+
+Bluebird.config({
+	cancellation: true,
+});
+
+class Container extends EventEmitter implements Leviathan.Worker {
+	private image: string;
+	private config: string
+	private osProc?: ChildProcess;
+	private dockerProc?: ChildProcess;
+
+	private signalHandler: (signal: NodeJS.Signals) => Promise<void>;
+	private internalState: Leviathan.WorkerState = { network: {} };
+
+	constructor(options: Leviathan.Options) {
+		super();
+		this.image = `/data/os.img`;
+		this.config = `/data/config.json`;
+		this.signalHandler = this.teardown.bind(this);
+	}
+
+	public get state() {
+		return this.internalState;
+	}
+
+	private static generateId(): string {
+		return Math.random()
+			.toString(36)
+			.substring(2, 10);
+	}
+
+	public async setup(): Promise<void> {
+		const dockerJson = `{"storage-driver": "overlay2","graph": "/data","dns": ["8.8.8.8"],"iptables": false}`
+		await ensureFile(`/etc/docker/daemon.json`)
+		await fs.writeFileSync(`/etc/docker/daemon.json`, dockerJson)	  
+		
+		try{
+			await execP(`rm -rf /var/run/docker.pid`)
+		} catch {
+			console.log(`No previous docker pid`)
+		}
+		this.dockerProc = exec('dockerd &')
+
+		// pulling from my own branch at the moment - maybe make a PR on that repo to allow for custom builds 
+        try {
+			await execP(`git clone -b ryan/build-from-saved-img https://github.com/balena-os/balenaos-in-container.git ${__dirname}/container`)
+		} catch(e){
+			console.log(e)
+		}
+
+		manageHandlers(this.signalHandler, {
+			register: true,
+		});
+	}
+
+	public async teardown(signal?: NodeJS.Signals): Promise<void> {
+		if (signal != null) {
+			if (signal === 'SIGTERM' || signal === 'SIGINT') {
+				if (this.osProc != null) {
+					this.osProc.kill();
+					this.osProc = undefined;
+				}
+			}
+
+			process.kill(process.pid, signal);
+		}
+
+		if (this.osProc != null) {
+			this.osProc.kill();
+			this.osProc = undefined;
+		}
+
+		try{
+			await execP(`${__dirname}/container docker-compose down -v`);
+		}catch{
+			console.log(`no balenaos containers running - no removal required`)
+		}
+
+		manageHandlers(this.signalHandler, {
+			register: false,
+		});
+	}
+
+	public async flash(stream: Stream.Readable): Promise<void> {
+		// we need to get the config.json... 
+        // For now, just look at a volume - but we want a better way of getting this here imo
+		await fs.copyFileSync(this.config, `${__dirname}/container/config.json`);
+		
+		// do a docker load - need to get sha from it and inject into the dockerfile via build arg
+		const { stdout, stderr } = await execP(`docker load < ${this.image}`);
+		let sha = stdout.replace('Loaded image ID: ', '')
+		let shaReplace = sha.replace(/(\r\n|\n|\r)/gm, "") // could be doing this cleaner
+		// no-cache arguement here because sometimes it was building an old image
+		let build = exec(`cd ${__dirname}/container && docker-compose build --build-arg SHA=${shaReplace} --no-cache`);
+	}
+
+	public async powerOn(): Promise<void> {
+		this.osProc = exec(`cd ${__dirname}/container && docker-compose up --force-recreate`);
+	}
+
+	// maybe off a powerdown option - but it won't really be useful afaik
+	public async powerOff(): Promise<void> {
+		return
+	}
+
+	// no networm config required - so just return
+	public async network(configuration: {
+		wired?: { nat: boolean };
+	}): Promise<void> {
+		return
+	}
+
+	public async captureScreen(
+		action: 'start' | 'stop',
+	): Promise<void | Stream.Readable> {
+		throw new Error(`balena-os in container cannot perform screen capture!`)
+	}
+}
+
+export default Container;


### PR DESCRIPTION
This adds a new worker that lets tests run on a balena-os in container device: https://github.com/balena-os/balenaos-in-container

You can use a saved docker image file, such as the ones generated by yocto jenkins jobs (`balena-image.docker`) to create a balenaos-in-container for that os version. 

To run it, you can clone this branch, and run `make container`, then you can run the cloud test suite with it (with some modifications, such as commenting out preloading parts, and adding a line to write the config.json this required by the os-in-container tool)

Change-type: minor
Signed-off-by: Ryan Cooke <ryan@balena.io>