### PR TITLE
Make fixes to client to improve usage with qemu worker

### DIFF
--- a/client/bin/multi-client.js
+++ b/client/bin/multi-client.js
@@ -489,7 +489,7 @@ class State {
 					deviceUrl = device;
 				}
 				try{
-					let status = await rp.get(`${deviceUrl}/state`);
+					let status = await rp.get((new url.URL('/state', deviceUrl)).toString());
 					if (status === "IDLE") {
 						// make sure that the worker being targetted isn't already about to be used by another child process
 						if(!busyWorkers.includes(deviceUrl)){
@@ -502,7 +502,7 @@ class State {
 						}
 					}
 				} catch(err) {
-					state.info(`Couldn't retrieve ${device.tags.DUT} worker's state. Querying ${deviceUrl} and received ${err.name}: ${err.statusCode}`)
+					state.info(`Couldn't retrieve ${device.tags ? device.tags.DUT : device} worker's state. Querying ${deviceUrl} and received ${err.name}: ${err.statusCode}`)
 				}
 			}
 

--- a/client/lib/index.js
+++ b/client/lib/index.js
@@ -332,7 +332,10 @@ module.exports = class Client extends PassThrough {
 							process.send({ type, data });
 							break;
 						case 'status':
-							if (!data.success) {
+							if (data.message === `Flashing`){
+								this.log(`Flashing: ${data.percentage}%`)
+							}
+							else if (!data.success) {
 								this.log(`Test suite has exited with: FAIL`)
 								process.exitCode = 2;
 							} else {

--- a/compose/generic-x86.yml
+++ b/compose/generic-x86.yml
@@ -11,6 +11,7 @@ services:
       - 'reports-storage:/reports'
     environment:
       - UDEV=0
+      - WORKER_TYPE=qemu
   worker:
     build: 
       context: ./worker

--- a/core/Dockerfile.template
+++ b/core/Dockerfile.template
@@ -16,7 +16,7 @@ ENV DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
 
 ENV npm_config_unsafe_perm=true
 
-RUN install_packages jq git vim rsync unzip bluez
+RUN install_packages jq git vim rsync unzip bluez skopeo
 
 WORKDIR /usr/app
 


### PR DESCRIPTION
This PR fixes 2 problems:

- when using the qemu worker, erroneous `Test suite has exited with: FAIL` messages were coming up while "flashing"
- When the `workspace/config.js` file had multiple suites targetting the same worker url, both suites would try to run at the same time on the same worker