### PR TITLE
worker: merge Leviathan Options and RuntimeConfiguration

### DIFF
--- a/worker/config/default.js
+++ b/worker/config/default.js
@@ -2,8 +2,10 @@ module.exports = {
 	worker: {
 		port: process.env.WORKER_PORT || 2000,
 		runtimeConfiguration: {
-			workdir: process.env.WORKDIR || '/data',
-			workerType: process.env.WORKER_TYPE || 'testbot_hat',
+			worker: {
+				workdir: process.env.WORKDIR || '/data',
+				deviceType: process.env.WORKER_TYPE || 'testbot_hat',
+			},
 			screenCapture: process.env.SCREEN_CAPTURE === 'true',
 			network: {
 				wired: process.env.NETWORK_WIRED_INTERFACE || 'eth1',

--- a/worker/lib/helpers/nm.ts
+++ b/worker/lib/helpers/nm.ts
@@ -31,7 +31,7 @@ class Teardown {
 
 class NetworkManager {
 	constructor(
-		private options: Leviathan.Options['network'],
+		private options: Leviathan.RuntimeConfiguration['network'],
 		private bus = dbus.sessionBus({
 			busAddress:
 				process.env.DBUS_SYSTEM_BUS_ADDRESS ||

--- a/worker/lib/index.ts
+++ b/worker/lib/index.ts
@@ -23,20 +23,15 @@ const workersDict: Dictionary<typeof TestBotWorker | typeof QemuWorker> = {
 async function setup(runtimeConfiguration: Leviathan.RuntimeConfiguration)
 	: Promise<express.Application> {
 	const possibleWorkers = Object.keys(workersDict);
-	if (!possibleWorkers.includes(runtimeConfiguration.workerType)) {
+	if (!possibleWorkers.includes(runtimeConfiguration.worker.deviceType)) {
 		throw new Error(
-			`${runtimeConfiguration.workerType} is not a supported worker`,
+			`${runtimeConfiguration.worker.deviceType} is not a supported worker`,
 		);
 	}
 
 	const worker: Leviathan.Worker = new workersDict[
-		runtimeConfiguration.workerType
-	]({
-		worker: { workdir: runtimeConfiguration.workdir },
-		network: runtimeConfiguration.network,
-		screenCapture: runtimeConfiguration.screenCapture,
-		qemu: runtimeConfiguration.qemu,
-	});
+		runtimeConfiguration.worker.deviceType
+	](runtimeConfiguration);
 
 	/**
 	 * Server context
@@ -57,7 +52,7 @@ async function setup(runtimeConfiguration: Leviathan.RuntimeConfiguration)
 	// parse labels and create 'contract'
 	const contract: Contract = {
 		uuid: process.env.BALENA_DEVICE_UUID,
-		workerType: runtimeConfiguration.workerType,
+		workerType: runtimeConfiguration.worker.deviceType,
 		supportedFeatures: {}
 	};
 

--- a/worker/lib/workers/qemu.ts
+++ b/worker/lib/workers/qemu.ts
@@ -35,7 +35,7 @@ class QemuWorker extends EventEmitter implements Leviathan.Worker {
 	private bridgeName: string;
 	private dhcpRange: string;
 
-	constructor(options: Leviathan.Options) {
+	constructor(options: Leviathan.RuntimeConfiguration) {
 		super();
 
 		if (options != null) {

--- a/worker/lib/workers/testbot.ts
+++ b/worker/lib/workers/testbot.ts
@@ -53,7 +53,7 @@ class TestBotWorker extends EventEmitter implements Leviathan.Worker {
 	private readonly deviceInteractor: DeviceInteractor;
 	private dutLogStream: Stream.Writable | null = null;
 
-	constructor(options: Leviathan.Options) {
+	constructor(options: Leviathan.RuntimeConfiguration) {
 		super();
 
 		this.hatBoard = new TestBotHat();

--- a/worker/typings/worker.d.ts
+++ b/worker/typings/worker.d.ts
@@ -13,13 +13,6 @@ declare global {
 		[key: string]: T;
 	}
 	namespace Leviathan {
-		interface RuntimeConfiguration {
-			workdir: string;
-			workerType: string;
-			screenCapture: boolean;
-			network: Leviathan.Options.network;
-			qemu: Leviathan.QemuOptions;
-		}
 		interface WorkerState {
 			network: { wired?: string; wireless?: string };
 		}
@@ -65,10 +58,11 @@ declare global {
 			diagnostics(): any;
 		}
 
-		interface Options {
+		interface RuntimeConfiguration {
 			worker: {
 				disk?: string;
 				workdir: string;
+				deviceType: string;
 			};
 			network?:
 				| {


### PR DESCRIPTION
These objects contain a lot of the same configuration, yet are subtlely
divergent for no apparent reason. Merge them into RuntimeConfiguration
and replace all references with the new object.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>