### PR TITLE
fix preloading helpers for qemu worker

### DIFF
--- a/core/lib/components/balena/cli.js
+++ b/core/lib/components/balena/cli.js
@@ -86,10 +86,8 @@ module.exports = class CLI {
 		const Inspect = await Container.inspect();
 		const Mount = Inspect.Mounts.find((mount) => {
 			return mount.Name != null
-				? mount.Name.slice(
-						mount.Name.length - Inspect.Config.Labels.share.length,
-				  ) === Inspect.Config.Labels.share
-				: false;
+				? image.includes(mount.Destination)
+				: false 
 		});
 
 		image = image.replace(Mount.Destination, '');

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -9,6 +9,7 @@ services:
     volumes:
       - 'core-storage:/data'
       - 'reports-storage:/reports'
+      - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - UDEV=0
       - WORKER_TYPE=qemu


### PR DESCRIPTION
These changes enable the preload helpers to be used when running leviathan containers in the emulated test scenario. 

- Share host docker socket with core container (required for preloader)
- Modify prelaoder helper function to correctly find the path of the image 

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>