### PR TITLE
Standalone suite

### DIFF
--- a/core/lib/common/suite.js
+++ b/core/lib/common/suite.js
@@ -69,7 +69,7 @@ function cleanObject(object) {
 	}
 }
 
-class Suite {
+module.exports = class Suite {
 	constructor() {
 		const conf = require(config.get('leviathan.uploads.config'));
 
@@ -303,40 +303,3 @@ class Suite {
 		}
 	}
 }
-
-(async () => {
-	const suite = new Suite();
-
-	process.on('SIGINT', async () => {
-		suite.state.log(`Suite recieved SIGINT`);
-		await suite.teardown.runAll();
-		await suite.createJsonSummary();
-		await suite.removeDependencies();
-		await suite.removeDownloads();
-		process.exit(128);
-	});
-
-	const messageHandler = (message) => {
-		const { action } = message;
-
-		if (action === 'reconnect') {
-			for (const action of ['info', 'log', 'status']) {
-				suite.state[action]();
-			}
-		}
-	};
-	process.on('message', messageHandler);
-
-	await suite.init();
-	suite.printRunQueueSummary();
-	await suite.run();
-
-	suite.state.log(`Suite run complete`);
-	process.off('message', messageHandler);
-	suite.state.log(`Exiting suite child process...`);
-	if (suite.passing) {
-		process.exit();
-	} else {
-		process.exit(1);
-	}
-})();

--- a/core/lib/common/suite.js
+++ b/core/lib/common/suite.js
@@ -49,7 +49,7 @@ const path = require('path');
 
 const Context = require('./context');
 const State = require('./state');
-const Teardown = require('./teardown');
+const { Teardown } = require('./taskQueue');
 const Test = require('./test');
 
 function cleanObject(object) {

--- a/core/lib/common/suiteSubprocess.js
+++ b/core/lib/common/suiteSubprocess.js
@@ -26,9 +26,43 @@
 'use strict';
 
 const Suite = require('./suite');
+const config = require('config');
+const fs = require('fs-extra');
+
+async function removeArtifacts() {
+	const artifactsPath = config.get('leviathan.artifacts');
+	if (fs.existsSync(artifactsPath)) {
+		console.log('Removing artifacts from previous tests...');
+		fs.emptyDirSync(artifactsPath);
+	}
+}
+
+async function removeDownloads() {
+	const downloadsPath = config.get('leviathan.downloads');
+	if (fs.existsSync(downloadsPath) && !process.env.DEBUG_KEEP_IMG) {
+		console.log('Removing downloads directory...');
+		fs.emptyDirSync(downloadsPath);
+	}
+}
+
+async function createJsonSummary(suite) {
+	console.log('Creating JSON test summary...');
+	const data = JSON.stringify(suite.testSummary, null, 4);
+	fs.writeFileSync('/reports/test-summary.json', data);
+}
 
 (async () => {
 	const suite = new Suite();
+
+	suite.setup.register(removeArtifacts);
+	suite.setup.register(async () => {
+		return fs.ensureDir(config.get('leviathan.downloads'));
+	});
+
+	suite.teardown.register(removeDownloads);
+	suite.teardown.register(async () => {
+		return createJsonSummary(suite);
+	});
 
 	process.on('SIGINT', async () => {
 		suite.state.log(`Suite recieved SIGINT`);

--- a/core/lib/common/suiteSubprocess.js
+++ b/core/lib/common/suiteSubprocess.js
@@ -29,6 +29,8 @@ const Suite = require('./suite');
 const config = require('config');
 const fs = require('fs-extra');
 
+const conf = require(config.get('leviathan.uploads.config'));
+
 async function removeArtifacts() {
 	const artifactsPath = config.get('leviathan.artifacts');
 	if (fs.existsSync(artifactsPath)) {
@@ -52,7 +54,22 @@ async function createJsonSummary(suite) {
 }
 
 (async () => {
-	const suite = new Suite();
+	const suitePath = config.get('leviathan.uploads.suite');
+	const deviceTypeSlug = conf.deviceType;
+	const extraSuiteConf = {
+		deviceType: conf.deviceType,
+		networkWired: conf.networkWired,
+		networkWireless: conf.networkWireless,
+		osPubKey: conf.osPubKey,
+		downloadType: conf.downloadType,
+		balenaApiKey: conf.balenaApiKey,
+		balenaApiUrl: conf.balenaApiUrl,
+	}
+	const suite = new Suite(
+		suitePath,
+		deviceTypeSlug,
+		extraSuiteConf,
+	);
 
 	suite.setup.register(removeArtifacts);
 	suite.setup.register(async () => {

--- a/core/lib/common/suiteSubprocess.js
+++ b/core/lib/common/suiteSubprocess.js
@@ -1,0 +1,66 @@
+/**
+ * # Test suite subprocess
+ *
+ * Contains code to setup and run a test suite in a subprocess with signal
+ * handling and messaging between the child and parent processes
+ *
+ * @module SuiteSubprocess
+ */
+
+/*
+ * Copyright 2022 balena
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const Suite = require('./suite');
+
+(async () => {
+	const suite = new Suite();
+
+	process.on('SIGINT', async () => {
+		suite.state.log(`Suite recieved SIGINT`);
+		await suite.teardown.runAll();
+		await suite.createJsonSummary();
+		await suite.removeDependencies();
+		await suite.removeDownloads();
+		process.exit(128);
+	});
+
+	const messageHandler = (message) => {
+		const { action } = message;
+
+		if (action === 'reconnect') {
+			for (const action of ['info', 'log', 'status']) {
+				suite.state[action]();
+			}
+		}
+	};
+	process.on('message', messageHandler);
+
+	await suite.init();
+	suite.printRunQueueSummary();
+	await suite.run();
+
+	suite.state.log(`Suite run complete`);
+	process.off('message', messageHandler);
+	suite.state.log(`Exiting suite child process...`);
+	if (suite.passing) {
+		process.exit();
+	} else {
+		process.exit(1);
+	}
+})();
+

--- a/core/lib/common/taskQueue.js
+++ b/core/lib/common/taskQueue.js
@@ -1,8 +1,11 @@
 /**
- * # Teardown
+ * # TaskQueue
  *
- * You can register functions to be carried out upon "teardown" of the suite or test. These will
- * execute when the test ends, regardless of passing or failing:
+ * A queue of tasks to be carried out at a certain part of the suite or test.
+ *
+ * # Teardown 
+ * A TaskQueue used to maintain a list of tasks to execute at the end of the
+ * suite or test. These will execute regardless of passing or failing.
  *
  * ```js
  * this.suite.teardown.register(() => {
@@ -41,7 +44,7 @@
  *  }
  * ```
  *
- * @module Teardown
+ * @module TaskQueue
  */
 
 /*
@@ -66,9 +69,49 @@ const isFunction = require('lodash/isFunction');
 const noop = require('lodash/noop');
 const Bluebird = require('bluebird');
 
-module.exports = class Teardown {
+class TaskQueue {
 	constructor() {
-		this.store = new Map();
+		this.tasks = new Map();
+	}
+
+	async runAll(scheduler = setImmediate) {
+		for (const bucket of Array.from(this.tasks.keys()).reverse()) {
+			await this.run(bucket, scheduler);
+		}
+	}
+
+	async run(bucket = 'global', scheduler = setImmediate) {
+		const prev = Bluebird.setScheduler(scheduler);
+
+		if (this.tasks.has(bucket)) {
+			for (const task of this.tasks.get(bucket).reverse()) {
+				await task().catch((error) => {
+					console.log(error);
+				});
+			}
+
+			this.tasks.delete(bucket);
+		}
+
+		Bluebird.setScheduler(prev);
+	}
+
+	register(fn, bucket = 'global') {
+		if (!isFunction(fn)) {
+			throw new Error(`Can only register functions, got ${typeof fn}`);
+		}
+
+		if (!this.tasks.has(bucket)) {
+			this.tasks.set(bucket, [fn]);
+		} else {
+			this.tasks.get(bucket).push(fn);
+		}
+	}
+}
+
+class Teardown extends TaskQueue {
+	constructor() {
+		super();
 
 		process.on('SIGINT', noop);
 		process.on('SIGTERM', noop);
@@ -81,38 +124,9 @@ module.exports = class Teardown {
 			process.exit();
 		});
 	}
+}
 
-	async runAll(scheduler = setImmediate) {
-		for (const bucket of Array.from(this.store.keys()).reverse()) {
-			await this.run(bucket, scheduler);
-		}
-	}
-
-	async run(bucket = 'global', scheduler = setImmediate) {
-		const prev = Bluebird.setScheduler(scheduler);
-
-		if (this.store.has(bucket)) {
-			for (const teardown of this.store.get(bucket).reverse()) {
-				await teardown().catch((error) => {
-					console.log(error);
-				});
-			}
-
-			this.store.delete(bucket);
-		}
-
-		Bluebird.setScheduler(prev);
-	}
-
-	register(fn, bucket = 'global') {
-		if (!isFunction(fn)) {
-			throw new Error(`Can only register functions, got ${typeof fn}`);
-		}
-
-		if (!this.store.has(bucket)) {
-			this.store.set(bucket, [fn]);
-		} else {
-			this.store.get(bucket).push(fn);
-		}
-	}
+module.exports = {
+	Setup: TaskQueue,
+	Teardown: Teardown,
 };

--- a/core/lib/main.js
+++ b/core/lib/main.js
@@ -245,7 +245,7 @@ async function setup() {
 
 				// The reason we need to fork is because many 3rd party libariers output to stdout
 				// so we need to capture that
-				suite = fork('./lib/common/suite', {
+				suite = fork('./lib/common/suiteSubprocess', {
 					stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
 				});
 				suiteStarted = true;

--- a/worker/bin/index.ts
+++ b/worker/bin/index.ts
@@ -15,7 +15,7 @@ import setup from '../lib/index';
 		if (typeof address !== 'string') {
 			console.log(`Worker http listening on port ${address.port}`);
 		} else {
-			throw new Error('Failed to allocate server address.');
+			console.log(`Worker listening at path ${address}`);
 		}
 	});
 })();


### PR DESCRIPTION
Opening this in the hopes of some early feedback. This branch is working towards splitting the configuration from the Suite and Worker classes, with the goal of allowing a test runner to dynamically create a pool of workers, and map test modules to workers to run in parallel. This workflow would replace the client container in cases where tests are run exclusively virtualized.

Each commit should stand on its own, and maintain existing functionality with the current workflow of using the client to talk to the core service and run tests on a statically declared pool of workers.