### PR TITLE
minor: Deprecate the use of conf.js in test suites

### DIFF
--- a/client/lib/index.js
+++ b/client/lib/index.js
@@ -325,6 +325,7 @@ module.exports = class Client extends PassThrough {
 										artifact.data = JSON.parse(conf);
 									}
 									artifact.data.deviceType = deviceType;
+									artifact.data.image = image;
 									break;
 								default:
 									throw new Error('Unexpected upload request. Panicking...');


### PR DESCRIPTION
This way is the only way (IMHO) to not create a massive breaking change but also be able to deprecate the use of conf.js
It's stealthily cutting out the middle man that is conf.js in test suites which has been confusing us for some time now. 

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
