### PR TITLE
worker: qemu: add option to disable network autoconfiguration

### DIFF
--- a/worker/config/default.js
+++ b/worker/config/default.js
@@ -17,6 +17,7 @@ module.exports = {
 				memory: process.env.QEMU_MEMORY || '2G',
 				debug: process.env.QEMU_DEBUG || false,
 				network: {
+					autoconfigure: true,
 					bridgeName: process.env.QEMU_BRIDGE_NAME || null,
 					bridgeAddress: process.env.QEMU_BRIDGE_ADDRESS || null,
 					dhcpRange: process.env.QEMU_DHCP_RANGE || null,

--- a/worker/typings/worker.d.ts
+++ b/worker/typings/worker.d.ts
@@ -27,6 +27,7 @@ declare global {
 				vars: string
 			},
 			network: {
+				autoconfigure: boolean;
 				bridgeName: string;
 				bridgeAddress: string;
 				dhcpRange: string;


### PR DESCRIPTION
Network configuration, including creating a bridge, setting iptables
rules, and running a DHCP server, requires privileges. This can be done
easily in a container, but would otherwise necessitate running the whole
test suite privileged, or with CAP_NET_ADMIN at least.

Allow users to disable network autoconfiguration in favor of manually
setting up a bridge and DHCP server separately. This allows the suite to
be run unprivileged, if necessary.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>