### PR TITLE
core: update to node v14.18.1

### DIFF
--- a/core/Dockerfile.template
+++ b/core/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balenalib/%%BALENA_ARCH%%-alpine-node:12.19.1-3.12-run-20201211 AS npm-install
+FROM balenalib/%%BALENA_ARCH%%-alpine-node:14.18-20211208 AS npm-install
 
 ENV npm_config_unsafe_perm true
 
@@ -11,13 +11,13 @@ COPY package*.json ./
 
 RUN npm ci
 
-FROM balenalib/%%BALENA_ARCH%%-alpine:3.12-run-20211030
+FROM balenalib/%%BALENA_ARCH%%-alpine:3.14-run-20211207
 
 ENV UDEV 1
 ENV DBUS_SYSTEM_BUS_ADDRESS unix:path=/host/run/dbus/system_bus_socket
 
 # hadolint ignore=DL3018
-RUN apk add --no-cache nodejs=~12.22.6 \
+RUN apk add --no-cache nodejs=~14.18.1 \
 		       jq \
 		       git \
 		       vim \


### PR DESCRIPTION
Small bump to Node v14 for the core container. I tried this while I was troubleshooting an issue with the container building.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>