### PR TITLE
worker: allow listening from UNIX domain socket path

### DIFF
--- a/worker/bin/index.ts
+++ b/worker/bin/index.ts
@@ -15,7 +15,7 @@ import setup from '../lib/index';
 		if (typeof address !== 'string') {
 			console.log(`Worker http listening on port ${address.port}`);
 		} else {
-			throw new Error('Failed to allocate server address.');
+			console.log(`Worker listening at path ${address}`);
 		}
 	});
 })();


### PR DESCRIPTION
Previously, the worker would exit with an error if the server address
was a string, instead of an object describing a TCP socket.
Unfortunately, a string is a valid address in the case of listening to a
UNIX domain socket. Remove this error condition, as the server will
raise an error anyway if the port cannot be used.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>