### PR TITLE
Disable tagging by the deploy-to-balena-action

### DIFF
--- a/.github/workflows/balena-ci.yml
+++ b/.github/workflows/balena-ci.yml
@@ -21,8 +21,7 @@ jobs:
           balena_token: ${{ secrets.BALENA_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           fleet: ${{ matrix.fleets }}
-          versionbot: false
+          versionbot: true
           environment: balena-cloud.com
-          create_tag: true
       - name: Log release ID built
         run: echo "Built release ID ${{ steps.build.outputs.release_id }}"


### PR DESCRIPTION
These extra tags create a lot of noise on busy repositories.

Also enable versionbot for proper forward-versioning.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>