### PR TITLE
core: test: remove intermediate suite object

### DIFF
--- a/core/lib/common/test.js
+++ b/core/lib/common/test.js
@@ -29,19 +29,7 @@ const Context = require('./context');
 
 module.exports = class Test {
 	constructor(id, suite) {
-		this.suite = {
-			rootPath: suite.rootPath,
-			context: suite.context,
-			teardown: {
-				register: (fn, bucket) => {
-					suite.teardown.register(fn, bucket);
-				},
-			},
-			deviceType: suite.deviceType,
-			options: suite.options,
-			state: suite.state,
-		};
-
+		this.suite = suite;
 		this.id = id;
 
 		this.teardown = {


### PR DESCRIPTION
The Test object is constructed with a Suite instance, which is
accessible from inside tests using 'this.suite'. However, another object
is created using only certain properties from the input suite object.

Remove the intermediate object so that all properties from the suite
object are exposed in the test code.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>