### PR TITLE
core: Prevent duplicate entries in balenarc.yml

### DIFF
--- a/core/lib/common/suite.js
+++ b/core/lib/common/suite.js
@@ -114,7 +114,7 @@ class Suite {
 		}
 
 		// Setting the correct API environment for CLI calls
-		exec(`echo "balenaUrl: '${conf.balenaApiUrl}'" >> ~/.balenarc.yml`);
+		exec(`echo "balenaUrl: '${conf.balenaApiUrl}'" > ~/.balenarc.yml`);
 
 		// In the future, deprecate the options object completely to create a mega-conf
 		// Breaking changes will need to be done to both test suites + helpers


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>

Fixes this error at runtime:
```
[2022-02-03T17:06:25.758Z][localho-hup]     not ok 1 - Error parsing config file /root/.balenarc.yml: duplicated mapping key at line 2, column 1:     balenaUrl: 'balena-cloud.com'     ^
```