### PR TITLE
patch: Track test skips & summarize the summaries

### DIFF
--- a/client/bin/multi-client.js
+++ b/client/bin/multi-client.js
@@ -236,11 +236,11 @@ class NonInteractiveState {
 		let summaries = [];
 		nativeFs.readdirSync(`reports`).forEach((file) => {
 			if (/^test-summary-(.*).json$/.test(file)) {
-				summaries.push(fs.readFileSync('reports/' + file).toString());
+				summaries.push(JSON.parse(fs.readFileSync('reports/' + file).toString()));
 				fs.unlinkSync('reports/' + file);
 			}
 		});
-		nativeFs.writeFileSync(`reports/final-result`, summaries.join(',\n'));
+		nativeFs.writeFileSync(`reports/final-result.json`, JSON.stringify(summaries, null, 2));
 	});
 
 	const signalHandler = once(async (sig) => {

--- a/client/bin/multi-client.js
+++ b/client/bin/multi-client.js
@@ -232,6 +232,15 @@ class NonInteractiveState {
 				},
 			).join(',')}`,
 		);
+
+		let summaries = [];
+		nativeFs.readdirSync(`reports`).forEach((file) => {
+			if (/^test-summary-(.*).json$/.test(file)) {
+				summaries.push(fs.readFileSync('reports/' + file).toString());
+				fs.unlinkSync('reports/' + file);
+			}
+		});
+		nativeFs.writeFileSync(`reports/final-result`, summaries.join(',\n'));
 	});
 
 	const signalHandler = once(async (sig) => {

--- a/client/lib/index.js
+++ b/client/lib/index.js
@@ -85,7 +85,9 @@ module.exports = class Client extends PassThrough {
 
 	async handleArtifact(artifact, token, attempt) {
 		if (attempt > 1) {
-			this.log(`Previously failed to upload artifact ${artifact.name} - retrying...`);
+			this.log(
+				`Previously failed to upload artifact ${artifact.name} - retrying...`,
+			);
 		}
 		const ignore = ['node_modules'];
 
@@ -306,7 +308,7 @@ module.exports = class Client extends PassThrough {
 
 							const artifact = {
 								name,
-								id
+								id,
 							};
 
 							switch (id) {
@@ -320,7 +322,7 @@ module.exports = class Client extends PassThrough {
 									if (image === 'false') {
 										// Had to create fake image in home directory otherwise
 										// facing a permission issue since client root is read-only
-										const fakeImagePath = '/home/test-balena.img.gz'
+										const fakeImagePath = '/home/test-balena.img.gz';
 										await fs.writeFile(fakeImagePath, '');
 										artifact.path = makePath(fakeImagePath);
 										artifact.type = 'isFile';
@@ -371,7 +373,7 @@ module.exports = class Client extends PassThrough {
 				} catch (e) {
 					capturedError = e;
 					ws.close();
-					throw new Error(`[WSHandlerError] ${e}`)
+					throw new Error(`[WSHandlerError] ${e}`);
 				}
 			};
 

--- a/client/lib/schemas/multi-client-config.js
+++ b/client/lib/schemas/multi-client-config.js
@@ -18,7 +18,7 @@ const innerSchema = {
 			],
 		},
 		image: {
-			type: ['string', "boolean"],
+			type: ['string', 'boolean'],
 		},
 		workers: {
 			oneOf: [

--- a/core/lib/common/suite.js
+++ b/core/lib/common/suite.js
@@ -129,13 +129,16 @@ class Suite {
 		this.teardown = new Teardown();
 		this.state = new State();
 		this.passing = null;
+
+		// Test summary
 		this.testSummary = {
 			suite: ``,
 			stats: {
 				tests: 0,
-				passes: 0,
-				fails: 0,
 				ran: 0,
+				skipped: () => this.testSummary.stats.tests - this.testSummary.stats.ran,
+				passed: 0,
+				failed: 0,
 			},
 			tests: {},
 		};
@@ -219,11 +222,11 @@ class Suite {
 						this.testSummary.stats.ran++;
 						let result = testNode.passing();
 						if (result) {
-							this.testSummary.tests[title] = 'pass';
-							this.testSummary.stats.passes++;
+							this.testSummary.tests[title] = 'passed';
+							this.testSummary.stats.passed++;
 						} else {
-							this.testSummary.tests[title] = 'fail';
-							this.testSummary.stats.fails++;
+							this.testSummary.tests[title] = 'failed';
+							this.testSummary.stats.failed++;
 						}
 						return;
 					}
@@ -293,7 +296,6 @@ class Suite {
 		this.state.log('Run queue summary:');
 		const treeExpander = ({ title, tests }, depth) => {
 			this.state.log(`${'\t'.repeat(depth)} ${title}`);
-
 			if (tests == null) {
 				this.testSummary.stats.tests++;
 				this.testSummary.tests[title] = 'skipped';
@@ -322,7 +324,8 @@ class Suite {
 	}
 
 	async createJsonSummary() {
-		this.state.log(`Creating JSON test summary...`);
+		this.testSummary.stats.skipped = this.testSummary.stats.skipped()
+		this.testSummary.dateTime = `${new Date().toString()}`
 		let data = JSON.stringify(this.testSummary, null, 4);
 		await fs.writeFileSync(`/reports/test-summary.json`, data);
 	}


### PR DESCRIPTION
Improvements made: 
1. Merge all summaries into one summary JSON file
2. Add skipped stats and summary creation time. 
3. UX: Deleting individual summary files to give a cleaner look in Jenkins

```
[
  {
    "suite": "Testbot Diagnositcs",
    "stats": {
      "tests": 4,
      "ran": 3,
      "skipped": 1,
      "passed": 3,
      "failed": 0
    },
    "tests": {
      "Flashing an image": "passed",
      "Power cycling the DUT": "skipped",
      "Is the DUT reachable?": "passed",
      "Recording DUT serial output": "passed"
    },
    "dateTime": "Mon Feb 21 2022 20:38:24 GMT+0000 (Coordinated Universal Time)"
  },
  {
    "suite": "Unmanaged BalenaOS release suite",
    "stats": {
      "tests": 3,
      "ran": 3,
      "skipped": 0,
      "passed": 3,
      "failed": 0
    },
    "tests": {
      "resinos.fingerprint file test": "passed",
      "ext4 filesystems are checked on boot": "passed",
      "OS-release file check": "passed"
    },
    "dateTime": "Mon Feb 21 2022 20:45:02 GMT+0000 (Coordinated Universal Time)"
  }
]
```




Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
