### PR TITLE
core: balenaos: use temp file for image path

### DIFF
--- a/core/lib/components/os/balenaos.js
+++ b/core/lib/components/os/balenaos.js
@@ -62,6 +62,7 @@ const config = require('config');
 const imagefs = require('resin-image-fs');
 const { fs } = require('mz');
 const { join } = require('path');
+const tmp = require('tmp');
 const pipeline = Bluebird.promisify(require('stream').pipeline);
 const zlib = require('zlib');
 
@@ -141,7 +142,7 @@ module.exports = class BalenaOS {
 		this.network = options.network;
 		this.image = {
 			input: options.image === undefined ? config.get('leviathan.uploads').image : options.image,
-			path: join(config.get('leviathan.downloads'), `image-${id()}`),
+			path: tmp.tmpNameSync(),
 		};
 		this.configJson = options.configJson || {};
 		this.contract = {


### PR DESCRIPTION
The BalenaOS object has a fetch() method that unpacks a compressed disk
image from an input path to a destination path, called "path". The
destination is currently pulled from a config file.

We don't need to retain the extracted image, so switch to a temp file
path, which makes this bit of configuration unnecessary.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>