### PR TITLE
patch: Clear cache when test starts

### DIFF
--- a/client/lib/index.js
+++ b/client/lib/index.js
@@ -83,7 +83,7 @@ module.exports = class Client extends PassThrough {
 		if (attempt > 1){
 			this.log(`Previously failed to upload artifact ${artifact.name} - retrying...`);
 		}
-		const ignore = ['node_modules', 'package-lock.json'];
+		const ignore = ['node_modules'];
 
 		// Sanity checks + sanity checks
 		if (artifact.path != null) {

--- a/core/Dockerfile.template
+++ b/core/Dockerfile.template
@@ -31,9 +31,11 @@ WORKDIR /usr/app
 
 COPY --from=npm-install /tmp/node ./
 
-# Install balena binary in PATH
+# Install balena binary & npm in PATH
 RUN ln -sf /usr/app/node_modules/balena-cli/bin/balena /usr/bin/balena && \
-    balena version
+    balena version && \
+    ln -sf /usr/app/node_modules/npm/bin/npm-cli.js /usr/bin/npm && \
+    npm --version
 
 COPY contracts contracts
 COPY lib lib

--- a/core/lib/common/suite.js
+++ b/core/lib/common/suite.js
@@ -32,7 +32,6 @@ const isObject = require('lodash/isObject');
 const isString = require('lodash/isString');
 const template = require('lodash/template');
 const fs = require('fs-extra');
-
 const AJV = require('ajv');
 const ajv = new AJV();
 // AJV plugins
@@ -43,6 +42,8 @@ const Bluebird = require('bluebird');
 const fse = require('fs-extra');
 const npm = require('npm');
 const { tmpdir } = require('os');
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
 const path = require('path');
 
 const Context = require('./context');
@@ -71,7 +72,6 @@ function cleanObject(object) {
 class Suite {
 	constructor() {
 		const conf = require(config.get('leviathan.uploads.config'));
-
 		this.rootPath = path.join(__dirname, '..');
 		this.options = assignIn(
 			{
@@ -113,6 +113,7 @@ class Suite {
 
 	async init() {
 		await Bluebird.try(async () => {
+			await exec('npm cache clear --silent --force');
 			await this.installDependencies();
 			await fs.ensureDir(config.get('leviathan.downloads'));
 			if (fs.existsSync(config.get('leviathan.artifacts'))) {
@@ -122,7 +123,7 @@ class Suite {
 			this.rootTree = this.resolveTestTree(
 				path.join(config.get('leviathan.uploads.suite'), 'suite'),
 			);
-			this.testSummary.suite = this.rootTree.title
+			this.testSummary.suite = this.rootTree.title;
 		}).catch(async error => {
 			await this.removeDependencies();
 			await this.removeDownloads();
@@ -146,9 +147,9 @@ class Suite {
 				(deviceType != null && !ajv.compile(deviceType)(this.deviceType)) ||
 				(os != null &&
 					this.context.get().os != null &&
-					!ajv.compile(os)(this.context.get().os.contract) ||
+					!ajv.compile(os)(this.context.get().os.contract)) ||
 				(workerContract != null &&
-					this.context.get().workerContract != null) &&
+					this.context.get().workerContract != null &&
 					!ajv.compile(workerContract)(this.context.get().workerContract))
 			) {
 				return;
@@ -203,7 +204,7 @@ class Suite {
 			await this.createJsonSummary();
 			await this.removeDependencies();
 			// This env variable can be used to keep a configured, unpacked image for use when developing tests
-			if(process.env.DEBUG_KEEP_IMG !== true){
+			if (process.env.DEBUG_KEEP_IMG !== true) {
 				await this.removeDownloads();
 			}
 			this.state.log(`Teardown complete.`);

--- a/core/lib/common/suite.js
+++ b/core/lib/common/suite.js
@@ -32,6 +32,7 @@ const isObject = require('lodash/isObject');
 const isString = require('lodash/isString');
 const template = require('lodash/template');
 const fs = require('fs-extra');
+
 const AJV = require('ajv');
 const ajv = new AJV();
 // AJV plugins
@@ -72,6 +73,7 @@ function cleanObject(object) {
 class Suite {
 	constructor() {
 		const conf = require(config.get('leviathan.uploads.config'));
+
 		this.rootPath = path.join(__dirname, '..');
 		this.options = assignIn(
 			{
@@ -123,7 +125,7 @@ class Suite {
 			this.rootTree = this.resolveTestTree(
 				path.join(config.get('leviathan.uploads.suite'), 'suite'),
 			);
-			this.testSummary.suite = this.rootTree.title;
+			this.testSummary.suite = this.rootTree.title
 		}).catch(async error => {
 			await this.removeDependencies();
 			await this.removeDownloads();
@@ -147,9 +149,9 @@ class Suite {
 				(deviceType != null && !ajv.compile(deviceType)(this.deviceType)) ||
 				(os != null &&
 					this.context.get().os != null &&
-					!ajv.compile(os)(this.context.get().os.contract)) ||
+					!ajv.compile(os)(this.context.get().os.contract) ||
 				(workerContract != null &&
-					this.context.get().workerContract != null &&
+					this.context.get().workerContract != null) &&
 					!ajv.compile(workerContract)(this.context.get().workerContract))
 			) {
 				return;
@@ -204,7 +206,7 @@ class Suite {
 			await this.createJsonSummary();
 			await this.removeDependencies();
 			// This env variable can be used to keep a configured, unpacked image for use when developing tests
-			if (process.env.DEBUG_KEEP_IMG !== true) {
+			if(process.env.DEBUG_KEEP_IMG !== true){
 				await this.removeDownloads();
 			}
 			this.state.log(`Teardown complete.`);

--- a/core/lib/main.js
+++ b/core/lib/main.js
@@ -66,7 +66,7 @@ async function setup() {
 				path: config.get('leviathan.uploads')[req.headers['x-artifact-id']],
 				hash: req.headers['x-artifact-hash'],
 			};
-			const ignore = ['node_modules', 'package-lock.json'];
+			const ignore = ['node_modules'];
 
 			let hash = null;
 			if (await pathExists(artifact.path)) {


### PR DESCRIPTION

The NPM cache for RPi0 got corrupted which lead to NPM errors: https://www.flowdock.com/app/rulemotion/device-testing/threads/Oa9Ewh7FqSTu0OR_XAGqOzPbxxg

Adding a `npm cache clear` in order to clean cache before each test run.

﻿Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
