### PR TITLE
revert: core: balenaos: use temp file for image path

### DIFF
--- a/core/lib/components/os/balenaos.js
+++ b/core/lib/components/os/balenaos.js
@@ -142,7 +142,7 @@ module.exports = class BalenaOS {
 		this.network = options.network;
 		this.image = {
 			input: options.image === undefined ? config.get('leviathan.uploads').image : options.image,
-			path: tmp.tmpNameSync(),
+			path: join(config.get('leviathan.downloads'), `image-${id()}`),
 		};
 		this.configJson = options.configJson || {};
 		this.contract = {


### PR DESCRIPTION
This change caused multiple issues that are causing problems in production testbots. 

- unpacked images are being stored in the tmp directory, which isn't being cleared at the end of the test suite, so testbots are having storage issues
- when preloading, we use the host's docker daemon - this requires finding the path of the image from the hsot OS, which is easier if the image is in a docker volume

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>