### PR TITLE
makefile: fix detached flag in make detach

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ local-test: clean core worker client
 
 # run local core and worker in detached mode, primarily for jenkins
 detached: clean core worker
-	$(COMPOSEBIN) -f $(LOCALCOMPOSEFILE) up core worker $(ARGS) --detach
+	$(COMPOSEBIN) -f $(LOCALCOMPOSEFILE) up --detach core worker $(ARGS)
 
 # stop any existing core, worker, or client containers
 stop: $(COMPOSEBIN)


### PR DESCRIPTION
`make detached` throws an error because the detached flag is at the end of the docker-compose command. Moved it to the right place so no errors get thrown.

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>