### PR TITLE
core: worker: Increase to 300 seconds the timeout for DUT reboot

### DIFF
--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -345,7 +345,7 @@ module.exports = class Worker {
 				(await this.executeCommandInHostOS(
 					'[[ ! -f /tmp/reboot-check ]] && echo pass',
 					target,
-					{ interval: 10000, tries: 10 },
+					{ interval: 10000, tries: 30 },
 				)) === 'pass'
 			);
 		}, false);


### PR DESCRIPTION
There are boards for which reboot takes longer so let's take
them into account too by increasing this timeout.

Change-type: patch
Signed-off-by: Florin Sarbu <florin@balena.io>