### PR TITLE
worker: qemu: fix worker image path

### DIFF
--- a/worker/lib/workers/qemu.ts
+++ b/worker/lib/workers/qemu.ts
@@ -263,7 +263,7 @@ class QemuWorker extends EventEmitter implements Leviathan.Worker {
 			'-smp',
 			this.qemuOptions.cpus,
 			'-drive',
-			'format=raw,file=/data/os.img,if=virtio',
+			`format=raw,file=${this.image},if=virtio`,
 			'-serial',
 			`file:${dutSerialPath}`,
 		];


### PR DESCRIPTION
Workers have an option to override the disk image path used, but this
was ignored in the qemu worker. Fix it to use this option when present.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>