### PR TITLE
worker: fix TS2571 error in exception handler

### DIFF
--- a/worker/lib/index.ts
+++ b/worker/lib/index.ts
@@ -279,7 +279,9 @@ async function setup(runtimeConfiguration: Leviathan.RuntimeConfiguration)
 				worker.on('progress', onProgress);
 				await worker.flash(req);
 			} catch (e) {
-				res.write(`error: ${e.message}`);
+				if (e instanceof Error) {
+					res.write(`error: ${e.message}`);
+				}
 			} finally {
 				worker.removeListener('progress', onProgress);
 				res.write('status: done');


### PR DESCRIPTION
Older TS versions typed objects passed to exception handlers as `any`,
regardless of the fact that it's not guaranteed these objects inherit
from the Error prototype. Newer TS versions throw an error because the
type is unknown:

  worker/lib/index.ts:282:25 - error TS2571: Object is of type 'unknown'.

Fix this error by checking that the object passed to the error handler
is indeed an instance of Error before accessing the message property.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>