### PR TITLE
worker: listen on UNIX domain socket

### DIFF
--- a/core/config/default.js
+++ b/core/config/default.js
@@ -6,10 +6,6 @@ module.exports = {
   express: {
     port: process.env.CORE_PORT || 80
   },
-  worker: {
-    url: 'http://127.0.0.1',
-    port: process.env.WORKER_PORT || 2000
-  },
   leviathan: {
     artifacts: '/tmp/artifacts',    // To store artifacts meant to be reported as results at the end of the suite
     downloads: '/data/downloads',    // To store/download assets needed for the suite (non-persistent) 

--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -61,7 +61,7 @@ module.exports = class Worker {
 		logger = { log: console.log, status: console.log, info: console.log },
 	) {
 		this.deviceType = deviceType;
-		this.url = `${config.get('worker.url')}:${config.get('worker.port')}`;
+		this.url = `http://unix:/run/leviathan/worker.sock:`;
 		this.logger = logger;
 	}
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -6,7 +6,8 @@ volumes:
 services:
   core:
     build: ./core
-    network_mode: 'host'
+    ports:
+      - "80:80"
     volumes:
       - 'core-storage:/data'
       - 'reports-storage:/reports'

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -2,6 +2,7 @@ version: '2'
 volumes:
   core-storage:
   reports-storage:
+  leviathan:
 services:
   core:
     build: ./core
@@ -9,10 +10,10 @@ services:
     volumes:
       - 'core-storage:/data'
       - 'reports-storage:/reports'
+      - 'leviathan:/run/leviathan'
     environment:
       - UDEV=0
       - WORKER_TYPE=qemu
-      - WORKER_PORT=${WORKER_PORT}
       - CORE_PORT=${CORE_PORT}
   worker:
     build: 
@@ -28,11 +29,11 @@ services:
     volumes:
       - 'core-storage:/data'
       - 'reports-storage:/reports'
+      - 'leviathan:/run/leviathan'
     environment:
       - UDEV=0
       - WORKER_TYPE=qemu
       - SCREEN_CAPTURE=true
-      - WORKER_PORT=${WORKER_PORT}
   client:
     build: ./client
     network_mode: host

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,8 @@ services:
     privileged: true
     build:
       context: ./core
-    network_mode: host
+      ports:
+        - "80:80"
     volumes:
       - 'core-storage:/data'
       - 'reports-storage:/reports'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2.1'
 volumes:
   core-storage:
   reports-storage:
+  leviathan:
 services:
   core:
     privileged: true
@@ -11,6 +12,7 @@ services:
     volumes:
       - 'core-storage:/data'
       - 'reports-storage:/reports'
+      - 'leviathan:/run/leviathan'
     labels:
       share: core-storage
       io.balena.features.balena-socket: '1'
@@ -25,6 +27,7 @@ services:
     volumes:
       - 'core-storage:/data'
       - 'reports-storage:/reports'
+      - 'leviathan:/run/leviathan'
     labels:
       io.balena.features.dbus: '1'
       io.balena.features.balena-socket: '1'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ services:
     privileged: true
     build:
       context: ./core
-      ports:
-        - "80:80"
+    ports:
+      - "80:80"
     volumes:
       - 'core-storage:/data'
       - 'reports-storage:/reports'

--- a/worker/Dockerfile.template
+++ b/worker/Dockerfile.template
@@ -40,6 +40,4 @@ COPY --from=node-build /tmp/node/package.json .
 COPY --from=node-build /tmp/node/node_modules node_modules
 COPY --from=node-build /tmp/node/build build
 
-EXPOSE 2000
-
 CMD [ "./entry.sh" ]

--- a/worker/bin/index.ts
+++ b/worker/bin/index.ts
@@ -7,8 +7,8 @@ import setup from '../lib/index';
 	/**
 	 * Start Express Server
 	 */
-  const socketPath = '/run/leviathan/worker.sock';
+	const socketPath = '/run/leviathan/worker.sock';
 	const server = app.listen(socketPath, () => {
-    console.log(`Worker http listening on ${socketPath}`);
+		console.log(`Worker http listening on ${socketPath}`);
 	});
 })();

--- a/worker/bin/index.ts
+++ b/worker/bin/index.ts
@@ -2,20 +2,13 @@ import * as config from 'config';
 import setup from '../lib/index';
 
 (async function(): Promise<void> {
-	const port: number = config.get('worker.port');
-
 	const app = await setup();
 
 	/**
 	 * Start Express Server
 	 */
-	const server = app.listen(port, () => {
-		const address = server.address();
-
-		if (typeof address !== 'string') {
-			console.log(`Worker http listening on port ${address.port}`);
-		} else {
-			throw new Error('Failed to allocate server address.');
-		}
+  const socketPath = '/run/leviathan/worker.sock';
+	const server = app.listen(socketPath, () => {
+    console.log(`Worker http listening on ${socketPath}`);
 	});
 })();

--- a/worker/config/default.js
+++ b/worker/config/default.js
@@ -1,6 +1,5 @@
 module.exports = {
 	worker: {
-		port: process.env.WORKER_PORT || 2000,
 		runtimeConfiguration: {
 			workdir: process.env.WORKDIR || '/data',
 			workerType: process.env.WORKER_TYPE || 'testbot_hat',

--- a/worker/entry.sh
+++ b/worker/entry.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
+# cleanup old socket
+rm -f /run/leviathan/worker.sock
+
 npm start


### PR DESCRIPTION
Listen on UNIX domain socket instead of TCP socket. This simplifies
configuration and reduces network overhead, as routing isn't required.
The worker service is expected to run on the same machine as the core
service.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>