### PR TITLE
allow setting of ports via env var

### DIFF
--- a/client/lib/index.js
+++ b/client/lib/index.js
@@ -358,7 +358,7 @@ module.exports = class Client extends PassThrough {
 
 			const createWs = () =>
 				new Promise((resolve, reject) => {
-					const ws = new WebSocket(`ws://${this.uri.hostname}/start`);
+					const ws = new WebSocket(`ws://${this.uri.host}/start`);
 
 					const msgHandler = wsMessageHandler(ws);
 					ws.on('message', msgHandler);

--- a/core/config/default.js
+++ b/core/config/default.js
@@ -4,11 +4,11 @@ const { join } = require('path');
 
 module.exports = {
   express: {
-    port: 80
+    port: process.env.CORE_PORT || 80
   },
   worker: {
     url: 'http://127.0.0.1',
-    port: 2000
+    port: process.env.WORKER_PORT || 2000
   },
   leviathan: {
     artifacts: '/tmp/artifacts',    // To store artifacts meant to be reported as results at the end of the suite

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -12,6 +12,8 @@ services:
     environment:
       - UDEV=0
       - WORKER_TYPE=qemu
+      - WORKER_PORT=${WORKER_PORT}
+      - CORE_PORT=${CORE_PORT}
   worker:
     build: 
       context: ./worker
@@ -31,6 +33,7 @@ services:
       - UDEV=0
       - WORKER_TYPE=qemu
       - SCREEN_CAPTURE=true
+      - WORKER_PORT=${WORKER_PORT}
   client:
     build: ./client
     network_mode: host

--- a/worker/config/default.js
+++ b/worker/config/default.js
@@ -1,6 +1,6 @@
 module.exports = {
 	worker: {
-		port: 2000,
+		port: process.env.WORKER_PORT || 2000,
 		runtimeConfiguration: {
 			workdir: process.env.WORKDIR || '/data',
 			workerType: process.env.WORKER_TYPE || 'testbot_hat',


### PR DESCRIPTION
This allows you do set the ports that core+worker listen on via env vars, pre-req for multiple qemu workers on same host

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>
See: https://github.com/balena-os/leviathan/issues/561