### PR TITLE
worker: Avoid running QEMU entrypoint cmds on testbot

### DIFF
--- a/worker/entry.sh
+++ b/worker/entry.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+if [ "${WORKER_TYPE}" != "qemu" ]; then
+	exec node ./build/bin
+fi
+
 tun_minor=$(grep tun /proc/misc | cut -d ' ' -f1)
 if [ -n "${tun_minor}" ]; then
 	mkdir -p /dev/net


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
See: https://github.com/balena-os/leviathan/pull/579