### PR TITLE
patch: Speed up Core's docker build

### DIFF
--- a/core/Dockerfile.template
+++ b/core/Dockerfile.template
@@ -24,7 +24,11 @@ COPY --from=npm-install /tmp/node ./
 
 RUN install_packages python3 make build-essential openssh-client
 
-RUN npm install balena-cli@12.51.1 -g --production --unsafe-perm
+RUN curl -L https://github.com/balena-io/balena-cli/releases/download/v12.51.1/balena-cli-v12.51.1-linux-x64-standalone.zip -o balena-cli.zip \
+    && unzip balena-cli.zip \
+    && rm balena-cli.zip 
+
+ENV PATH="/usr/src/app/balena-cli/:${PATH}"
 
 COPY contracts contracts
 


### PR DESCRIPTION
```
➜  bro git:(master) ✗ sudo docker build . -t balena-cli:latest
Sending build context to Docker daemon  2.048kB
Step 1/5 : FROM node:12-bullseye
 ---> 99ea8906ba9c
Step 2/5 : WORKDIR /usr/src/app
 ---> Using cache
 ---> 481b8f063fa6
Step 3/5 : RUN curl -L https://github.com/balena-io/balena-cli/releases/download/v12.51.1/balena-cli-v12.51.1-linux-x64-standalone.zip -o balena-cli.zip     && unzip balena-cli.zip     && rm balena-cli.zip
 ---> Using cache
 ---> 4e36cd5d926e
Step 4/5 : ENV PATH="/usr/src/app/balena-cli/:${PATH}"
 ---> Using cache
 ---> 14dc16a84c2e
Step 5/5 : CMD ["balena", "--version"]
 ---> Using cache
 ---> 93e83fc800a5
Successfully built 93e83fc800a5
Successfully tagged balena-cli:latest


➜  bro git:(master) ✗ sudo docker run -it balena-cli:latest
12.51.1
```