### PR TITLE
Revert "patch: Reduce helpers delays and retries"

### DIFF
--- a/core/lib/common/utils.js
+++ b/core/lib/common/utils.js
@@ -112,8 +112,8 @@ module.exports = {
 	waitUntil: async (
 		promise,
 		rejectionFail = false,
-		_times = 7,
-		_delay = 15000,
+		_times = 20,
+		_delay = 30000,
 	) => {
 		const _waitUntil = async timesR => {
 			if (timesR === 0) {

--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -165,8 +165,8 @@ module.exports = class Worker {
 	ip(
 		target,
 		timeout = {
-			interval: 5000,
-			tries: 10,
+			interval: 10000,
+			tries: 60,
 		},
 	) {
 		return /.*\.local/.test(target)
@@ -227,8 +227,8 @@ module.exports = class Worker {
 		command,
 		target,
 		timeout = {
-			interval: 3000,
-			tries: 3,
+			interval: 10000,
+			tries: 10,
 		},
 	) {
 		const ip = /.*\.local/.test(target) ? await this.ip(target) : target;
@@ -278,7 +278,7 @@ module.exports = class Worker {
 				);
 			},
 			{
-				max_tries: 5,
+				max_tries: 10,
 				interval: 5000,
 			},
 		);

--- a/core/lib/components/balena/sdk.js
+++ b/core/lib/components/balena/sdk.js
@@ -85,8 +85,8 @@ module.exports = class BalenaSDK {
 		command,
 		device,
 		timeout = {
-			interval: 3000,
-			tries: 3,
+			interval: 10000,
+			tries: 60,
 		},
 	) {
 		const sshPort = 22;

--- a/workspace/.gitignore
+++ b/workspace/.gitignore
@@ -2,7 +2,6 @@
 *.img
 *.js
 *.conf
-*.docker
 
 reports/
 saved-images/


### PR DESCRIPTION
Reverts balena-os/leviathan#488

It appears that the current HUP suite in meta-balena at the revision below, do not have a long enough timeout to detect the DUT is online after flashing. I've testing with latest leviathan and the tip of meta-balena test suites with raspberrypi3.
https://github.com/balena-os/meta-balena/tree/cab2b5aa7b97afad9006ed3c3701e49a9d76d366/tests/suites/hup

```
[2021-11-21T18:14:17.357Z][192-hup] Powering off DUT
[2021-11-21T18:14:17.454Z][192-hup] Preparing to flash
[2021-11-21T18:17:49.918Z][192-hup] Flash completed
[2021-11-21T18:17:49.930Z][192-hup] Powering on DUT
[2021-11-21T18:17:51.495Z][192-hup] DUT powered on
[2021-11-21T18:17:51.505Z][192-hup]         # Waiting for DUT to be reachable
[2021-11-21T18:18:40.659Z][192-hup]         not ok 1 - 500 - "Could not resolve 3c985c0.local"
```
Providing a longer timeout to this function seems to resolve the suite, but fixing the test in meta-balena will still fail for ESR branches. We likely need to revert or adjust this leviathan commit with new default timeouts.