### PR TITLE
patch: Replace link-checker with Lychee

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -16,9 +16,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@master
-      - name: Run link check
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.1.1
         with:
-          use-quiet-mode: 'no'
-          use-verbose-mode: 'yes'
- 
+          args: >
+            --config ./lychee.toml
+            --github-token ${{ secrets.GITHUB_TOKEN }}
+            **/*.md

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,80 @@
+###
+### Display
+###
+# Verbose program output
+verbose = true
+
+# Show progress
+progress = false
+
+
+###
+### Runtime
+###
+# Number of threads to utilize.
+# Defaults to number of cores available to the system if omitted.
+#threads = 2
+
+# Maximum number of allowed redirects [default: 10]
+max_redirects = 10
+
+# Maximum number of concurrent network requests [default: 128]
+max_concurrency = 20
+
+
+###
+### Requests
+###
+# User agent to send with each request
+user_agent = "curl/7.71.1"
+
+# Website timeout from connect to response finished
+timeout = 20
+
+# Comma-separated list of accepted status codes for valid links.
+# Omit to accept all response types.
+#accept = "text/html"
+
+# Proceed for server connections considered insecure (invalid TLS)
+insecure = false
+
+# Only test links with the given scheme (e.g. https)
+# Omit to check links with any scheme
+#scheme = "https"
+
+# Request method
+method = "get"
+
+# Custom request headers
+headers = []
+
+
+###
+### Exclusions
+###
+# Exclude URLs from checking (supports regex)
+# Excluding private links
+exclude = [
+    https://github.com/balena-io-hardware/testbot-hardware/*
+]
+
+# Exclude URLs contained in a file from checking
+exclude_file = []
+
+include = []
+
+# Exclude all private IPs from checking
+# Equivalent to setting `exclude_private`, `exclude_link_local`, and `exclude_loopback` to true
+exclude_all_private = true
+
+# # Exclude private IP address ranges from checking
+# exclude_private = false
+
+# # Exclude link-local IP address range from checking
+# exclude_link_local = false
+
+# # Exclude loopback IP address range and localhost from checking
+# exclude_loopback = false
+
+# Exclude all mail addresses from checking
+exclude_mail = true


### PR DESCRIPTION
Current link checker doesn't have a easy way to exclude private repository links. 
Going in with the trusted Lychee