### PR TITLE
Makefile: replace BALENA_ARCH in Dockerfile templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ COMPOSE=$(shell \
 	fi)
 
 Dockerfile:
-	find . -maxdepth 2 -type f -name 'Dockerfile.template' -exec bash -c 'npm_config_yes=true npx dockerfile-template -d BALENA_MACHINE_NAME="intel-nuc" -f {} > `dirname {}`/Dockerfile' \;
+	find . -maxdepth 2 -type f -name 'Dockerfile.template' -exec bash -c 'npm_config_yes=true npx dockerfile-template -d BALENA_ARCH="amd64" -f {} > `dirname {}`/Dockerfile' \;
 
 local: Dockerfile
 	@ln -sf ./compose/generic-x86.yml ./docker-compose.yml

--- a/worker/Dockerfile.template
+++ b/worker/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balenalib/%%BALENA_MACHINE_NAME%%-golang:1.15-buster-build AS go-build
+FROM balenalib/%%BALENA_ARCH%%-golang:1.15-buster-build AS go-build
 
 RUN GO111MODULE=on go get -u github.com/nadoo/glider@v0.12.2
 


### PR DESCRIPTION
This change is required for variable substitution in the Dockerfile templates after replacing `BALENA_MACHINE_NAME` with `BALENA_ARCH` in https://github.com/balena-os/leviathan/pull/518

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>