### PR TITLE
core: refactor Teardown as TaskQueue

### DIFF
--- a/core/lib/common/suite.js
+++ b/core/lib/common/suite.js
@@ -48,7 +48,7 @@ const path = require('path');
 
 const Context = require('./context');
 const State = require('./state');
-const Teardown = require('./teardown');
+const { Teardown } = require('./taskQueue');
 const Test = require('./test');
 
 // Device identification


### PR DESCRIPTION
Refactor Teardown class as TaskQueue to facilitate registering tasks for
setup as well as teardown. A separate Teardown object inherits from
TaskQueue and retains the signal handling from the original object.

This is a precursor to separating the forking behavior from the suite
object in preparation for having a standalone runner for virtualized
workers. For example, we can move the removeDownloads hook from the
Suite object to a separate SuiteSubprocess object that is specifically
for handling suites not running on a the same physical machine.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>