### PR TITLE
Stub the proxy endpoint as glider has been removed from the worker

### DIFF
--- a/worker/lib/index.ts
+++ b/worker/lib/index.ts
@@ -209,33 +209,14 @@ async function setup(): Promise<express.Application> {
 			res: express.Response,
 			next: express.NextFunction,
 		) => {
-			// For simplicity we will delegate to glider for now
+			// This function is effectively stubbed and does nothing except return 127.0.0.1.
+			// Glider has been removed from the worker, since the old proxy tests were always
+			// passing even without a working proxy, they were invalid.
+			// New proxy tests install glider in a container on the DUT and don't use this endpoint.
+			console.warn(`proxy endpoint has been deprecated, returning localhost`)
 			try {
-				proxy.kill();
 				if (req.body.port != null) {
-					let ip;
-
-					if (worker.state.network.wired != null) {
-						ip = {
-							ip: getIpFromIface(worker.state.network.wired),
-						};
-					}
-
-					if (worker.state.network.wireless != null) {
-						ip = {
-							ip: getIpFromIface(worker.state.network.wireless),
-						};
-					}
-
-					if (ip == null) {
-						throw new Error('DUT network could not be found');
-					}
-
-					process.off('exit', proxy.kill);
-					proxy.proc = spawn('glider', ['-listen', req.body.port]);
-					process.on('exit', proxy.kill);
-
-					res.send(ip);
+					res.send('127.0.0.1');
 				} else {
 					res.send('OK');
 				}


### PR DESCRIPTION
When we removed the dependency on glider in the proxy tests, we also
removed glider from the worker. However, older versions of the tests
from ESR branches would still call this endpoint and expect a sane
response.

Fortunately, the old proxy tests were invalid and would always pass
even if glider wasn't working. ICMP traffic does not use the proxy.
So, we can just pretend to start a glider instance so the old tests
continue to run, even with an invalid result.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
See: https://github.com/balena-os/leviathan/pull/534