### PR TITLE
core: state: fix TypeError when not running as a subprocess

### DIFF
--- a/core/lib/common/state.js
+++ b/core/lib/common/state.js
@@ -26,7 +26,9 @@ module.exports = class State {
 			sendObject.data = this._log.join('\n');
 		}
 
-		process.send(sendObject);
+		if (process.send !== undefined) {
+			process.send(sendObject);
+		}
 	}
 
 	status(status) {
@@ -41,7 +43,9 @@ module.exports = class State {
 			sendObject.data = this._status;
 		}
 
-		process.send(sendObject);
+		if (process.send !== undefined) {
+			process.send(sendObject);
+		}
 	}
 
 	info(info) {
@@ -56,6 +60,8 @@ module.exports = class State {
 			sendObject.data = this._info;
 		}
 
-		process.send(sendObject);
+		if (process.send !== undefined) {
+			process.send(sendObject);
+		}
 	}
 };


### PR DESCRIPTION
The suite module sends log messages to the parent process when it's
forked using process.send(). When the suite module is not forked, this
results in a TypeError, as process.send is undefined.

Check that process.send is not undefined before attempting to call it.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>