### PR TITLE
patch: Support staging environment for balenaCLI

### DIFF
--- a/core/lib/common/suite.js
+++ b/core/lib/common/suite.js
@@ -113,6 +113,9 @@ class Suite {
 			}
 		}
 
+		// Setting the correct API environment for CLI calls
+		exec(`echo "balenaUrl: '${conf.balenaApiUrl}'" >> ~/.balenarc.yml`);
+
 		// In the future, deprecate the options object completely to create a mega-conf
 		// Breaking changes will need to be done to both test suites + helpers
 		this.options = {

--- a/core/lib/components/balena/cli.js
+++ b/core/lib/components/balena/cli.js
@@ -56,7 +56,6 @@ module.exports = class CLI {
 		logger = { log: console.log, status: console.log, info: console.log },
 	) {
 		this.logger = logger;
-		exec(`BALENARC_BALENA_URL=${apiUrl}`);
 	}
 
 	/**

--- a/core/lib/components/balena/sdk.js
+++ b/core/lib/components/balena/sdk.js
@@ -68,7 +68,6 @@ module.exports = class BalenaSDK {
 		this.balena = getSdk({
 			apiUrl: `https://api.${apiUrl}`,
 		});
-
 		this.pine = this.balena.pine;
 		this.logger = logger;
 	}


### PR DESCRIPTION
~~Looking for help on this, I only added the API env support to the SDK constructor because if I added it to both CLI and SDK then the file was being modified twice. Constructor can't be async so in a synchronous loop, both constructors for CLI and SDK run together and end up modifying the file twice. Hence, I had to give up and add this to the SDK only.~~ 

Okay thought this through, found a better way to do it. 

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
