### PR TITLE
qemu: network: disable dnsmasq DNS server

### DIFF
--- a/worker/lib/workers/qemu.ts
+++ b/worker/lib/workers/qemu.ts
@@ -252,6 +252,10 @@ class QemuWorker extends EventEmitter implements Leviathan.Worker {
       `--dhcp-leasefile=/var/run/qemu-dnsmasq-${bridgeName}.leases`,
     ];
 
+		// Disable DNS entirely, as we only require DHCP and this avoids problems
+		// with running multiple instances of dnsmasq concurrently
+		dnsmaqArgs.push('--port=0');
+
 		return this.setupBridge(bridgeName, bridgeAddress).then(() => {
 			return new Promise((resolve, reject) => {
 				if (this.dnsmasqProc && !this.dnsmasqProc.killed) {


### PR DESCRIPTION
Dnsmasq can be configured (and already is) to only listen on specific
interfaces—for DHCP. By default, it will still listen on port 53 for DNS
queries, which makes it impossible to run multiple instances
concurrently.

From the man page:

  -p, --port=<port>
    Listen on <port> instead of the standard DNS port (53). Setting this to
    zero completely disables DNS function, leaving only DHCP and/or TFTP.

Specify --port=0 to disable DNS, and allow multiple instances to run
concurrently.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>