### PR TITLE
Revert "worker: use nodejs package from upstream alpine"

### DIFF
--- a/worker/Dockerfile.template
+++ b/worker/Dockerfile.template
@@ -17,14 +17,13 @@ COPY bin bin
 
 RUN npm run build
 
-FROM balenalib/%%BALENA_ARCH%%-alpine:3.12-run-20211030
+FROM balenalib/%%BALENA_ARCH%%-alpine-node:12.19.1-3.12-run-20201211
 
 ENV UDEV 1
 
 # ovmf is only packaged for x86_64 and aarch64 so ignore failures on arm
 # hadolint ignore=DL3018
 RUN apk add --no-cache \
-  nodejs=~12.22.6 \
   libusb-dev dbus-dev \
   gstreamer-tools gst-plugins-base gst-plugins-bad gst-plugins-good \
   bridge bridge-utils iproute2 dnsmasq iptables \


### PR DESCRIPTION
FD context: https://www.flowdock.com/app/rulemotion/p-testbot/threads/ZU9ant6-VdGwrp7mzEn5WVn13NZ

﻿This reverts commit 398474b5ac9e894152ea9a99a8a851462c3b0343.

Change-type: patch
