### PR TITLE
Install registry and proxy as local services

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -33,3 +33,19 @@ services:
       - WORKER_TYPE=qemu
       - SCREEN_CAPTURE=true
       - WORKER_PORT=${WORKER_PORT}
+  registry:
+    image: registry:2.7.1
+    environment:
+      REGISTRY_HTTP_ADDR: 0.0.0.0:5000
+    ports:
+      - 5000:5000
+    tmpfs:
+      - /var/lib/registry
+    healthcheck: # restart if less than 300mb free
+      test: test "$(df /var/lib/registry | tail -n1 | awk '{print $4}')" -gt 307200
+  proxy:
+    image: nadoo/glider:v0.14.0
+    command: -verbose -listen :8123
+    ports:
+      - 8123:8123/tcp
+      - 8123:8123/udp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,3 +29,19 @@ services:
       io.balena.features.dbus: '1'
       io.balena.features.balena-socket: '1'
       io.balena.features.balena-api: '1'
+  registry:
+    image: registry:2.7.1
+    environment:
+      REGISTRY_HTTP_ADDR: 0.0.0.0:5000
+    ports:
+      - 5000:5000
+    tmpfs:
+      - /var/lib/registry
+    healthcheck: # restart if less than 300mb free
+      test: test "$(df /var/lib/registry | tail -n1 | awk '{print $4}')" -gt 307200
+  proxy:
+    image: nadoo/glider:v0.14.0
+    command: -verbose -listen :8123
+    ports:
+      - 8123:8123/tcp
+      - 8123:8123/udp


### PR DESCRIPTION
We will need to add/update worker endpoints and test suites
to correctly make use of these, but it should be non-breaking.

Change-type: minor
Signed-off-by: Kyle Harding <kyle@balena.io>