### PR TITLE
worker: set up bridge parameters dynamically

### DIFF
--- a/worker/config/default.js
+++ b/worker/config/default.js
@@ -10,15 +10,21 @@ module.exports = {
 				wireless: process.env.NETWORK_WIRELESS_INTERFACE || 'wlan0',
 			},
 			qemu: {
-				network: {
-					bridgeName: process.env.QEMU_BRIDGE_NAME || 'br0',
-					bridgeAddress: process.env.QEMU_BRIDGE_ADDRESS || '192.168.100.1',
-					dhcpRange: process.env.QEMU_DHCP_RANGE || '192.168.100.2,192.168.100.254',
-				},
 				architecture: process.env.QEMU_ARCH || 'x86_64',
 				cpus: process.env.QEMU_CPUS || '4',
 				memory: process.env.QEMU_MEMORY || '2G',
 				debug: process.env.QEMU_DEBUG || false,
+				network: {
+					bridgeName: process.env.QEMU_BRIDGE_NAME || null,
+					bridgeAddress: process.env.QEMU_BRIDGE_ADDRESS || null,
+					dhcpRange: process.env.QEMU_DHCP_RANGE || null,
+					vncPort: process.env.QEMU_VNC_PORT || null,
+					qmpPort: process.env.QEMU_QMP_PORT || null,
+					vncMinPort: process.env.QEMU_VNC_MIN_PORT || 5900,
+					vncMaxPort: process.env.QEMU_VNC_MAX_PORT || 5999,
+					qmpMinPort: process.env.QEMU_QMP_MIN_PORT || 5000,
+					qmpMaxPort: process.env.QEMU_QMP_MAX_PORT || 5899,
+				}
 			}
 		},
 	},

--- a/worker/lib/helpers/index.ts
+++ b/worker/lib/helpers/index.ts
@@ -179,9 +179,7 @@ export function resolveLocalTarget(target: string): PromiseLike<string> {
 export async function getRuntimeConfiguration(
 	possibleWorkers: string[],
 ): Promise<Leviathan.RuntimeConfiguration> {
-	const runtimeConfiguration: any = cleanObject(
-		config.get('worker.runtimeConfiguration'),
-	);
+	const runtimeConfiguration: any = config.get('worker.runtimeConfiguration');
 
 	if (!possibleWorkers.includes(runtimeConfiguration.workerType)) {
 		throw new Error(

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -2891,6 +2891,11 @@
 				"unpipe": "~1.0.0"
 			}
 		},
+		"find-free-port": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/find-free-port/-/find-free-port-2.0.0.tgz",
+			"integrity": "sha1-SyLl9leesaOMQaxryz7+0bbamxs="
+		},
 		"find-up": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",

--- a/worker/package.json
+++ b/worker/package.json
@@ -29,6 +29,7 @@
 		"drivelist": "^8.0.6",
 		"etcher-sdk": "^2.0.16",
 		"express": "^4.16.4",
+		"find-free-port": "^2.0.0",
 		"firmata": "^2.0.0",
 		"fs-extra": "^8.1.0",
 		"lodash": "^4.17.11",

--- a/worker/typings/worker.d.ts
+++ b/worker/typings/worker.d.ts
@@ -19,15 +19,21 @@ declare global {
 		}
 
 		interface QemuOptions {
-			network: {
-				bridgeName: string;
-				bridgeAddress: string;
-				dhcpRange: string
-			};
 			architecture: string;
 			cpus: string;
 			memory: string;
 			debug: boolean;
+			network: {
+				bridgeName: string;
+				bridgeAddress: string;
+				dhcpRange: string;
+				vncPort: number;
+				qmpPort: number;
+				vncMinPort: number;
+				vncMaxPort: number;
+				qmpMinPort: number;
+				qmpMaxPort: number;
+			}
 		}
 
 		interface Worker extends EventEmitter {


### PR DESCRIPTION
Set up the bridge parameters for the qemu worker dynamically. This is to avoid conflicts when multiple workers + qemu instances are running on the same host. 

The following are dynamically generated instead of being hardcoded/set with env variables:
- bridge name
- bridge ip 
- dnsmasq dhcp range
- qemu vnc port
- qemu qmp port

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>
Required-by: https://github.com/balena-os/leviathan/pull/568