### PR TITLE
worker: add runtimeConfiguration as parameter to setup()

### DIFF
--- a/worker/bin/index.ts
+++ b/worker/bin/index.ts
@@ -1,10 +1,12 @@
 import * as config from 'config';
 import setup from '../lib/index';
+import { getRuntimeConfiguration } from '../lib/helpers';
 
 (async function (): Promise<void> {
 	const port: number = config.get('worker.port');
 
-	const app = await setup();
+	const runtimeConfiguration = await getRuntimeConfiguration();
+	const app = await setup(runtimeConfiguration);
 
 	/**
 	 * Start Express Server

--- a/worker/lib/helpers/index.ts
+++ b/worker/lib/helpers/index.ts
@@ -176,16 +176,9 @@ export function resolveLocalTarget(target: string): PromiseLike<string> {
 	});
 }
 
-export async function getRuntimeConfiguration(
-	possibleWorkers: string[],
-): Promise<Leviathan.RuntimeConfiguration> {
+export async function getRuntimeConfiguration()
+	: Promise<Leviathan.RuntimeConfiguration> {
 	const runtimeConfiguration: any = config.get('worker.runtimeConfiguration');
-
-	if (!possibleWorkers.includes(runtimeConfiguration.workerType)) {
-		throw new Error(
-			`${runtimeConfiguration.workerType} is not a supported worker`,
-		);
-	}
 
 	if (
 		runtimeConfiguration.network == null ||

--- a/worker/lib/index.ts
+++ b/worker/lib/index.ts
@@ -6,7 +6,6 @@ import * as http from 'http';
 import { getSdk } from 'balena-sdk';
 import config = require("config");
 import {
-	getRuntimeConfiguration,
 	resolveLocalTarget,
 } from './helpers';
 import { TestBotWorker } from './workers/testbot';
@@ -22,10 +21,14 @@ const workersDict: Dictionary<typeof TestBotWorker | typeof QemuWorker> = {
 	qemu: QemuWorker,
 };
 
-async function setup(): Promise<express.Application> {
-	const runtimeConfiguration = await getRuntimeConfiguration(
-		Object.keys(workersDict),
-	);
+async function setup(runtimeConfiguration: Leviathan.RuntimeConfiguration)
+	: Promise<express.Application> {
+	const possibleWorkers = Object.keys(workersDict);
+	if (!possibleWorkers.includes(runtimeConfiguration.workerType)) {
+		throw new Error(
+			`${runtimeConfiguration.workerType} is not a supported worker`,
+		);
+	}
 
 	const worker: Leviathan.Worker = new workersDict[
 		runtimeConfiguration.workerType


### PR DESCRIPTION
Add Leviathan.RuntimeConfiguration as a parameter to setup(), allowing
reuse of this function to create and run Worker servers without a config
file.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>