### PR TITLE
Enable nested changelogs when this project is consumed

### DIFF
--- a/.versionbot/CHANGELOG.yml
+++ b/.versionbot/CHANGELOG.yml
@@ -1,0 +1,9637 @@
+- version: 1.36.0
+  date: 2022-02-28T17:42:42Z
+  commits:
+  - hash: 02c67364a11b861add8b124c72ada7aba1cfd1c4
+    author: Vipul Gupta (@vipulgupta2048)
+    footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+    subject: Delete deprecated getting started guide
+    body:
+  - hash: a55ded691d6984477720d4426a4323092aa0e6de
+    author: Vipul Gupta (@vipulgupta2048)
+    footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+    subject: 'minor: Create quickstart guides for testbot+qemu'
+    body:
+  - hash: df54ef7c078ceb9a697d833d2b4e019e95263c03
+    author: Vipul Gupta (@vipulgupta2048)
+    footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+    subject: Remove/unify env variable to reduce confusion
+    body:
+  - hash: 0d132c8bb55cd77138c0f99ee7f88c173c736a83
+    author: Vipul Gupta (@vipulgupta2048)
+    footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+    subject: Add childern pages to the docs index
+    body:
+  - hash: 013f090f36063b90857e6245ddcbad0d950a855f
+    author: Vipul Gupta (@vipulgupta2048)
+    footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+    subject: Add leviathan usecase list
+    body:
+  - hash: a9bd1e29f43a92076b8407a667b3c7697893d3ed
+    author: Vipul Gupta (@vipulgupta2048)
+    footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+    subject: Improve language consistency
+    body:
+- version: 1.35.29
+- date: 2022-02-28T14:23:27Z
+- commits:
+  - hash: 83ec888d7c9486c67e49b341e7b1763b91431614
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: 'patch: Add config.js for e2e suite'
+- commits:
+  - body:
+- version: 1.35.28
+- date: 2022-02-23T12:56:23Z
+- commits:
+  - hash: 881e475df23d11f58adbd37e3c4dfce2e44c50e0
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: 'worker: bump testbot sdk for bbb improvments'
+- commits:
+  - body:
+- version: 1.35.27
+- date: 2022-02-23T12:22:12Z
+- commits:
+  - hash: c29b78075a2c71fe712cf1f73e36571908d31df7
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: 'revert: core: balenaos: use temp file for image path'
+- commits:
+  - body:
+- version: 1.35.26
+- date: 2022-02-22T12:02:19Z
+- commits:
+  - hash: 8953e3d73d843268b24c25f7ebbf7af461a91ef6
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: 'patch: Track test skips & summarize the summaries'
+- commits:
+  - body:
+- commits:
+  - hash: 55151cef4df8948d474837614e9592ccc8cd1a55
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Lint & prettify files
+- commits:
+  - body:
+- version: 1.35.25
+- date: 2022-02-18T18:16:54Z
+- commits:
+  - hash: e2cf76bf1f2a0af0f20f230d229296e866a186e5
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: 'worker: fix build on x86'
+- commits:
+  - body:
+- version: 1.35.24
+- date: 2022-02-18T17:50:52Z
+- commits:
+  - hash: 513bb579f1d97a54493a635e19525524a83dcd89
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: 'worker: bump testbot sdk for fin fix'
+- commits:
+  - body:
+- version: 1.35.23
+- date: 2022-02-15T00:18:23Z
+- commits:
+  - hash: f7bc14f645851276291bd9c5c420e668287fa85b
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'worker: fix TS2571 error in exception handler'
+- commits:
+  - body: |-
+      Older TS versions typed objects passed to exception handlers as `any`,
+      regardless of the fact that it's not guaranteed these objects inherit
+      from the Error prototype. Newer TS versions throw an error because the
+      type is unknown:
+      worker/lib/index.ts:282:25 - error TS2571: Object is of type 'unknown'.
+      Fix this error by checking that the object passed to the error handler
+      is indeed an instance of Error before accessing the message property.
+- version: 1.35.22
+- date: 2022-02-11T20:42:27Z
+- commits:
+  - hash: a77056a9d642fc88c9067ba380cb6cca1f92fce6
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'workers: qemu: specify machine and cpu type for aarch64'
+- commits:
+  - body:
+- commits:
+  - hash: 530401012384bcf27bbe4fb3f0f3d67e92d51f46
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'workers: qemu: ignore stdio without debug'
+- commits:
+  - body: |-
+      When debug is disabled, QEMU's stdio is piped to the parent process. If
+      that stream isn't read, it can fill and cause the child process to block
+      waiting for the pipe buffer to accept more data.
+      Override the default and ignore stdio when debug is not enabled to
+      prevent this.
+- version: 1.35.21
+- date: 2022-02-11T16:32:04Z
+- commits:
+  - hash: 921e0f5aa032c9d34032a3e49fb5603ab2c5c055
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: 'patch: Throw errors on upload'
+- commits:
+  - body:
+- version: 1.35.20
+- date: 2022-02-08T14:49:39Z
+- commits:
+  - hash: b63a36982b9c25ea42b5021cb81074e33630eede
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - subject: 'Revert "worker: use nodejs package from upstream alpine"'
+- commits:
+  - body: This reverts commit 398474b5ac9e894152ea9a99a8a851462c3b0343.
+- commits:
+  - hash: 84f5ef8c6c19037a7db9869cb07fb68111820baf
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - subject: 'Revert "core: use nodejs package from upstream alpine"'
+- commits:
+  - body: This reverts commit be9c9bf2e75f5d0906a2bdbd336168332f0500b8.
+- version: 1.35.19
+- date: 2022-02-08T09:54:06Z
+- commits:
+  - hash: e8fd6bf5174472d2d3c48b47cba3de1c63acbdfe
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'worker: merge Leviathan Options and RuntimeConfiguration'
+- commits:
+  - body: |-
+      These objects contain a lot of the same configuration, yet are subtlely
+      divergent for no apparent reason. Merge them into RuntimeConfiguration
+      and replace all references with the new object.
+- version: 1.35.18
+- date: 2022-02-07T18:40:20Z
+- commits:
+  - hash: e024650e0ec017744cd9d0d3aa6b0db9fca889d5
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'core: test: proxy to context to shorten test code'
+- commits:
+  - body: |-
+      Return a proxy of this object that will forward access to properties
+      present in the context object to that object.
+      This allows us to shorten, e.g.:
+      this.context.get().worker.executeCommandInHostOS(...)
+      To just:
+      this.worker.executeCommandInHostOS(...)
+- version: 1.35.17
+- date: 2022-02-07T17:01:41Z
+- commits:
+  - hash: 6b5eac9370d742d069dae16fc8c8686d37dd4ff7
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'worker: qemu: fix worker image path'
+- commits:
+  - body: |-
+      Workers have an option to override the disk image path used, but this
+      was ignored in the qemu worker. Fix it to use this option when present.
+- version: 1.35.16
+- date: 2022-02-03T18:03:16Z
+- commits:
+  - hash: 1b28c504fef335c5ac5fbc46bd7f85c01c0a1811
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: 'core: Prevent duplicate entries in balenarc.yml'
+- commits:
+  - body:
+- version: 1.35.15
+- date: 2022-02-03T17:34:43Z
+- commits:
+  - hash: 4331bf8ce926d54aac3c16560b70f918c17977bc
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'core: worker: join command arrays with spaces'
+- commits:
+  - body: |-
+      This allows users to pass commands to worker.executeCommandInHostOS() as
+      arrays and have the elements be joined by spaces into a string before
+      execution. This allows for better styling with line breaks, etc. without
+      explicitly adding a join to the array.
+- version: 1.35.14
+- date: 2022-02-03T12:54:34Z
+- commits:
+  - hash: 4b92fefabb9932f3998732fd1497fff584fd7ea9
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: 'patch: Support staging environment for balenaCLI'
+- commits:
+  - body:
+- version: 1.35.13
+- date: 2022-02-03T10:32:29Z
+- commits:
+  - hash: fcf81044c2d75c87b33614348b16636f5c2af4a4
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'core: utils: replace any-promise with native'
+- commits:
+  - body: |-
+      This fixes the error:
+      any-promise is already defined as "global.Promise"
+      When running a suite in-proc.
+- version: 1.35.12
+- date: 2022-02-01T17:40:00Z
+- commits:
+  - hash: b04fea67c9e3dae3b14aa1c0c3c54204b6b89f5b
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'core: state: fix TypeError when not running as a subprocess'
+- commits:
+  - body: |-
+      The suite module sends log messages to the parent process when it's
+      forked using process.send(). When the suite module is not forked, this
+      results in a TypeError, as process.send is undefined.
+      Check that process.send is not undefined before attempting to call it.
+- version: 1.35.11
+- date: 2022-02-01T14:53:27Z
+- commits:
+  - hash: 0f05d49f0f49675be65d5e4d2c72391524affca2
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: Disable tagging by the deploy-to-balena-action
+- commits:
+  - body: |-
+      These extra tags create a lot of noise on busy repositories.
+      Also enable versionbot for proper forward-versioning.
+- version: 1.35.10
+- date: 2022-02-01T14:43:13Z
+- commits:
+  - hash: 0cf2f323779b50bef8b7316abcf0e97814b755b4
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'worker: get workerType from runtimeConfiguration'
+- commits:
+  - body: |-
+      Get workerType from runtimeConfiguration, obviating the need for the
+      config module.
+- version: 1.35.9
+- date: 2022-01-26T16:14:28Z
+- commits:
+  - hash: d8f83a06d61d9c51acbc9f2116ad47a722118b43
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: 'client: Export additional env vars required for cloud suites'
+- commits:
+  - body:
+- version: 1.35.8
+- date: 2022-01-26T11:00:25Z
+- commits:
+  - hash: 5643b63f990c0dd3c87436d4f115aee40b91d4b4
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: 'patch: Delete interactive client code'
+- commits:
+  - body:
+- commits:
+  - hash: f7895cbec9f74e9e2bb3ddec6d8df5b280e327a2
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Delete interactive mode documentation
+- commits:
+  - body:
+- commits:
+  - hash: 12cc9ace0cfe913c87f630d3080f2f4eb837f0b3
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Remove client/core interactive mode interaction
+- commits:
+  - body:
+- version: 1.35.7
+- date: 2022-01-26T09:15:45Z
+- commits:
+  - hash: 312cff0e9ec4f9be64b4c8e604482420c7cd438c
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'core: refactor Teardown as TaskQueue'
+- commits:
+  - body: |-
+      Refactor Teardown class as TaskQueue to facilitate registering tasks for
+      setup as well as teardown. A separate Teardown object inherits from
+      TaskQueue and retains the signal handling from the original object.
+      This is a precursor to separating the forking behavior from the suite
+      object in preparation for having a standalone runner for virtualized
+      workers. For example, we can move the removeDownloads hook from the
+      Suite object to a separate SuiteSubprocess object that is specifically
+      for handling suites not running on a the same physical machine.
+- version: 1.35.6
+- date: 2022-01-25T23:41:15Z
+- commits:
+  - hash: 4c6cbbe50bb664b76631881b939c59ae758d4e14
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'core: test: remove intermediate suite object'
+- commits:
+  - body: |-
+      The Test object is constructed with a Suite instance, which is
+      accessible from inside tests using 'this.suite'. However, another object
+      is created using only certain properties from the input suite object.
+      Remove the intermediate object so that all properties from the suite
+      object are exposed in the test code.
+- version: 1.35.5
+- date: 2022-01-25T16:00:07Z
+- commits:
+  - hash: 2026e208b0ea6f16efb7334dd530adc531bf825c
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: 'core: add some logging to preload helper'
+- commits:
+  - body:
+- version: 1.35.4
+- date: 2022-01-25T11:53:21Z
+- commits:
+  - hash: b241f5253f88ad98c93f5242d70ce9faf63bb3b4
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'worker: add runtimeConfiguration as parameter to setup()'
+- commits:
+  - body: |-
+      Add Leviathan.RuntimeConfiguration as a parameter to setup(), allowing
+      reuse of this function to create and run Worker servers without a config
+      file.
+- version: 1.35.3
+- date: 2022-01-24T20:24:18Z
+- commits:
+  - hash: 931aa56368e959e171ad8bc3cded9b1547fbfbdd
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'core: balenaos: use temp file for image path'
+- commits:
+  - body: |-
+      The BalenaOS object has a fetch() method that unpacks a compressed disk
+      image from an input path to a destination path, called "path". The
+      destination is currently pulled from a config file.
+      We don't need to retain the extracted image, so switch to a temp file
+      path, which makes this bit of configuration unnecessary.
+- version: 1.35.2
+- date: 2022-01-24T16:56:39Z
+- commits:
+  - hash: b405e00e9ff939ef5f08b36779b4a93dd83b516e
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'worker: qemu: add firmware path options'
+- commits:
+  - body: |-
+      QEMU can accept firmware blobs for different architectures, machine
+      types, and feature sets (e.g., secure boot). OVMF is a commonly
+      available firmware implementing the UEFI specification for virtual
+      machines based on edk2.
+      Various distributions package and ship OVMF firmware, but with varying
+      paths between them. Allow for user defined paths to firmware files,
+      instead of a static path.
+- commits:
+  - hash: 6259a5f108bedcef1b41b9b1496ceae2aa2bf030
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'worker: qemu: add method to find firmware'
+- commits:
+  - body: |-
+      Automatically scan common locations for OVMF/AAVMF when the firmware
+      isn't specified in QemuOptions.
+- version: 1.35.1
+- date: 2022-01-21T18:01:17Z
+- commits:
+  - hash: ee0b8ffdc745c34adc309275ef0f499d6f132804
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'worker: allow listening from UNIX domain socket path'
+- commits:
+  - body: |-
+      Previously, the worker would exit with an error if the server address
+      was a string, instead of an object describing a TCP socket.
+      Unfortunately, a string is a valid address in the case of listening to a
+      UNIX domain socket. Remove this error condition, as the server will
+      raise an error anyway if the port cannot be used.
+- commits:
+  - hash: 2a044428888a3bfa4b2f4f9a7779befc58f4c0e4
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: 'core: update cloud helpers after sdk bump'
+- commits:
+  - body:
+- version: 1.35.0
+- date: 2022-01-19T15:22:56Z
+- commits:
+  - hash: 6c2fe18f0ae3550d257eec6227c6ab8acb2421fa
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: 'core: Update balena-sdk to 16.12.1'
+- commits:
+  - body: Update balena-sdk from 11.18.2 to 16.12.1
+- commits:
+  - hash: f6304dad3f308d14aac8388e05f2ea381cc6f5b7
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: 'core: Update balena-cli to 13.1.10'
+- commits:
+  - body: Update balena-cli from 12.55.11 to 13.1.10
+- commits:
+  - hash: 6c3272dd222ab7899f2fceb9f8471464a6c03d2c
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: 'worker: Update balena-sdk to 16.12.1'
+- commits:
+  - body: Update balena-sdk from 15.59.2 to 16.12.1
+- commits:
+  - hash: d1cee08a92aaef2f90d2fd3f7cc2be70cb9df127
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: 'client: Update balena-sdk to 16.12.1'
+- commits:
+  - body: Update balena-sdk from 16.9.2 to 16.12.1
+- commits:
+  - hash: 5c143100f1e77adc07203bb5d631c930c39c159f
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: 'core: Update balena-sdk init function'
+- commits:
+  - body:
+- commits:
+  - hash: abe8d59c616b6696ca49e4b95682b4caefc48873
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: 'core: Update fetchOS helper to use new SDK functions'
+- commits:
+  - body: getSupportedVersions has been deprecated
+- version: 1.34.2
+- date: 2022-01-18T14:48:17Z
+- commits:
+  - hash: ae5e0564b47ace2a494313614d8bf732a2e4a4da
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: fix preloading helpers for qemu worker
+- commits:
+  - body:
+- version: 1.34.1
+- date: 2022-01-18T11:51:49Z
+- commits:
+  - hash: 22f47a26b640c63b4fdfc6bd86e8a23ffb051ad4
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: 'patch: Change code theme in docs'
+- commits:
+  - body:
+- commits:
+  - hash: 695777eb6f19f136ba494e1d6b18979756020267
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Update documentation
+- commits:
+  - body:
+- version: 1.34.0
+- date: 2022-01-18T10:50:00Z
+- commits:
+  - hash: 365516343cf8da56fd375f2e318c76b142e215a0
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: 'minor: Add testbot e2e tests'
+- commits:
+  - body:
+- commits:
+  - hash: 2921474e7ea5a57fbe9f1fc6cfeee91a2e281199
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Add diagnostics endpoint & worker logic
+- commits:
+  - body:
+- commits:
+  - hash: 760711879ef484574c74a63843398157effe66c1
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Expose testbot methods for e2e tests
+- commits:
+  - body:
+- commits:
+  - hash: 4d58e42e1c4c8ca8d2a7444c4ef2cbd337705d6f
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Delete old tests
+- commits:
+  - body:
+- commits:
+  - hash: fe178995aa7894d95035799c1f69dfc783a19960
+- commits:
+  - author: Alex
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Alex Bucknall <alex.bucknall@gmail.com>
+- commits:
+  - subject: Fixed serial logging test
+- commits:
+  - body:
+- commits:
+  - hash: 04f7bdcf2b935a8ffcf325d811676d69574d79f9
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Add example config.js
+- commits:
+  - body:
+- commits:
+  - hash: edb63d72f665bc0a8b130f2448bb9e2ba0985f66
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Add fake image Upload option
+- commits:
+  - body:
+- commits:
+  - hash: 31d4a2aa38a80a041eb21f34fe4f2ad36479d6ec
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Support QEMU worker in e2e tests
+- commits:
+  - body:
+- commits:
+  - hash: 81bb17194dd6cdcfddfd1eece2505e72309bafce
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Document e2e test suite
+- commits:
+  - body:
+- commits:
+  - hash: 563f19886666f755d21bce1b1d5bb0323687204b
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Add fetchOS download progress on image download
+- commits:
+  - body:
+- commits:
+  - hash: 69ff455ed9e55cb713318eca2d2d5ace75704d2f
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Add QEMU test suite improvements to e2e
+- commits:
+  - body:
+- commits:
+  - hash: 9d2b8606863e4ef6518e263a4acbbe00d3e668f6
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Add developmentMode as true
+- commits:
+  - body:
+- commits:
+  - hash: 405a0dacee2770964a1050fcaed5ce2cfe282b63
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Add worker contracts in tests
+- commits:
+  - body:
+- commits:
+  - hash: 5f67f2b9e242c42593d9d6acf91ba395cf0327f3
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Unify contract/diagnostic endpoints
+- commits:
+  - body:
+- commits:
+  - hash: 18dce64d4c0a9df4f4b77d64b8ab586d0c07702b
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Add more information to test assertions
+- commits:
+  - body:
+- version: 1.33.0
+- date: 2022-01-17T13:36:35Z
+- commits:
+  - hash: 4a591302ffe210b862cf747d4ecb9c02a3eb4ad7
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: 'minor: Deprecate the use of conf.js in test suites'
+- commits:
+  - body:
+- version: 1.32.7
+- date: 2022-01-17T13:29:51Z
+- commits:
+  - hash: 847070b5fafcaf2842d590dc79f09d8806878195
+- commits:
+  - author: Vipul Gupta
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Add applicationConfigVariables to balena.yml
+- commits:
+  - body:
+- version: 1.32.6
+- date: 2022-01-14T08:34:27Z
+- commits:
+  - hash: dcd7d6339a7c3777844003fa2e2cda4e9ad9ea17
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: 'patch: Add deploy with balena'
+- commits:
+  - body: Added some sane defaults
+- version: 1.32.5
+- date: 2022-01-13T23:32:08Z
+- commits:
+  - hash: b7816cb73a1afb85602944ca04917e721d992c9b
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: 'worker: Avoid running QEMU entrypoint cmds on testbot'
+- commits:
+  - body:
+- version: 1.32.4
+- date: 2022-01-13T21:33:38Z
+- commits:
+  - hash: 1c687c9d9f9fe91898f985cd6260cc7a2983d3ed
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: Update deploy-to-balena-action to v0.5.4
+- commits:
+  - body: Avoid pinning to master as we don't want to pick up breaking changes.
+- version: 1.32.3
+- date: 2022-01-12T15:13:51Z
+- commits:
+  - hash: be4130fff3bbbed25e9ce600548289d48db5c17b
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'Makefile: always use known good compose version'
+- commits:
+  - body: |-
+      Compose v2.2 seems to no longer support device_cgroup_rules
+      configuration. This was removed in Compose file v3, but it still doesn't
+      work with Compose v2.2 even when using the older Compose file v2.4
+      that's supposed to support it. Revert to a known good version of
+      compose.
+- commits:
+  - hash: 6434cb9f61240493eeeddb515c2c37ad58e61a5b
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'workers: qemu: make kvm optional'
+- commits:
+  - body: |-
+      KVM requires support from the CPU, BIOS/firmware, and hypervisor to all
+      be enabled. In the case where support is missing or disabled in any of
+      these places, KVM cannot be used. If the device node is missing,
+      attempting to map it in the compose file will fail, and the worker
+      cannot be started.
+      Instead, set a device cgroup policy to allow our container to create and
+      access the required device nodes at runtime if KVM is supported. This
+      allows a fallback to software emulation when KVM is not available. It
+      also allows for software emulation of targets not matching the host
+      architecture.
+- version: 1.32.2
+- date: 2022-01-11T20:02:29Z
+- commits:
+  - hash: d0dbc3894395cfb8609eb1871a470d9e48645b9c
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'workers: qemu: enable serial logging'
+- commits:
+  - body:
+- version: 1.32.1
+- date: 2022-01-11T18:24:35Z
+- commits:
+  - hash: 3792769b3c03cb660f22f41e5d7de9f128111a05
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: 'patch: Add deploy to balena action'
+- commits:
+  - body:
+- commits:
+  - hash: bd2ceecfcafa906c2ac932f7de671b851b8b02fb
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Add submodules
+- commits:
+  - body:
+- version: 1.32.0
+- date: 2022-01-09T10:54:34Z
+- commits:
+  - hash: de193fbf2773c2753c3ba6ca3cbd7fff1918dd7f
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: 'minor: Remove git hooks'
+- commits:
+  - body:
+- commits:
+  - hash: 9ba6bc83cbc56b4aae8e015b6a6913ab38f1f3df
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: '[Client] Formatting fixes'
+- commits:
+  - body:
+- commits:
+  - hash: 4e4c998d74ce784d51b8bc8eedab3fd6edc8d8e9
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: '[Client] Trim dependencies'
+- commits:
+  - body:
+- commits:
+  - hash: c5d8243b93a3789bcac164415ca36bd884269abb
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: '[Core] Formatting fixes && trim dependencies'
+- commits:
+  - body:
+- commits:
+  - hash: 837c0f4905700029dc458730808dd598d85d6e83
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: '[Worker] Fix double ==, Formatting  && trim dependencies'
+- commits:
+  - body:
+- commits:
+  - hash: 20d8e2300a3faa72ca56622c11202f90f586ed0b
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Amend leviathan package.json scripts
+- commits:
+  - body:
+- commits:
+  - hash: 7f668a35ef669ac560f60a85a0a4e0e6947e8e57
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Convert to balena-lint
+- commits:
+  - body:
+- version: 1.31.9
+- date: 2022-01-07T10:29:27Z
+- commits:
+  - hash: 8a5e4fa77dcc4245980124ee9a7c09aa539247d9
+- commits:
+  - author: Vipul Gupta
+- commits:
+  - subject: 'patch: Replace link-checker with Lychee'
+- commits:
+  - body:
+- version: 1.31.8
+- date: 2021-12-29T06:24:48Z
+- commits:
+  - hash: f214899dfecc7dca4f83105936dafb882ab478aa
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: 'patch: Clear cache when test starts'
+- commits:
+  - body:
+- commits:
+  - hash: 810434b46e3d25ba16c074e97d15c33c1bcce49b
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Remove package-lock.json file from ignore lists
+- commits:
+  - body:
+- version: 1.31.7
+- date: 2021-12-22T16:14:18Z
+- commits:
+  - hash: e85b348b0a28d1f8c31637d062708c88c53feb33
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: 'local-test: Split up client and local compose files'
+- commits:
+  - body:
+- commits:
+  - hash: b1116c56dcc04b82a0b75ad4e2cf4b85446d376c
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: 'local-test: Abort on container exit'
+- commits:
+  - body: We should abort when the client exits, primarily for CI purposes.
+- commits:
+  - hash: 142c1317745fc7ca8b55729484a857781bfe4fad
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: 'local-test: Remove dependency on npx'
+- commits:
+  - body:
+- commits:
+  - hash: b7d23c0073aac800288f9b0ac4064a59b687ef5d
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: 'local-test: Remove orphan containers on compose up'
+- commits:
+  - body:
+- version: 1.31.6
+- date: 2021-12-21T13:43:56Z
+- commits:
+  - hash: a9f120d7b174a66ea0e13c129f4df53823a73698
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: 'patch: Update balena-sdk to 16.1.0'
+- commits:
+  - body:
+- commits:
+  - hash: 0e3899f90b721c30531c1571849525210d06f0bd
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Update balena-sdk calling function
+- commits:
+  - body:
+- version: 1.31.5
+- date: 2021-12-20T13:46:11Z
+- commits:
+  - hash: 532b4d50c009c558490195be48fe58aa200d376d
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: 'client: Expose config module path in docker cmd'
+- commits:
+  - body:
+- commits:
+  - hash: feb675b31f5478c854ced50ee5126307eb74e81d
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: 'client: Change base image to alpine'
+- commits:
+  - body:
+- version: 1.31.4
+- date: 2021-12-17T15:58:46Z
+- commits:
+  - hash: e38c7f0f0759bf7c7e9502f8a98738603155e4f9
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'worker: remove libvirt from optional dependencies'
+- commits:
+  - body: |-
+      We no longer require libvirt in the worker image for virtualized
+      testbots, remove it from optional dependencies to save time.
+- version: 1.31.3
+- date: 2021-12-16T16:33:26Z
+- commits:
+  - hash: ee125345bbca2013eefbb2345b1f9146db053d7e
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: 'worker: set up bridge parameters dynamically'
+- commits:
+  - body:
+- version: 1.31.2
+- date: 2021-12-15T14:44:10Z
+- commits:
+  - hash: e3ae94044d7377a69dc134fca6eb5014210630eb
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: Update package-lock.json
+- commits:
+  - body:
+- version: 1.31.1
+- date: 2021-12-15T11:21:28Z
+- commits:
+  - hash: 810faf85f6740d3ecd68d1bd8b1fdad24898c106
+- commits:
+  - author: Alexandru Costache
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Alexandru Costache <alexandru@balena.io>
+- commits:
+  - subject: Add CM4 IO-Board
+- commits:
+  - body:
+- version: 1.31.0
+- date: 2021-12-09T21:06:57Z
+- commits:
+  - hash: d22f57f2ae7cdf545fa6235c74289d1a4c55388f
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: 'core: Change base images from debian to alpine'
+- commits:
+  - body:
+- commits:
+  - hash: 28812cba7a8c1f6740c25970c8a1b63e53181abf
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: 'worker: Change base images from debian to alpine'
+- commits:
+  - body:
+- commits:
+  - hash: 398474b5ac9e894152ea9a99a8a851462c3b0343
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'worker: use nodejs package from upstream alpine'
+- commits:
+  - body: |-
+      The upstream alpine nodejs package is smaller than the external one
+      downloaded in the balenalib image, switch to the upstream package.
+- commits:
+  - hash: be9c9bf2e75f5d0906a2bdbd336168332f0500b8
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'core: use nodejs package from upstream alpine'
+- commits:
+  - body: Switch to the upstream nodejs package, just like in the previous commit.
+- commits:
+  - hash: fc452aae4c9e870a42cf6f4946d12301ba9275aa
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'worker: remove unnecesary qemu modules'
+- commits:
+  - body: |-
+      Remove unused qemu firmware and modules, including massive edk2 firmware
+      we don't need.
+- version: 1.30.14
+- date: 2021-12-07T12:40:12Z
+- commits:
+  - hash: 520880901ea61397eda18bf4c674adf977c8b279
+- commits:
+  - author: Vipul Gupta
+- commits:
+  - subject: 'patch: Remove duplicate build property'
+- commits:
+  - body:
+- version: 1.30.13
+- date: 2021-12-05T15:42:32Z
+- commits:
+  - hash: ea97a71f36ea66434bc77d343e027163ff8502b7
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: allow setting of ports via env var
+- commits:
+  - body:
+- version: 1.30.12
+- date: 2021-12-02T23:56:46Z
+- commits:
+  - hash: d7dad0ff5135a7a1f6142759cdaf8539fa87edd8
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: 'worker: Return error if bridge address is already in use'
+- commits:
+  - body:
+- version: 1.30.11
+- date: 2021-12-02T15:58:04Z
+- commits:
+  - hash: f49413fbdfa4f36a21cc2dbf88d08f5974f98a8e
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: Add contracts upstream to project repo.yml
+- commits:
+  - body: This should enable embedded changelogs.
+- commits:
+  - hash: 5b6b99b6aa3a8fab26b04f6d6b9733bfcffeb9b8
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: 'core/contracts: Update to v1.13.40'
+- commits:
+  - body: Update contracts from 1.13.33 to 1.13.40
+- version: 1.30.10
+- date: 2021-11-30T20:55:35Z
+- commits:
+  - hash: 8efa5414b2e758ae03e89e19eb892a2f681cb192
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: 'core: Install balena CLI via package-json'
+- commits:
+  - body: |-
+      This also removes some big build dependencies that were leftover
+      in the final build stage.
+- commits:
+  - hash: 55f04b1871f5802b1d970253b592d0cc0e551dab
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: 'core: Fix rebased multicast-dns reference'
+- commits:
+  - body:
+- version: 1.30.9
+- date: 2021-11-30T19:25:17Z
+- commits:
+  - hash: de1bb4de1220b9f2f271f503648590fe32cf9e52
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: 'patch: Streamline the docs'
+- commits:
+  - body:
+- commits:
+  - hash: 6f2c42525b83130a24b0241988299ed0c3ff550b
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Add config.json example to target all devices in fleet
+- commits:
+  - body:
+- commits:
+  - hash: e6054ef61ae2cef33a883bf64aed6f2543432809
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Fix dead links
+- commits:
+  - body:
+- commits:
+  - hash: afc82ad9f52e0d7655ac6e63e6109f9080a4fe5e
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Add GitHub action for finding dead links
+- commits:
+  - body:
+- commits:
+  - hash: 4604bc5cab3d049b540171e5098af3ec4ab967e7
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Generate documentation
+- commits:
+  - body:
+- version: 1.30.8
+- date: 2021-11-30T00:10:11Z
+- commits:
+  - hash: c69d2c2a2d5389a740824f47f6f496d68bbda69e
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'qemu: switch to emulated pflash to support UEFI vars'
+- commits:
+  - body: |-
+      QEMU is able to optionally use OVMF firmware, built from Tianocore edk2,
+      to support UEFI. QEMU can be told to load OVMF firmware using a number
+      of methods, not all of which fully support persistent UEFI variables,
+      such as are required by secure boot.
+      Switch from using the -bios flag to fully emulated pflash to load OVMF,
+      including support for persistent UEFI variables. Also switch from the pc
+      machine to q35, which is required for fully emulated pflash.
+      https://github.com/tianocore/edk2/blob/e1e7306b54147e65cb7347b060e94f336d4a82d2/OvmfPkg/README#L65
+- version: 1.30.7
+- date: 2021-11-29T23:59:36Z
+- commits:
+  - hash: dcfc24f6c3756ee08c3580550730147214530ead
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'Makefile: fix ENOENT when paths don''t exist in clean target'
+- commits:
+  - body:
+- commits:
+  - hash: 4253ba5d92405da557ce10f91b2533b6d63dd5f1
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'Makefile: fix race condition with parallel make'
+- commits:
+  - body: |-
+      The $(COMPOSEBIN) target would be run in parallel with dependent
+      targets when parallel make was used, causing a race condition. Add the
+      $(COMPOSEBIN) target to the .NOTPARALLEL built-in target to fix this
+      race.
+- version: 1.30.6
+- date: 2021-11-29T13:56:07Z
+- commits:
+  - hash: 6fded4e76c1f2ea49539276d8571537e744375d9
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: Force install to replace missing dependencies
+- commits:
+  - body:
+- commits:
+  - hash: 3ac85edcdc5196a6d4b5ca94ce26300a2d15293a
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: Remove deprecated balena-sync package
+- commits:
+  - body:
+- commits:
+  - hash: 884f982320301e78e8d7186585c09b459b892e10
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: Update multicast-dns commit ref as the PR has been rebased
+- commits:
+  - body:
+- version: 1.30.5
+- date: 2021-11-26T14:43:49Z
+- commits:
+  - hash: f44ff127cf0f3b5372f7151906ef9df9427466a8
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: 'worker: update package-lock'
+- commits:
+  - body:
+- version: 1.30.4
+- date: 2021-11-26T13:10:07Z
+- commits:
+  - hash: 7de9677aa5db8d269cd4463d5507cbf1df889236
+- commits:
+  - author: Alexandru Costache
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Alexandru Costache <alexandru@balena.io>
+- commits:
+  - subject: Add RevPi Core 3
+- commits:
+  - body:
+- commits:
+  - hash: b03af4adf3da9a063b7928f0beaca77b0cda5faf
+- commits:
+  - author: Alexandru Costache
+- commits:
+  - footers:
+      signed-off-by: Alexandru Costache <alexandru@balena.io>
+- commits:
+  - subject: 'worker: Update testbot SDK to include RevPi support'
+- commits:
+  - body:
+- version: 1.30.3
+- date: 2021-11-26T12:24:20Z
+- commits:
+  - hash: 7b80c2b992d43d18e8e8ad55c57ba7473be524d7
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: Fix ordering of docker-compose args
+- commits:
+  - body:
+- version: 1.30.2
+- date: 2021-11-26T09:18:06Z
+- commits:
+  - hash: 3996ccd515adcde5282dca757c2dacb80d2d5d25
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: 'makefile: fix detached flag in make detach'
+- commits:
+  - body:
+- version: 1.30.1
+- date: 2021-11-25T17:30:06Z
+- commits:
+  - hash: 811787994da58e6894d8d24b4449150dabf07c6a
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: 'worker: set up iptables and cleanup in teardown'
+- commits:
+  - body:
+- commits:
+  - hash: 05a0394d0d949cae8e06c345a21817ea7cdf3675
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: 'worker: wait for qemu image resize before flashing'
+- commits:
+  - body:
+- version: 1.30.0
+- date: 2021-11-25T16:40:10Z
+- commits:
+  - hash: 750a069d169e054cc557c192d59dcabe31d603d5
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: Rework the makefile and flatten compose files to root of project
+- commits:
+  - body: |-
+      We now have more useful make targets and don't rely on the bash
+      scripts in the root of the workspace.
+      We also have a slightly more reliable mechanism for making sure
+      a docker-compose binary is available.
+- commits:
+  - hash: f373ed27e163a8149608c8375f3dd03109797fd9
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: Update documentation with new makefile commands
+- commits:
+  - body:
+- version: 1.29.10
+- date: 2021-11-23T02:02:46Z
+- commits:
+  - hash: 12ea023b7f6dd0793ed9a120a8c6a3cb113c10b8
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: Stub the proxy endpoint as glider has been removed from the worker
+- commits:
+  - body: |-
+      When we removed the dependency on glider in the proxy tests, we also
+      removed glider from the worker. However, older versions of the tests
+      from ESR branches would still call this endpoint and expect a sane
+      response.
+      Fortunately, the old proxy tests were invalid and would always pass
+      even if glider wasn't working. ICMP traffic does not use the proxy.
+      So, we can just pretend to start a glider instance so the old tests
+      continue to run, even with an invalid result.
+- version: 1.29.9
+- date: 2021-11-22T18:18:47Z
+- commits:
+  - hash: 50864042fde4923e079294a0b6380bdad13c6546
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: Add detached target to makefile for running in jenkins
+- commits:
+  - body:
+- commits:
+  - hash: aca70f5def3d8af01e54f90119967e9190ad1156
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: Fix typo in qemu lib dnsmasqArgs
+- commits:
+  - body:
+- version: 1.29.8
+- date: 2021-11-22T15:54:16Z
+- commits:
+  - hash: 8560fcad93ce3460f1f4577355f7bdb90aff1119
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'qemu: network: disable dnsmasq DNS server'
+- commits:
+  - body: |-
+      Dnsmasq can be configured (and already is) to only listen on specific
+      interfaces—for DHCP. By default, it will still listen on port 53 for DNS
+      queries, which makes it impossible to run multiple instances
+      concurrently.
+      From the man page:
+      -p, --port=<port>
+      Listen on <port> instead of the standard DNS port (53). Setting this to
+      zero completely disables DNS function, leaving only DHCP and/or TFTP.
+      Specify --port=0 to disable DNS, and allow multiple instances to run
+      concurrently.
+- version: 1.29.7
+- date: 2021-11-21T22:55:25Z
+- commits:
+  - hash: e5262c93ef1e8520bf2990c27e9eef2b1c3e53ea
+- commits:
+  - author: Kyle Harding
+- commits:
+  - subject: 'Revert "patch: Reduce helpers delays and retries"'
+- commits:
+  - body:
+- commits:
+  - hash: 46bec0b5a258eb067750d20e6c02df6a98f4e64f
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: 'client: fix flashing status messages'
+- commits:
+  - body:
+- commits:
+  - hash: 98e7ebad82cc8f8da6b281b05c043f990f417abf
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: 'client: let client execute suites on one worker'
+- commits:
+  - body:
+- commits:
+  - hash: d491ff74aecfd33e1bdec84dc20a0cd303d2f576
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: 'core: add dependencies for hup suite'
+- commits:
+  - body:
+- version: 1.29.6
+- date: 2021-11-16T09:36:04Z
+- commits:
+  - hash: 166eeec153af669a5fe155a76c05f01568378b8c
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: 'patch: Remove nadoo/glider from Dockerfile'
+- commits:
+  - body:
+- version: 1.29.5
+- date: 2021-11-16T07:25:31Z
+- commits:
+  - hash: 256c5c51726a4bbe33da925f1c047fd16c2ffde0
+- commits:
+  - author: Vipul Gupta
+- commits:
+  - subject: 'patch: Create balena-ci.yml'
+- commits:
+  - body:
+- commits:
+  - hash: ab61d68ed3ef4b8b695df568d52018cabb3ffa57
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: Update dependabot to bump actions
+- commits:
+  - body:
+- commits:
+  - hash: cf5ba688012f3d198a46671f2ebe0b6be36493bc
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Add matrix of fleets to deploy releases
+- commits:
+  - body:
+- version: 1.29.4
+- date: 2021-11-15T21:21:51Z
+- commits:
+  - hash: 9fdaaea8dedfcc1bd3a3aabec4651e7d9269d78d
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'worker: qemu: fix unresolved promise in setupBridge()'
+- commits:
+  - body: Fix returning a promise from setupBridge() that never resolves.
+- version: 1.29.3
+- date: 2021-11-15T21:00:18Z
+- commits:
+  - hash: 615d6e35106cb2c77ab13ec8d8cf462f6de41915
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: 'patch: Install git in the worker for npm dependencies'
+- commits:
+  - body:
+- version: 1.29.2
+- date: 2021-11-15T13:09:25Z
+- commits:
+  - hash: b0fb5cda6a384ea1bae1832f5b995b866315a4d6
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: 'patch: Reduce helpers delays and retries'
+- commits:
+  - body:
+- commits:
+  - hash: 6f57b9cb5ed570e6e53cea0342720c3c047da5fe
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Reduce timeouts for cloud worker
+- commits:
+  - body:
+- version: 1.29.1
+- date: 2021-11-15T11:07:11Z
+- commits:
+  - hash: 5b86c3d9c6ef41ad316b5f40f3053d032184b906
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: add worker contract
+- commits:
+  - body:
+- version: 1.29.0
+- date: 2021-11-15T10:33:08Z
+- commits:
+  - hash: cdafda3f8a1f7e098e081501ff90e1185b969342
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'client: upload: handle error status'
+- commits:
+  - body: |-
+      Add simple error handling to check the response status code against the
+      expected status and reject the promise if they don't match.
+- commits:
+  - hash: 1301a8f5441fefd6ded67be056898f0bbe16a56e
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'workers: qemu: interface directly without libvirt'
+- commits:
+  - body: |-
+      Previously, the QEMU worker was setup and controlled through JS bindings
+      of libvirt. This package adds an unnecessary abstraction and associated
+      complexity. It's no longer maintained, and does not work with current
+      and supported versions of Node.
+      Spawn QEMU directly using child_process.spawn(). Setup networking
+      through a bridge and qemu-bridge-helper, rather than libvirt.
+- commits:
+  - hash: 9f1067be57b9cd6d70eebea2228bf0d2e855b191
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: Re-enable qemu worker
+- commits:
+  - body:
+- commits:
+  - hash: e83bcdf7fa986f3d6c41e24e4ef95577dc6288ab
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'workers: qemu: promisify network setup'
+- commits:
+  - body:
+- commits:
+  - hash: b0a5a8f65144e050dc4fcd6bf145ff8327739042
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'workers: qemu: re-enable support for screenCapturer'
+- commits:
+  - body:
+- commits:
+  - hash: 3a1c56a9f3c1c73311cad4c1541374d81933bb25
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'compose: generic-x86: update for QemuWorker'
+- commits:
+  - body: |-
+      Update generic-x86 compose file for use with QemuWorker. Including:
+      - Disable udev for core and worker, as NetworkManager isn't used
+      - Remove privileged flag for both containers in favor of capabilities
+      - Remove mapping in the host docker socket
+      - Add device mapping for /dev/kvm (hardware virtualization)
+      - Add device mapping for /dev/net/tun (network setup)
+      - Remove unneeded configuration disabling pid and ipc namespacing
+      - Specify WORKER_TYPE=qemu env var for worker container
+- commits:
+  - hash: 028455bbf6753cc5a55ecc17743e85f6d8de7675
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'worker: Dockerfile: fix build error w/ libusb'
+- commits:
+  - body: Install libusb-1.0.0-dev to fix build error
+- commits:
+  - hash: 619b8198a7171b0eb61cb18daf5238dcae9add0b
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'worker: Dockerfile: install ovmf for uefi support'
+- commits:
+  - body: Install OVMF package for UEFI firmware used by QEMU
+- commits:
+  - hash: eac85a52fe3333f85aa5405b12075361d304c552
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'worker: Dockerfile: setup qemu bridge.conf'
+- commits:
+  - body: Create qemu-bridge-helper ACL file
+- commits:
+  - hash: 171b0862ec9b58125bd98ecc7fbf8cea21540fdb
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'worker: Dockerfile: remove libvirt dependencies'
+- commits:
+  - body: Libvirt is no longer used, remove it
+- commits:
+  - hash: 46b80e025e4f7463c694e3b52198b2dca695f677
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'core/contracts: bump to v1.13.33'
+- commits:
+  - body: |-
+      This brings in several device types useful for the QEMU worker,
+      including genericx86-64-ext, generic-amd64, and generic-aarch64.
+- commits:
+  - hash: b5aae0b81d256901aa2e04aa6a4cd72367fbae9b
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'compose/generic-x86.yml: enable SCREEN_CAPTURE'
+- commits:
+  - body:
+- commits:
+  - hash: 2ea43d2d6e3ff10a26d50f34481f07fd051fd75d
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'worker: breakout qemu configs'
+- commits:
+  - body: |-
+      Breakout QEMU worker configs from implementation, including
+      architecture, cpus, memory, and network config. Add defaults to
+      worker/config/default.js, and allow overrides with env vars.
+- commits:
+  - hash: f38959bccd94db8c226b5c703c960d1346e58f13
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'worker: qemu: don''t return from powerOff until qemu exits'
+- commits:
+  - body: |-
+      This avoids the case where the suite tries to start up another qemu
+      instance before the first one has exited, and a required port (such as
+      the one used for QMP) is already in use.
+- commits:
+  - hash: d73c98e632086508b3cf8d53705afc22e1e93407
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'README: update with QEMU worker instructions'
+- commits:
+  - body:
+- commits:
+  - hash: b9f687eec9657528b53c96750ebd051e77db079c
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'worker: qemu: add debug option to show serial console'
+- commits:
+  - body: |-
+      Add a debug configuration variable to show output from QEMU process in
+      worker terminal.
+- version: 1.28.37
+- date: 2021-11-09T23:20:32Z
+- commits:
+  - hash: ed6b6f6ec85b7bb118e096a97761b224ff8a3579
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'Makefile: replace BALENA_ARCH in Dockerfile templates'
+- commits:
+  - body:
+- commits:
+  - hash: 030f47322f0f89e81673adde601d627500d8c9c1
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'worker: Dockerfile: s/BALENA_MACHINE_NAME/BALENA_ARCH'
+- commits:
+  - body:
+- version: 1.28.36
+- date: 2021-11-08T20:30:30Z
+- commits:
+  - hash: 9334e328c0574483cec1145c2d19b647a09c7e64
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'core: bump balena-cli to 12.51.1'
+- commits:
+  - body: Bump balena-cli in core service from 12.48.0 to 12.51.1
+- commits:
+  - hash: 3f3da9d396aed6f6de0e0082a52b2ad1a186a4b4
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: Upgrade Node to v12 in core and worker
+- commits:
+  - body: Upgrade from Node 10 and Debian Buster (EOL) to Node 12 and Debian Bullseye.
+- version: 1.28.35
+- date: 2021-11-03T11:01:13Z
+- commits:
+  - hash: e3f0551159bb2f87e833d169f5d0ae857de05778
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: allow option to keep image post test
+- commits:
+  - body:
+- commits:
+  - hash: 2fec0e39855a34ce7265d87689c1f5749fa22925
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: stub worker functions if env variable present
+- commits:
+  - body:
+- version: 1.28.34
+- date: 2021-11-02T09:05:04Z
+- commits:
+  - hash: ed4ed90273be66dec6d24fd0972a53408d106616
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: add title to json summary
+- commits:
+  - body:
+- version: 1.28.33
+- date: 2021-10-29T13:20:53Z
+- commits:
+  - hash: f8e0ed5e1314c0e069dfa00418c5d3abaa441926
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: add json test summary
+- commits:
+  - body:
+- version: 1.28.32
+- date: 2021-10-29T10:36:09Z
+- commits:
+  - hash: c41b4a99cee6773bf84b6a5ba505bed4511e6362
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: stop testbotsdk build breaking local make
+- commits:
+  - body:
+- version: 1.28.31
+- date: 2021-10-29T10:24:36Z
+- commits:
+  - hash: 687a77741025414f19f6939c2507036d0b46fbd9
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'Makefile: fix $(command -v) invocation'
+- commits:
+  - body: Redirect stdout to /dev/null to prevent the variable from being trashed.
+- commits:
+  - hash: dbf0fe26fa54d9b6547aa0e19f304b3660328e13
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'Makefile: update usage of --yes for npm >= 7'
+- commits:
+  - body:
+- version: 1.28.30
+- date: 2021-10-26T11:28:36Z
+- commits:
+  - hash: 9d697a2684ba81474515705e24381b13d1f37837
+- commits:
+  - author: Vipul Gupta
+- commits:
+  - subject: 'patch: Fix bluebird-retry options syntax'
+- commits:
+  - body:
+- version: 1.28.29
+- date: 2021-10-26T05:17:46Z
+- commits:
+  - hash: 7fab3433970131059b1b3c8b48fb36f458242884
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: 'patch: Clarify caching implementation in fetchOS helper'
+- commits:
+  - body:
+- version: 1.28.28
+- date: 2021-10-20T13:43:01Z
+- commits:
+  - hash: f8f7a43f57aacae33c1d341fb0261c84950d43c6
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: fix parsing of os-release file for flasher images
+- commits:
+  - body:
+- version: 1.28.27
+- date: 2021-10-20T09:47:54Z
+- commits:
+  - hash: 3552b5636db506d95eea051d7ebe2caf9a6306a2
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: add beaglebone support
+- commits:
+  - body:
+- version: 1.28.26
+- date: 2021-10-20T09:29:24Z
+- commits:
+  - hash: 91d1fb0974ddce0dd9bcc931706301a1a526915b
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: 'patch: Disable Dependabot from Leviathan'
+- commits:
+  - body:
+- version: 1.28.25
+- date: 2021-10-20T09:11:58Z
+- commits:
+  - hash: 061b532c812a1cdc73574c617b882e3c535c09ea
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: fix suite hangups
+- commits:
+  - body:
+- version: 1.28.24
+- date: 2021-10-18T13:20:19Z
+- commits:
+  - hash: 359d18b9dbeb6857c131c32c50994c3aca833ec2
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'Makefile: fix npx confirmation breaking Dockerfile target'
+- commits:
+  - body: |-
+      When running npx, if the dockerfile-template package needs installed,
+      the output from this will be written to the Dockerfile, and the Make
+      process will hang with no output.
+      Add the --yes flag to require no confirmation.
+- commits:
+  - hash: 12eddc18032be5247985b55e87b45049c60b6ce9
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'Makefile: add compatibility for docker-compose v2'
+- commits:
+  - body: |-
+      Docker-compose v2 adds compose functionality to the docker binary
+      itself, as a plugin, removing the 'docker-compose' binary in the
+      process.
+      Use a variable for compose functionality, and use either
+      `docker-compose`, or `docker compose` where appropriate.
+- version: 1.28.23
+- date: 2021-09-08T12:33:55Z
+- commits:
+  - hash: 28c37c0266017f27ed3a134614011a05447d7ada
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: 'patch: Update .dockerignore'
+- commits:
+  - body:
+- version: 1.28.22
+- date: 2021-09-06T10:24:18Z
+- commits:
+  - hash: 0b09df765fd7229309c99d5c7d1afc534d4a01b9
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'core: fix typo of retrieve'
+- commits:
+  - body:
+- version: 1.28.21
+- date: 2021-09-01T23:08:14Z
+- commits:
+  - hash: e334139971ca75dd0b1555c789337a3cc210d73d
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: 'patch: Reduce timeout interval retrying archiveLogs helper'
+- commits:
+  - body:
+- version: 1.28.20
+- date: 2021-09-01T18:50:35Z
+- commits:
+  - hash: 7dc3525ae9ff1aeedd294b639344c12ef9cb07ad
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Update Archiver implementation
+- commits:
+  - body: |-
+      The changes are as follows:
+      1. Create new archiveLogs helper
+      2. Create new implementation of the Archiver module
+      3. Add documentation for Archiver module
+- commits:
+  - hash: 9fbda6ce43ec701ec5dc5ccebafa51f1f51ea83a
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Add documentation for archiveLogs helper
+- commits:
+  - body:
+- version: 1.28.19
+- date: 2021-08-31T08:50:29Z
+- commits:
+  - hash: 924bb476e741f45928aafb090aa98f4ac0c1554d
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'core: handle promise rejection in state'
+- commits:
+  - body: |-
+      Existing code attempts to ignore failures opening LED file paths in
+      safeWrite(). However, there's an unhandled promise rejection in a couple
+      of places as a result of mishandling the rejection. Catch the error to
+      prevent this warning.
+- version: 1.28.18
+- date: 2021-08-30T17:03:20Z
+- commits:
+  - hash: ae9cddec54727d9f4691b5fdd80a6f9fdd5a8bad
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: 'patch: Update balena-cli to v12.48.0'
+- commits:
+  - body:
+- version: 1.28.17
+- date: 2021-08-25T14:41:30Z
+- commits:
+  - hash: bd0972124dc405f7ddea69aaa8065d547e5849ba
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: have test suite bail after first failure
+- commits:
+  - body:
+- version: 1.28.16
+- date: 2021-08-24T20:19:43Z
+- commits:
+  - hash: 1858f7263727ef192ccf3c18c3c71e758b0fe911
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: remove redundant parts of worker dockerfile
+- commits:
+  - body:
+- version: 1.28.15
+- date: 2021-08-24T14:55:29Z
+- commits:
+  - hash: 9ab2eef24beb260e1d5dbacc821368819d6019ed
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: disable bable-node
+- commits:
+  - body:
+- version: 1.28.14
+- date: 2021-08-19T16:15:38Z
+- commits:
+  - hash: 103e6228f9e15a93b5f3a0b0e8483841bcd1b52d
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: 'hotfix: wait for report stream to end before exit'
+- commits:
+  - body:
+- version: 1.28.13
+- date: 2021-08-19T11:52:59Z
+- commits:
+  - hash: c480cbf7c3479472c67953ab32a596d89cfabdbf
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: generate mocha-style report at the end of tests
+- commits:
+  - body:
+- version: 1.28.12
+- date: 2021-08-18T16:20:44Z
+- commits:
+  - hash: 8551c60f59c675d0d25d578938c8c16150200a56
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: increase ssh keepalive interval time
+- commits:
+  - body:
+- version: 1.28.11
+- date: 2021-08-15T16:28:15Z
+- commits:
+  - hash: 78dc1857b7a5eb40e88086c8f54b553a7db54456
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: 'patch: Restructure teardown order to prevent dependency issues'
+- commits:
+  - body:
+- commits:
+  - hash: 43e54d98738d1aed70c961f8dd44a8e5126c9943
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Add archiverLogs as helper
+- commits:
+  - body:
+- version: 1.28.10
+- date: 2021-08-11T15:48:51Z
+- commits:
+  - hash: 08967ebeb18a82a5920b395c62068d1dd5ea2165
+- commits:
+  - author: Joseph Kogut
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Joseph Kogut <joseph@balena.io>
+- commits:
+  - subject: 'client: log error message when image does not exist'
+- commits:
+  - body: |-
+      When the image specified in config.js does not exist, the
+      single-client.js script exits with no failures, and no logged errors.
+      Catch this error and log it to the console.
+- version: 1.28.9
+- date: 2021-08-06T12:00:32Z
+- commits:
+  - hash: 66ed9cb3d312d7aaf4ad7a076d5bff9c7ba23829
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: add message when suite exits to client
+- commits:
+  - body:
+- version: 1.28.8
+- date: 2021-08-05T10:18:30Z
+- commits:
+  - hash: bff95b962a3f871b3a759316da1318f117f3007f
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: enable testing without client uploads
+- commits:
+  - body:
+- commits:
+  - hash: f143d6c7a330c1b9ff069b5bef1658e4270b124b
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: store worker logs locally
+- commits:
+  - body:
+- version: 1.28.7
+- date: 2021-08-03T11:10:23Z
+- commits:
+  - hash: 5bef6289cde7b7721806ea86e609ca397f6670de
+- commits:
+  - author: Vipul Gupta
+- commits:
+  - subject: 'patch: Add docs/ to .dockerignore'
+- commits:
+  - body:
+- version: 1.28.6
+- date: 2021-08-02T14:41:39Z
+- commits:
+  - hash: fbccaf42320c58686245069ad6351e256ab57c32
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: bump testbot sdk package to support fin
+- commits:
+  - body:
+- version: 1.28.5
+- date: 2021-07-22T13:46:16Z
+- commits:
+  - hash: f6ff02c9cf43eae6f9688b1fb2869ca16964f840
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: 'patch: Make CLI helpers considerate of API environments'
+- commits:
+  - body:
+- version: 1.28.4
+- date: 2021-07-22T12:59:22Z
+- commits:
+  - hash: 875be42cdfaac204e29dbe7c58e389cc292ec5a3
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: 'patch: Fix grouping of online testbots when selecting available workers'
+- commits:
+  - body:
+- version: 1.28.3
+- date: 2021-07-21T12:48:49Z
+- commits:
+  - hash: b027270d0c857187ed550796e30fe6e52f4eabc5
+- commits:
+  - author: Kyle Harding
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Kyle Harding <kyle@balena.io>
+- commits:
+  - subject: Replace broken link and fix readme formatting
+- commits:
+  - body:
+- version: 1.28.2
+- date: 2021-07-21T08:29:32Z
+- commits:
+  - hash: 1954e608026f7a189b11bc378e8e5dbfc766fbba
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: 'patch: Move generated docs to root for GitHub Pages'
+- commits:
+  - body:
+- version: 1.28.1
+- date: 2021-07-19T22:14:10Z
+- commits:
+  - hash: 69aa6b6f416db80cc66bb85d2104c53aafbb27c2
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: 'patch: generate leviathan helpers documentation'
+- commits:
+  - body:
+- version: 1.28.0
+- date: 2021-07-19T21:14:39Z
+- commits:
+  - hash: bc7fe147c3621f78d397909ea877afe5a5c8ba59
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Add Leviathan helpers documentation
+- commits:
+  - body:
+- commits:
+  - hash: a39d280c019a04086d53e435c769cca4096dc244
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Configure typedoc for leviathan helpers
+- commits:
+  - body:
+- commits:
+  - hash: e8391c920b33f756c4dd79d2a20ad43ca5a512c1
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Document helper methods in tsdoc format
+- commits:
+  - body:
+- commits:
+  - hash: cc328d055bde2527d7a6a25a1becf9e977700422
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Add params, throws, returns for helper documentation
+- commits:
+  - body:
+- commits:
+  - hash: e89420826aae5a66043838b63d4dd0d9e851ce44
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Add docs to dockerignore
+- commits:
+  - body:
+- commits:
+  - hash: 544c918353d07b4733b8f86821982e2aca8ec0f7
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Add learn more section
+- commits:
+  - body:
+- commits:
+  - hash: 964e6c486d7cc47053dc10c1539a58fe7a1cd690
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Add What next section to Quickstart
+- commits:
+  - body:
+- version: 1.27.13
+- date: 2021-07-14T11:56:44Z
+- commits:
+  - hash: 6081968fbc3406f57d2b26449362ead41914d67e
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: fix preload helper
+- commits:
+  - body:
+- version: 1.27.12
+- date: 2021-07-12T06:45:05Z
+- commits:
+  - hash: 5ed5bbff791becd0366c69eab872a826f70107ed
+- commits:
+  - author: Vipul Gupta
+- commits:
+  - subject: 'patch: Update waitUntil helper''s rejection condition to default false'
+- commits:
+  - body: waitUntil is a helper that runs a function for a designated number of times
+      till it satisfies a particular condition to break out of the loop. In the current
+      implementation, if `rejectionFail` is `true` and if the command fails to satisfy
+      the condition in an iteration then the `waitUntil` helper returns an error which
+      isn't quite helpful for a function that is meant to continuously wait until
+      something is complete. Hence, the change to make `rejectionFail` as default
+      to `false` in the `waitUntil` helper
+- version: 1.27.11
+- date: 2021-07-06T08:31:56Z
+- commits:
+  - hash: 5a0165ee483fc542929dfd4c5792b08c852aadc0
+- commits:
+  - author: Miguel Casqueira
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Miguel Casqueira <miguel@balena.io>
+- commits:
+  - subject: Fix balenaOS image link in README
+- commits:
+  - body:
+- version: 1.27.10
+- date: 2021-06-30T15:49:37Z
+- commits:
+  - hash: 47c029dacf00f032bdf5ab557d3af58fc1037311
+- commits:
+  - author: Vipul Gupta
+- commits:
+  - subject: 'patch: Delete Codeowners'
+- commits:
+  - body:
+- version: 1.27.9
+- date: 2021-06-25T10:27:12Z
+- commits:
+  - hash: 74d0a96f918f5f0d49fb5e7b0f3ac75f38a88780
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: Allow use of balenaOS class with any image
+- commits:
+  - body:
+- commits:
+  - hash: 30d6eede6d843021dfd1a0eda379a2bee68d2393
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: fix test teardowns overlapping with suite teardown
+- commits:
+  - body:
+- commits:
+  - hash: e6a7933890fb69002c96c97a429889f8036e9b94
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: make fetchOS function use downloads dir
+- commits:
+  - body:
+- commits:
+  - hash: e5293c5740ccb26d9cd2e728203ede80be405fc4
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: add get os function to worker
+- commits:
+  - body:
+- commits:
+  - hash: 8f10c3cac6230826de73fc68c3e7b0697113d553
+- commits:
+  - author: Ryan Cooke
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: Fix formatting
+- commits:
+  - body:
+- version: 1.27.8
+- date: 2021-06-23T10:41:45Z
+- commits:
+  - hash: 5eaf5a894e7b37909c023b93e36da50bb1d34838
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: 'patch: Reboot DUT helper'
+- commits:
+  - body:
+- commits:
+  - hash: 73ab63f4c3d23428f940bb1eee6e89c05aa76362
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Add fetchOS helper
+- commits:
+  - body:
+- commits:
+  - hash: 6069718b484d5bfc4b6d2b2943a3ad168df6ae3c
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Add documentation to helpers
+- commits:
+  - body:
+- version: 1.27.7
+- date: 2021-06-18T16:00:20Z
+- commits:
+  - hash: 44f4822f9207f43d96b6451eb145e7b80314479f
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: add log timestamping
+- commits:
+  - body:
+- commits:
+  - hash: b2fa20dd179233703933937daeb0e52d2cabfe1b
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: change to iso format
+- commits:
+  - body:
+- version: 1.27.6
+- date: 2021-06-16T11:25:23Z
+- commits:
+  - hash: d447524699bea3e9ef52dc7660b31a5f579b1b25
+- commits:
+  - author: Robert Günzler
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Robert Günzler <robertg@balena.io>
+- commits:
+  - subject: 'multi-client: catch exceptions of the single-client children'
+- commits:
+  - body:
+- commits:
+  - hash: 234596184f08841ecf0793271fb2527485b9aa04
+- commits:
+  - author: Vipul Gupta
+- commits:
+  - subject: Specify code for default exception
+- commits:
+  - body:
+- version: 1.27.5
+- date: 2021-06-09T09:52:39Z
+- commits:
+  - hash: ba96f4c053809527f8128f642341caee04ed9b29
+- commits:
+  - author: Robert Günzler
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Robert Günzler <robertg@balena.io>
+- commits:
+  - subject: 'client: improve multi-client output'
+- commits:
+  - body: |-
+      This makes the final log more readable by explaining the status code, we
+      set in the single-client
+- commits:
+  - hash: a4be55e96ffce3c1e453aebc63e6b376aa563baa
+- commits:
+  - author: Robert Günzler
+- commits:
+  - footers:
+      signed-off-by: Robert Günzler <robertg@balena.io>
+- commits:
+  - subject: 'client: fix --print flag'
+- commits:
+  - body:
+- version: 1.27.4
+- date: 2021-05-31T14:42:45Z
+- commits:
+  - hash: 3ad2bdfe9a73dd26b874dc5e43bca407d56a4e6a
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: stop retry from throwing in pushcontainer
+- commits:
+  - body:
+- version: 1.27.3
+- date: 2021-05-28T16:04:36Z
+- commits:
+  - hash: 2e87be15e3d67fe42f5b2b28643591c67d0d4422
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: fix image upload retry
+- commits:
+  - body:
+- commits:
+  - hash: 2c202fd86ecd5b112713d4c8d3d79e1ee5872cd0
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: directly use stream objects and improve logs
+- commits:
+  - body:
+- version: 1.27.2
+- date: 2021-05-26T10:42:22Z
+- commits:
+  - hash: b6c8aa2bc8869cb06eb63c6d00285cb8d4f3142a
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: make timeout on waitUntilServicesRunning a param
+- commits:
+  - body:
+- version: 1.27.1
+- date: 2021-05-14T23:06:23Z
+- commits:
+  - hash: 6efaaadfbcb3a9dc7ef14b42800fe4abbf3de80f
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: stop client sending multiple jobs to same worker
+- commits:
+  - body:
+- version: 1.27.0
+- date: 2021-05-14T14:21:49Z
+- commits:
+  - hash: 7c36b55f9487348014b80c4bca99d8c157e56fed
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: 'minor: Parallelize multi-suite testing with multiple workers'
+- commits:
+  - body:
+- commits:
+  - hash: 6b5742a400cb1c795e54c1f151ebf678b4c8be70
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Add state endpoint & getState() method
+- commits:
+  - body: |-
+      Add getState() method to know when the testbot is IDLE/BUSY for
+      the multi-suite parallelization & queue to work.
+- commits:
+  - hash: 15d7e5370e86b11e4de7e67b47cccb20f91fa327
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Filter only online testbots with DUT tag
+- commits:
+  - body: |-
+      - Add a filter to remove any offline testbots from matching devices
+      - Document BalenaCloudInteractor with typedoc annotations
+- commits:
+  - hash: 4e19c8ec1e59c4dd5b16b4456e445c92ad160f7d
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Clearly indicate which suites are running
+- commits:
+  - body: |-
+      - Clear out & add new comments
+      - Fix Indendation
+      - Reduce IDLE timeout in core/state.js
+      - Deleted TODO file
+- commits:
+  - hash: 02afc5afb6bb4640c7fcdab65f96b3466522a9c8
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Add documentation for worker types & properties
+- commits:
+  - body: |-
+      - Document all available config.js properties
+      - All worker types
+      - Add examples of config.js
+- commits:
+  - hash: 2e6d3c0ba93078a86192931bbab4947d16870839
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Document fileNamePrefix() and added more information
+- commits:
+  - body:
+- commits:
+  - hash: 0b3b40470e0d61ae3c7c3cc43ceba297bad931a3
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: 'Change run --> job #403'
+- commits:
+  - body:
+- commits:
+  - hash: 01efa6239cbbfd5299869256566077662c41dd79
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Document balenaOS image format in docs
+- commits:
+  - body: Also, added documentation directory to .dockerignore
+- commits:
+  - hash: 4016176d77a6d61c6bd176240895285227fae3e7
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: allow client to gzip images before sending
+- commits:
+  - body:
+- version: 1.26.15
+- date: 2021-05-14T13:25:24Z
+- commits:
+  - hash: d5bf550703c34d9bb75e3d533b9797c5dde39c38
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: add more cloud helpers
+- commits:
+  - body:
+- commits:
+  - hash: f2fb91033d6a7504e0ac0feab58f3ec551754c7f
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: add documentation
+- commits:
+  - body:
+- commits:
+  - hash: ce495d7e9d53a29a6e0bf4f50d8af4e268a73892
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: Fix typedoc param declarations
+- commits:
+  - body:
+- commits:
+  - hash: 7238892780bd7d7d5d8e9b7fb777fcb77f3152ec
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: fix preload format in cli helper class
+- commits:
+  - body:
+- version: 1.26.14
+- date: 2021-05-13T17:16:02Z
+- commits:
+  - hash: de8c1afa029c5175bc15ffda7c180d757b98a09e
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: fix hdmi capture
+- commits:
+  - body:
+- commits:
+  - hash: c1a3fd0e757740708f3aeac7523b68577f7ba75a
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: make worker storage volume accessible by core
+- commits:
+  - body:
+- commits:
+  - hash: d45c16f984e332849b0eae018d1857b853843f9b
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: allow client to download artifacts
+- commits:
+  - body:
+- commits:
+  - hash: 47823c77b1770d237e73d3ca8bd5cf199c59a373
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: fix report archive naming
+- commits:
+  - body:
+- commits:
+  - hash: 00980e68679e186f9fdb11543022889741d81321
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: describe how to capture screen and send artifacts
+- commits:
+  - body:
+- commits:
+  - hash: ce4797c6effafeeaacec37c9768b5f2aca1cfdfc
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: Resolve promise for report downloads correctly
+- commits:
+  - body:
+- commits:
+  - hash: df73d99f7ceb79f179ccc5ca3a8def92bb119a8e
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: resolve both report and artifact download promises
+- commits:
+  - body: Commit body
+- version: 1.26.13
+- date: 2021-04-29T19:29:23Z
+- commits:
+  - hash: c8f1577bff8042e69aad6f538a72b9ff31bcce58
+- commits:
+  - author: Robert Günzler
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Robert Günzler <robertg@balena.io>
+- commits:
+  - subject: Add unpack type that does nothing
+- commits:
+  - body:
+- version: 1.26.12
+- date: 2021-04-14T13:08:35Z
+- commits:
+  - hash: c184ad486c64fa04d38688393775de88e5573329
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: Include bluez for bluetooth tests
+- commits:
+  - body:
+- commits:
+  - hash: 1357c142a68b65e3e636228d23b1bd45d4773ea1
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: fix docker-compose
+- commits:
+  - body:
+- version: 1.26.11
+- date: 2021-04-07T14:08:10Z
+- commits:
+  - hash: ecec5260af717c500b5c044223bfd27a53abca78
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: add push container and execute in container helper
+- commits:
+  - body:
+- commits:
+  - hash: 9ec02c0e336aad3827ddd06ce342bbbce07854b7
+- commits:
+  - author: Ryan Cooke
+- commits:
+  - subject: Merge branch 'master' into add-container-helpers
+- commits:
+  - body:
+- version: 1.26.10
+- date: 2021-03-26T09:15:15Z
+- commits:
+  - hash: 73968527953305d5dd2bae2ef697aaa2859684b8
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: move getting started leviathan guide here
+- commits:
+  - body:
+- version: 1.26.9
+- date: 2021-03-04T11:34:48Z
+- commits:
+  - hash: f6a4165af50b5b97d9d1bde8017e46e0f3fa6e6c
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: increase upload timeout from 5 to 10 mins
+- commits:
+  - body:
+- version: 1.26.8
+- date: 2021-03-01T10:33:03Z
+- commits:
+  - hash: 19996576d56604f3d8b39952a1e1f23cb2970e9e
+- commits:
+  - author: Roman Mazur
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Roman Mazur <roman@balena.io>
+- commits:
+  - subject: Update testbot library to support more device types
+- commits:
+  - body: The new testbot SDK is suitable for Intel NUC DUT.
+- commits:
+  - hash: 2b0baadf7e49cac0d852e632ae5d624dc2194c56
+- commits:
+  - author: Roman Mazur
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: Add NUC support and improve logging
+- commits:
+  - body:
+- version: 1.26.7
+- date: 2021-02-17T21:01:13Z
+- commits:
+  - hash: d84b0b15672930ea17fe2345beaf847e0b736dfa
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: bump dbus package
+- commits:
+  - body:
+- commits:
+  - hash: afe3ffb2f943c779bb9233adf22e8c7a417bb47d
+- commits:
+  - author: rcooke-warwick
+- commits:
+  - footers:
+      signed-off-by: Ryan Cooke <ryan@balena.io>
+- commits:
+  - subject: Create a functional releases
+- commits:
+  - body:
+- version: 1.26.6
+- date: 2021-02-04T12:43:24Z
+- commits:
+  - hash: f7ac0836399c3959cf5280cad61adc9ea27d901b
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - subject: Add Getting Started section to README
+- commits:
+  - body:
+- commits:
+  - hash: 3d294e30864dbba0207c61179d09ee776de9ab3c
+- commits:
+  - author: Vipul Gupta
+- commits:
+  - subject: Updated install instructions
+- commits:
+  - body:
+- commits:
+  - hash: fb6675f0e9364bc22d6d1fde2de8f8fcba6950e2
+- commits:
+  - author: Vipul Gupta
+- commits:
+  - subject: Provide information for rig-owners
+- commits:
+  - body:
+- commits:
+  - hash: f6f4a58e9b21fa1f886b34a7b5b092ab9bea48e1
+- commits:
+  - author: Vipul Gupta
+- commits:
+  - subject: Update URL's
+- commits:
+  - body:
+- commits:
+  - hash: 133e894d642d0d5de5251de3d6094fbbb7cfd33a
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Add note about access needed
+- commits:
+  - body:
+- commits:
+  - hash: 445070e2ee989cc7551e66f14ec360530829cdc1
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Remove private package limitations
+- commits:
+  - body:
+- version: 1.26.5
+- date: 2021-01-26T09:46:27Z
+- commits:
+  - hash: b14e588ff3cd2298f6d9f854a54de84b035f91e3
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Disable persistent logging test
+- commits:
+  - body:
+- version: 1.26.4
+- date: 2021-01-21T15:51:57Z
+- commits:
+  - hash: 23faa8ddc07e3279354a52d7b8b39376aba891d5
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Activate persistent logging test
+- commits:
+  - body: |-
+      Since https://github.com/balena-os/meta-balena/issues/1919 is resolved,
+      the previous deactivated persistent logging test is being activated again
+      in the OS test suite.
+- commits:
+  - hash: a673c61cb3026e676b1ac8b49c23449a5466ebfa
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Patch permission denied error in DNS test
+- commits:
+  - body:
+- version: 1.26.3
+- date: 2020-10-25T20:35:35Z
+- commits:
+  - hash: 7e44770c356a3410e34232c868f4cd5642ed3df0
+- commits:
+  - author: Roman Mazur
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Roman Mazur <roman@balena.io>
+- commits:
+  - subject: Revert "Add integrity check on file uploads"
+- commits:
+  - body:
+- version: 1.26.2
+- date: 2020-10-23T14:48:52Z
+- commits:
+  - hash: e5fc2889950300dd64a02411f7bcd492ac5054c5
+- commits:
+  - author: Vipul Gupta
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Replace url property with HTTPS for versionbot
+- commits:
+  - body:
+- version: 1.26.1
+- date: 2020-09-28T05:46:39Z
+- commits:
+  - hash: 1318717db41cd1e30816d503633bfbf6166a4b43
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Add integrity check to file upload
+- commits:
+  - body:
+- commits:
+  - hash: bcb4ab9c744066d4a47a4810d14d5e15ea0e60d0
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Improve message when fingerprint test passes
+- commits:
+  - body:
+- version: 1.26.0
+- date: 2020-08-12T13:38:56Z
+- commits:
+  - hash: 06a9cbcffb781d2dc48ab7dc5b5caf41d43f0163
+- commits:
+  - author: Roman Mazur
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Roman Mazur <roman@balena.io>
+- commits:
+  - subject: Add device info to reports file name
+- commits:
+  - body: It also adds ability to write TS in the client code.
+- version: 1.25.1
+- date: 2020-07-16T15:48:44Z
+- commits:
+  - hash: cdb5d87eacc5355cc44384bfce2362714076781e
+- commits:
+  - author: Roman Mazur
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Roman Mazur <roman@balena.io>
+- commits:
+  - subject: Fix DUT serial output download logic
+- commits:
+  - body: |-
+      The previous version was incorrectly triggering the download from
+      the signal handlers, which was not doing anything in the case of normal
+      process completion.
+- version: 1.25.0
+- date: 2020-07-13T13:59:15Z
+- commits:
+  - hash: 878dd203a1b3e13671518ef3d425722f505bda7d
+- commits:
+  - author: Roman Mazur
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Roman Mazur <roman@balena.io>
+- commits:
+  - subject: Capture DUT serial output
+- commits:
+  - body:
+- commits:
+  - hash: 3a82504c14303bf756492d89d44830471393ab59
+- commits:
+  - author: Roman Mazur
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Roman Mazur <roman@balena.io>
+- commits:
+  - subject: Remove qemu from available impl options
+- commits:
+  - body: The librarry we use (libvirt) is not compatible with Node 12.
+- commits:
+  - hash: 5f27c53740f83477ac33faff998fe89a79e86ade
+- commits:
+  - author: Roman Mazur
+- commits:
+  - footers:
+      signed-off-by: Roman Mazur <roman@balena.io>
+- commits:
+  - subject: Improve logging
+- commits:
+  - body:
+- version: 1.24.4
+- date: 2020-07-08T09:01:03Z
+- commits:
+  - hash: 1aa6246317ceeac088ff0bf87f328624706667e0
+- commits:
+  - author: dependabot[bot]
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: dependabot[bot] <support@github.com>
+- commits:
+  - subject: Bump npm from 6.13.4 to 6.14.6 in /core
+- commits:
+  - body: |-
+      Bumps [npm](https://github.com/npm/cli) from 6.13.4 to 6.14.6.
+      - [Release notes](https://github.com/npm/cli/releases)
+      - [Changelog](https://github.com/npm/cli/blob/latest/CHANGELOG.md)
+      - [Commits](https://github.com/npm/cli/compare/v6.13.4...v6.14.6)
+- version: 1.24.3
+- date: 2020-07-07T12:50:30Z
+- commits:
+  - hash: e78ae441edbd9bb332e6e59e8302e4f7571ccf64
+- commits:
+  - author: Roman Mazur
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Roman Mazur <roman@balena.io>
+- commits:
+  - subject: Store test report per worker device
+- commits:
+  - body:
+- version: 1.24.2
+- date: 2020-06-29T13:48:24Z
+- commits:
+  - hash: 5a2560bc2e3ae74712b12141a525f5458a69d97c
+- commits:
+  - author: Roman Mazur
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Roman Mazur <roman@balena.io>
+- commits:
+  - subject: Pin glider version to avoid build issues
+- commits:
+  - body:
+- version: 1.24.1
+- date: 2020-06-16T14:28:25Z
+- commits:
+  - hash: ecc47f1822dc36488273ed8f5b791de05f91a1af
+- commits:
+  - author: Roman Mazur
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Roman Mazur <roman@balena.io>
+- commits:
+  - subject: Fix error handling
+- commits:
+  - body: |-
+      Previous version waas not handling errors reported by the on-device core service.
+      Also, avoid resetting the test suite in case of the init error in the core.
+- version: 1.24.0
+- date: 2020-06-16T08:29:44Z
+- commits:
+  - hash: fcb962d01a8ea62a0d1acd19b73d99e200818287
+- commits:
+  - author: Vipul Gupta (@vipulgupta2048)
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
+- commits:
+  - subject: Disable execution of Persistent Logging test
+- commits:
+  - body:
+- version: 1.23.4
+- date: 2020-06-12T06:40:15Z
+- commits:
+  - hash: 6d560ab3a4ce93ec3584f24909f14b1148f297a0
+- commits:
+  - author: Giovanni Garufi
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Giovanni Garufi <giovanni@balena.io>
+- commits:
+  - subject: Reword fingerprint test assertions for consistency
+- commits:
+  - body:
+- version: 1.23.3
+- date: 2020-06-10T08:55:30Z
+- commits:
+  - hash: db7987084f3185ad2c36731499cc8d4fea1109cd
+- commits:
+  - author: Roman Mazur
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Roman Mazur <roman@balena.io>
+- commits:
+  - subject: Add basic retry logic to client->core communications
+- commits:
+  - body:
+- version: 1.23.2
+- date: 2020-06-05T14:02:56Z
+- commits:
+  - hash: 610b14ed8cdace815610cdf6bbf781ea68f23e9e
+- commits:
+  - author: Roman Mazur
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Roman Mazur <roman@balena.io>
+- commits:
+  - subject: Report suite results back to the client
+- commits:
+  - body:
+- version: 1.23.1
+- date: 2020-06-04T17:02:17Z
+- commits:
+  - hash: cb82447c6906e80961969fb3637c7ca521069f4b
+- commits:
+  - author: Roman Mazur
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Roman Mazur <roman@balena.io>
+- commits:
+  - subject: Disable boot-splash test
+- commits:
+  - body: |-
+      We need to review this test implementation and think if there is a more efficient way to do it.
+      Also, an ability to run short/long tests would be helpful.
+- version: 1.23.0
+- date: 2020-03-15T11:14:52Z
+- commits:
+  - hash: a76b0864bb8fd8a51341aa07f028e9c6f8466677
+- commits:
+  - author: dependabot[bot]
+- commits:
+  - footers:
+      signed-off-by: dependabot[bot] <support@github.com>
+- commits:
+  - subject: Bump acorn from 7.1.0 to 7.1.1
+- commits:
+  - body: |-
+      Bumps [acorn](https://github.com/acornjs/acorn) from 7.1.0 to 7.1.1.
+      - [Release notes](https://github.com/acornjs/acorn/releases)
+      - [Commits](https://github.com/acornjs/acorn/compare/7.1.0...7.1.1)
+- commits:
+  - hash: 461cbebacb3322ada21d094cbe074c8ea7aafb9d
+- commits:
+  - author: Roman Mazur
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Roman Mazur <roman@balena.io>
+- commits:
+  - subject: Start using testbot SDK in leviathan
+- commits:
+  - body: So we use the same logic we test with e2e tests of the SDK.
+- version: 1.22.3
+- date: 2020-02-20T17:28:22Z
+- commits:
+  - hash: 382a514f6287eef21dcb8f300fc3f26c8f3eeaa6
+- commits:
+  - author: Roman Mazur
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Roman Mazur <roman@balena.io>
+- commits:
+  - subject: Add status LED indicator
+- commits:
+  - body:
+- commits:
+  - hash: 27f752297301015c5bb78ed3ba12061272ae5c53
+- commits:
+  - author: Roman Mazur
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Roman Mazur <roman@balena.io>
+- commits:
+  - subject: Fix wired connection configuration
+- commits:
+  - body:
+- version: 1.22.2
+- date: 2020-02-16T15:51:27Z
+- commits:
+  - hash: d7a446fa8df1d465e744ccc05f4696c04c5f8a31
+- commits:
+  - author: Roman Mazur
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Roman Mazur <roman@balena.io>
+- commits:
+  - subject: Bump contracts to v1.1.94
+- commits:
+  - body: To support RPi4 device type.
+- version: 1.22.1
+- date: 2020-02-05T08:51:18Z
+- commits:
+  - hash: 1a92fbc3e05cfa624537cd5dd213bfa0b0b3d6d5
+- commits:
+  - author: Roman Mazur
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Roman Mazur <roman@balena.io>
+- commits:
+  - subject: Ensure host network is used in the container
+- commits:
+  - body:
+- version: 1.22.0
+- date: 2020-01-29T18:09:45Z
+- commits:
+  - hash: ce3ff6dfe2f05ee9f396ccf0c1d3b14734a1852a
+- commits:
+  - author: Roman Mazur
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Roman Mazur <roman@balena.io>
+- commits:
+  - subject: Dockerize client
+- commits:
+  - body: |-
+      Allows running the client as a docker container.
+      Also, introduces the workspace directory that should be used for local/dev runs.
+- version: 1.21.6
+- date: 2020-01-17T13:14:53Z
+- commits:
+  - hash: f4fae1a6b585683c9177954ca0dd2e9a108ca1b6
+- commits:
+  - author: Roman Mazur
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Roman Mazur <roman@balena.io>
+- commits:
+  - subject: Move libvirt to optional deps
+- commits:
+  - body: This way, packages install can complete on MacOS.
+- commits:
+  - hash: 34e6bba436232381780cfdf3b5377256e92e63e0
+- commits:
+  - author: Roman Mazur
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Roman Mazur <roman@balena.io>
+- commits:
+  - subject: Remove unused jenkins download type
+- commits:
+  - body: |-
+      We currently don't use the jenkins download type (and don't plan to use it as is).
+      This also removes unzip package dependency with security problems.
+- commits:
+  - hash: ebb808454c797b904f91315b2b5468ce35b913d3
+- commits:
+  - author: Roman Mazur
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Roman Mazur <roman@balena.io>
+- commits:
+  - subject: Consolidate git hooks setup
+- commits:
+  - body: |-
+      Moving all lint dependencies to the root project.
+      This also fixes running eslint on the modiified files.
+- commits:
+  - hash: 379cdb1f6f5461c616ff08a092a5ad511209682c
+- commits:
+  - author: Roman Mazur
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Roman Mazur <roman@balena.io>
+- commits:
+  - subject: Perform clean install in Docker build
+- commits:
+  - body:
+- commits:
+  - hash: 7c94c310c51950fd063c5fc369566d62f45dcfa9
+- commits:
+  - author: Roman Mazur
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Roman Mazur <roman@balena.io>
+- commits:
+  - subject: Fix lint errors
+- commits:
+  - body:
+- commits:
+  - hash: 83fa27ec734bfacddaf040ba7cabcc1bb6987028
+- commits:
+  - author: Roman Mazur
+- commits:
+  - footers:
+      signed-off-by: Roman Mazur <roman@balena.io>
+- commits:
+  - subject: Fix worker initialization
+- commits:
+  - body:
+- version: 1.21.5
+- date: 2020-01-09T09:37:14Z
+- commits:
+  - hash: c82977249f75dd9dfcd30daaabaca2a329e329fb
+- commits:
+  - author: Giovanni Garufi
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Giovanni Garufi <giovanni@balena.io>
+- commits:
+  - subject: Add package-lock files
+- commits:
+  - body:
+- version: 1.21.4
+- date: 2020-01-08T17:18:39Z
+- commits:
+  - hash: 276e24a815e1985c29f28ac3ee91c3289d10e547
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Remove the /select route in favour of enviroment variable configuration
+- commits:
+  - body:
+- commits:
+  - hash: 06860ae336789e58f2e52b11a3f83d76c0c20651
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Rework teardown based on the removal of /select
+- commits:
+  - body:
+- commits:
+  - hash: 6744d23f1120b5f97638700e7086afb3ea490513
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Refactor test suites to not use /select anymore
+- commits:
+  - body:
+- version: 1.21.3
+- date: 2020-01-02T16:51:02Z
+- commits:
+  - hash: ce68d1bd4b2b0b32899066c8ad4a8f575e4a5902
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Fix exit code handling
+- commits:
+  - body:
+- commits:
+  - hash: 5e26f5bbaf25068bef63dd1c10becb37e62b8b18
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Trigger signal handling once, but still capture all
+- commits:
+  - body:
+- version: 1.21.2
+- date: 2019-12-20T08:42:39Z
+- commits:
+  - hash: bccc4feaa420caa6adce4dae798d913f10934cdc
+- commits:
+  - author: Giovanni Garufi
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Giovanni Garufi <giovanni@balena.io>
+- commits:
+  - subject: Rename managed and unmanaged test suites
+- commits:
+  - body:
+- version: 1.21.1
+- date: 2019-12-19T17:45:58Z
+- commits:
+  - hash: a72d025b6ff2131fbb039d6016cef336aa181fe8
+- commits:
+  - author: Giovanni Garufi
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Giovanni Garufi <giovanni@balena.io>
+- commits:
+  - subject: Add default configs for single and multi client
+- commits:
+  - body:
+- commits:
+  - hash: f041dab83873bf786c2bb1c8629e7d5c4cbad00d
+- commits:
+  - author: Giovanni Garufi
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Giovanni Garufi <giovanni@balena.io>
+- commits:
+  - subject: Update .gitignore to exclude logs and default conf
+- commits:
+  - body:
+- version: 1.21.0
+- date: 2019-12-19T15:05:32Z
+- commits:
+  - hash: 0ec26632881ef2c262e67d30ebccaaf0611b01ad
+- commits:
+  - author: Giovanni Garufi
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Giovanni Garufi <giovanni@balena.io>
+- commits:
+  - subject: Add OS fingerprint test
+- commits:
+  - body:
+- version: 1.20.5
+- date: 2019-12-18T16:09:19Z
+- commits:
+  - hash: d397babfa600eb069e039b04b9227110d803a2d6
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Support for the testbot HAT
+- commits:
+  - body:
+- version: 1.20.4
+- date: 2019-12-18T15:21:17Z
+- commits:
+  - hash: 3502bde931261293b71e1388f656cf309575a2de
+- commits:
+  - author: Roman Mazur
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Roman Mazur <roman@balena.io>
+- commits:
+  - subject: Fix run from non-bin director
+- commits:
+  - body:
+- version: 1.20.3
+- date: 2019-12-18T12:34:38Z
+- commits:
+  - hash: 5cbe0af8166cec47058f9145398fa5684a2e690a
+- commits:
+  - author: Roman Mazur
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Roman Mazur <roman@balena.io>
+- commits:
+  - subject: Fix flash error processing
+- commits:
+  - body: |-
+      Regeexp is changed to a greedy one to handle lines like
+      error: ENOENT: not such file or directory
+- version: 1.20.2
+- date: 2019-12-18T12:26:44Z
+- commits:
+  - hash: d3030f2a942e791f13d867795dbaa3e8ec0e53e3
+- commits:
+  - author: Roman Mazur
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Roman Mazur <roman@balena.io>
+- commits:
+  - subject: Fail fast when dbus connection cannot be established
+- commits:
+  - body: |-
+      A quick fix to ensure we fail fast if DBUS connection cannot be
+      initialized. Previously the test was hanging in this case.
+- version: 1.20.1
+- date: 2019-12-17T21:11:27Z
+- commits:
+  - hash: aa3a3072f8d7911f762fb4f619d9f36da383eb36
+- commits:
+  - author: Roman Mazur
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Roman Mazur <roman@balena.io>
+- commits:
+  - subject: Update the state when suite finishes
+- commits:
+  - body: |-
+      We could not perform 2 test runs in a raw without restarting the core
+      because of the missing state update when suite is completed.
+      Before the change, the state was updated from /stop handler only.
+- version: 1.20.0
+- date: 2019-12-17T20:56:56Z
+- commits:
+  - hash: 16caa6c91e89b5e7fa9d6f29a6444877373c9eee
+- commits:
+  - author: Roman Mazur
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Roman Mazur <roman@balena.io>
+- commits:
+  - subject: Add non-interactive mode
+- commits:
+  - body: Can be used to run the client from CI jobs.
+- version: 1.19.8
+- date: 2019-12-17T20:21:51Z
+- commits:
+  - hash: a4640a9c4544ae0003651f1221b6644c84618b00
+- commits:
+  - author: Roman Mazur
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Roman Mazur <roman@balena.io>
+- commits:
+  - subject: Fix hanging suite process
+- commits:
+  - body: Before the change, the process was hanging awaiting IPC messages.
+- version: 1.19.7
+- date: 2019-12-17T16:31:10Z
+- commits:
+  - hash: ed8129184ad8011aa9deb102dcca2305a3f7e22e
+- commits:
+  - author: Roman Mazur
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Roman Mazur <roman@balena.io>
+- commits:
+  - subject: Fix error handling for the missing target drive
+- commits:
+  - body: |-
+      Previous implementation was not handling the thrown exception and
+      test was hanging instead of being terminated.
+      Example error: "Cannot find /dev/sda" (when SD card is missiing).
+- version: 1.19.6
+- date: 2019-12-17T09:19:47Z
+- commits:
+  - hash: 7b922b8980b13cac71486d1da4fcffa5ae897444
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Fix cli usage and other bugs
+- commits:
+  - body:
+- commits:
+  - hash: 886b4c7d6bbccd682baf69abd6486fae50c9e3df
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Inject logger in object state
+- commits:
+  - body:
+- commits:
+  - hash: a02b2542366acc0b547f6f7ca489bda5bda73a9b
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Fix some teardown related issues
+- commits:
+  - body:
+- commits:
+  - hash: 22b8212281486f53f9868683d0644601bfb050fd
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Fix panel width alignment
+- commits:
+  - body:
+- commits:
+  - hash: 7d613593891d2a1b36958b06e9acf6618647a2bc
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Move repository information files back to the top level
+- commits:
+  - body:
+- commits:
+  - hash: cce35199398f28c15542efc9029d702de0c8da81
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Remove relic CI configuration
+- commits:
+  - body:
+- commits:
+  - hash: f493224f4b4b241a598563c43b2cf159d1427dd1
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Add required reviewers to balenaCI
+- commits:
+  - body:
+- commits:
+  - hash: f6aa4cc998d4abedec1eacc42adf6de3ddf12eb5
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Mark project as private
+- commits:
+  - body:
+- commits:
+  - hash: b3ad8c7e16d8cc6c2921c0d812ad7eac9a3405ed
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Clean package-lock leftovers
+- commits:
+  - body:
+- commits:
+  - hash: 515ab658ceb62cbc229b7b6104edd6673dc0f70e
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Add forgotted lint configuratino
+- commits:
+  - body:
+- commits:
+  - hash: fcfb998919765dbe9bf9f78d8e4377eddc78fc1a
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Increase upload timeout
+- commits:
+  - body:
+- commits:
+  - hash: c295830480aae2885ef748b6692b6fd022a51a86
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Fix bugs introduced in code refactor
+- commits:
+  - body:
+- commits:
+  - hash: 4a1c80abf0b3e59e5796f58d861c5a3d272f334c
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Refactor message passing to only allow clients to format messages
+- commits:
+  - body:
+- commits:
+  - hash: a95fde6c61f9560cd8654f83c86d5eafad960ed8
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Catching up the client with core code
+- commits:
+  - body:
+- commits:
+  - hash: 3303d6a3a6a149870b65a82adb58a8cf2f29d206
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Catch up our suites with the new architecture
+- commits:
+  - body:
+- commits:
+  - hash: c45f4d2d3c9528d3cde92c0e33fd683f2ddac250
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Add State fixup
+- commits:
+  - body:
+- commits:
+  - hash: afa3dc240861448276c1183ccb90a2517e540642
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Standardise common parts of our components and move as a top level npm
+      package
+- commits:
+  - body:
+- commits:
+  - hash: ec1e24d7f435c85e47588fcba7b798a0a148c51b
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Remove lock files
+- commits:
+  - body:
+- commits:
+  - hash: d23815d90d6c4f20dabd4959080cdad021a38f49
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: No need to add prettier configuration in our container
+- commits:
+  - body:
+- commits:
+  - hash: 59863377f19898f4ae3739f32ac58c0c5d100c9a
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Fix teardown bug when still flashing the testbot
+- commits:
+  - body:
+- commits:
+  - hash: 3670126fc81cbf656600b8d5b6e890b3d64c8676
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Make clients take advantage of the new logging system
+- commits:
+  - body:
+- commits:
+  - hash: 806bf132e2d5487e31402fe41e51d8df3e56055f
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Fix some messaging issues
+- commits:
+  - body:
+- commits:
+  - hash: e32f5342cd07de44764602103e0fb08371f9ed4f
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Move .eslintrc to the top level
+- commits:
+  - body:
+- commits:
+  - hash: 63eff81d8dec4329d5038da928a9841fe2a56ba1
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Remove the need to pass CI as we can determine the style of output on
+      the tty properties of a stream
+- commits:
+  - body:
+- commits:
+  - hash: 08054e906224fa686f324743a16eade3d84fa45a
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Check lock has not been released already by another action
+- commits:
+  - body:
+- commits:
+  - hash: 65c29e4293f81dbddd81940f7ed46ae8a5e2221c
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: For a multi run with TTY attached, let us used ncurse like output
+- commits:
+  - body:
+- commits:
+  - hash: 08a163ae68e0796be60250224cd429d982565365
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: General bugfixes and enable scrollable content
+- commits:
+  - body:
+- commits:
+  - hash: 1201dae77ba3445270fb5e258d0d8d7278db4457
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Improve blessed output
+- commits:
+  - body:
+- commits:
+  - hash: d931fa6bf535ae81c0f82b92fb8f8b0767f4edf9
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Re-work the way we pass deviceType so we do not have to duplicate the
+      value
+- commits:
+  - body: |-
+      Allow for `-p` option, where we can print the whole output to console.log regardless
+      of the runtime display; usefull for CI/CD.
+- commits:
+  - hash: ad019aeec9c5682d468bb970c15282a7e1961a09
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Make /dut/ip call retriable
+- commits:
+  - body:
+- commits:
+  - hash: a1485f75894ebc498e0eb71d8ec17f95353932f3
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Show errors better in our blessed client
+- commits:
+  - body:
+- commits:
+  - hash: 2aa55a95be8b04148a78f0dd83364f476afb30ff
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Fix early error on non awaited promise
+- commits:
+  - body:
+- commits:
+  - hash: 2ccc6132513b402c040b696361a00f220ce18886
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Select appropriate tests in the os suite for the production flavours
+- commits:
+  - body:
+- commits:
+  - hash: b057248a58f9ac4964e37e2d2d11ba14d27a6df8
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Define structure to expose test artifacts
+- commits:
+  - body:
+- commits:
+  - hash: a340c37679ffbce9bafcffd9c149bca650479dbb
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Fix artifact paths
+- commits:
+  - body:
+- commits:
+  - hash: e4e8ce52a7bc4a45304dddf187491a8a81dc6558
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Implement archive functionality
+- commits:
+  - body:
+- commits:
+  - hash: 681d1842c8094c65085958803c7186aa49c341e3
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Do not bring the service down if we cannot connect the dbus
+- commits:
+  - body:
+- commits:
+  - hash: 34df7bf4331c42e9d5c6d758b566c24a5d2109f3
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Fix display for early errors
+- commits:
+  - body:
+- commits:
+  - hash: f042a5001bb82816839418790997e1051036100f
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Retry gstream pipeline kill if we could not kill it
+- commits:
+  - body:
+- commits:
+  - hash: 8b51073c9ca034a657b0c21672902e8c29efe5d9
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Make archiver take streams and handle them properly
+- commits:
+  - body:
+- commits:
+  - hash: 051db9d5ef5885bfcb0879b8db76f0eb8d7dc02e
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: In case the resolution was not properly negotiated, crop all sides
+- commits:
+  - body:
+- commits:
+  - hash: b9ca1e6b421fd7e42fa1ed9380727d2204bfab00
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Rework the teardown mechanism for our network controller
+- commits:
+  - body:
+- commits:
+  - hash: d644c712016dd5bb58240c9d1a0bd22d41645d27
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Increse delay to make sure commands are executed on the testbot
+- commits:
+  - body:
+- commits:
+  - hash: a51b37fc049d994aeace1f6bea53a009e8944e4a
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: As the ip interface has it's own retry, let's not repeat that
+- commits:
+  - body:
+- commits:
+  - hash: 8edeaf1399dcd79e335401829d61c76cbb4b9a35
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Fix typo
+- commits:
+  - body:
+- commits:
+  - hash: 786c7e25f4b75724a48df2b9a50e64b9d8410319
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Handle service config with real configuration files
+- commits:
+  - body:
+- commits:
+  - hash: 4d772363254c56e5523d02a2913d91f9ed0a24c3
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Remove all naming scheme
+- commits:
+  - body:
+- commits:
+  - hash: d2135a8865ba1a6c3e3629b3e87c2cf05db137f5
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Fix typo
+- commits:
+  - body:
+- commits:
+  - hash: c1a1da2681b01139bfdc62e5c9207a4917e5078d
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Implement multi-client
+- commits:
+  - body: |-
+      Provides worker discovery.
+      Config validation via JSON schemas.
+- commits:
+  - hash: 484b2aba56e9625345235fd3e4e5a4363d098261
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Be more optimistic about our lockingnparadigm
+- commits:
+  - body:
+- commits:
+  - hash: eba8554731ee0680e0532028ef674234f47661e6
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Make our client es5 runnable
+- commits:
+  - body:
+- commits:
+  - hash: bb14aca50ba305a068cf8f38008bcab4c9133f23
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Fix indentantion
+- commits:
+  - body:
+- commits:
+  - hash: 249bafc23ed604fd746553e013af5ee2924d39c7
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Pass more information back to the client to determine errors
+- commits:
+  - body:
+- commits:
+  - hash: 9828e4072cc74c78413526ca37d1de627b35583d
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Treat SIGTERM as kill signal too, this is to deal with CI services that
+      send SIGTERM to the process on cancel
+- commits:
+  - body:
+- commits:
+  - hash: 668e725bffc0aee99a44d6fc9f040d0cc1bff7ca
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Wrap resin-cli-visuals to make CI output safe
+- commits:
+  - body:
+- commits:
+  - hash: 40a31cbd839f0240390aaf9b58ae98641ca14ecc
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Inform core we are running the client in CI mode using the protocol header
+- commits:
+  - body:
+- commits:
+  - hash: ea2c73f13a09b722ab1d3beedc3e6fa35a6b4446
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Fix typo
+- commits:
+  - body:
+- commits:
+  - hash: 88b410a584e600545e98239839b9e7a3d0f14571
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Improve websocket usage
+- commits:
+  - body:
+- commits:
+  - hash: 906aedfec990fd3732027ba57ad727e18c8ef5a2
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Fail our execution until our service reports success
+- commits:
+  - body:
+- commits:
+  - hash: af5cf1d4e8d3cdecceb37fe6ed36b5199096340c
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Fix deadlock and connection being dropped
+- commits:
+  - body:
+- commits:
+  - hash: d43217d7e92a33ebf03203353f441e64df42437f
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Prevent unnecessary calls to stop the spinner
+- commits:
+  - body:
+- commits:
+  - hash: b6f195128b884d67c9916d52b07a5da7af66c95a
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Provide shorthand for tests to require modules from core
+- commits:
+  - body:
+- commits:
+  - hash: dff2e0d6664bc3bdb8f23484a96ff79515d98a54
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Small fixes across the project
+- commits:
+  - body:
+- commits:
+  - hash: 5b2a828da4554e6f4717dcbb9e55649ac047c851
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Improve client locking
+- commits:
+  - body:
+- commits:
+  - hash: 7009b85daaa17931d10f15beab6b29fb2bb915d9
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Merge supervisor suite into the OS suite as per internal discussion
+- commits:
+  - body:
+- commits:
+  - hash: a8b3ab106565a7ec73229498cfc2c65cfaded53b
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Allow configuration of waitUntil ignore promise rejection
+- commits:
+  - body:
+- commits:
+  - hash: b617d0d21dee1a23338479fbe389a93a217b1003
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Automate blink led test
+- commits:
+  - body:
+- commits:
+  - hash: 9e2cfec3c96549c38d84200b15e5a22e6deb0ed5
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Improve our Makefile with a DRY option, and argument validation
+- commits:
+  - body:
+- commits:
+  - hash: 71ff8223c572863bed8f6adc61672b2aff05099e
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Provide mechanism to capture video of our devices
+- commits:
+  - body: |-
+      Upgrade worker base images to buster to take advantage of the latest
+      gstreamer version. Re-work a bit of the options flow.
+- commits:
+  - hash: f4cc06e929ecee9ada1894e7d4e03855a0272f11
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Upgrade core base images to buster to match the worker
+- commits:
+  - body:
+- commits:
+  - hash: 359ec796032e7a67cc84092b8d96b3bd126d1f31
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Do not ignore docker-compose link as the remote balena builder will ignore
+      it too
+- commits:
+  - body:
+- commits:
+  - hash: c33636af762755a46b267d60be026a3072b8cd47
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Remove SIGINT handler just once, otherwise we might end up in a case
+      where we cannot SIGINT the process.
+- commits:
+  - body:
+- commits:
+  - hash: 8c13acb75e831e807352ec79a05194bf860403b9
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Show full error when we cannot find a module, to identify nested errors
+- commits:
+  - body:
+- commits:
+  - hash: 0a3917e4c7ef8d82adb71bf87c929f99828cf63b
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Make os filename more generic
+- commits:
+  - body:
+- commits:
+  - hash: e7c1098f63fb68a1fb796eac1bb87559b799410f
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Wait for the reboot check to pass
+- commits:
+  - body:
+- commits:
+  - hash: 34019484cdb51bee650a1276530a4450633488c2
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Implement screen capture test
+- commits:
+  - body:
+- commits:
+  - hash: afb2ed4f5d3d6f6adb0b299255246705aeaefbbf
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Remove old artifacts before uploading
+- commits:
+  - body:
+- commits:
+  - hash: 077755d73036465960d50b4facd710b74a91557a
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Handle stream errors
+- commits:
+  - body:
+- commits:
+  - hash: 6bb43265eac8e013435c0fdbb0b2c42bee3330f0
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Re-factor os parent test for clarity
+- commits:
+  - body:
+- commits:
+  - hash: 024003ae486c2119b8e7e175823fed704d8e1acf
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Prevent express from killing our capture reponse
+- commits:
+  - body:
+- commits:
+  - hash: bc26f560a3f027b95475ac1cbac97bcc733089a2
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Improve persistentLogging tests
+- commits:
+  - body:
+- commits:
+  - hash: 0346beda58693fe603fc86a8ffee952967cdd9d8
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Remove old artifact
+- commits:
+  - body:
+- commits:
+  - hash: b735e8fa0aa83e15de0b2264946d1a01db0f5e60
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Re-work the way we run reboots over SSH
+- commits:
+  - body:
+- commits:
+  - hash: 844b6247b2e0772ad3f8a86853d5fe489cb13431
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Remove any libvirt cgroup functionality as we do not use any of it
+- commits:
+  - body:
+- commits:
+  - hash: 85cf3bdf3532ae4568a0ebbc84533953377479e2
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Let our Makefile deal with the docker-compose linking
+- commits:
+  - body:
+- commits:
+  - hash: afac9c727de491cb16dfc1be13124ae4a528785d
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Make contracts a submodule
+- commits:
+  - body:
+- commits:
+  - hash: c54447200839a040721330344b5c74ae764ea2e8
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Refactor old code
+- commits:
+  - body:
+- commits:
+  - hash: 9810b1efe890ebd40f8afc469d85c46f523e8071
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Ignore the link to the compose
+- commits:
+  - body:
+- commits:
+  - hash: f79f2958d60d3d32a7d4b038f61640adbb41ef37
+- commits:
+  - author: Gergely Imreh
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Gergely Imreh <gergely@balena.io>
+- commits:
+  - subject: The file should be CODEOWNERS, not what it was.
+- commits:
+  - body:
+- commits:
+  - hash: 7f1140cdc28b9a9c6da083abf981f7db0f46a78d
+- commits:
+  - author: Gergely Imreh
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Gergely Imreh <gergely@balena.io>
+- commits:
+  - subject: Add MAINTAINERS file
+- commits:
+  - body:
+- commits:
+  - hash: dfdb8e29bb2601bc274334b833de2f6c957826be
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Handle premature end of stream when cache is being used
+- commits:
+  - body:
+- commits:
+  - hash: bfedc6979179d49dfe17cd85bb2c20b704339e06
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Protect against slow connection
+- commits:
+  - body:
+- commits:
+  - hash: ca67334b08aa4511604a57343b70889cab62de7b
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Remove all other identities before adding the new one
+- commits:
+  - body:
+- commits:
+  - hash: d5150a7d3569fc29267736462a7c23667683493e
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Remove dead code
+- commits:
+  - body:
+- commits:
+  - hash: 9770654b63a67f625b223ec0052e74881fa2b352
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Change the way we check for reboot and update tests
+- commits:
+  - body:
+- commits:
+  - hash: 143985c3e12c6e373eb602f084a632c4bdee868d
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Implement artifact caching
+- commits:
+  - body:
+- commits:
+  - hash: ec1088cc85f531b59eeb71803657633362164f5b
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Make flash cancellable
+- commits:
+  - body:
+- commits:
+  - hash: 3117087066b5bf9ea049209365c9389e0218fc7f
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Implement heartbeat to keep websocket alive
+- commits:
+  - body:
+- commits:
+  - hash: 74048e1f789ea5223b4ae582623f8c46501350ea
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Fix network manager dbus backend
+- commits:
+  - body:
+- commits:
+  - hash: 90e431439e618f73f119843a82a6b1dc3a029130
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: 'worker: move to a native dbus backend, to fix some network related bugs'
+- commits:
+  - body:
+- commits:
+  - hash: 95ab53d32f52153432bc785303b5c61af2f46f4d
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Rework network environment flow
+- commits:
+  - body:
+- commits:
+  - hash: b1ad83a91d1a82aaa757fad80af268e881bd4c35
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Remove unused dependecies
+- commits:
+  - body:
+- commits:
+  - hash: c83b9defb5c29a5a531d4db677c685e508a3eef9
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Lock core's dependencies
+- commits:
+  - body:
+- commits:
+  - hash: d57ff74c97a22681f922076116bfe66a4296a4f7
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Handle SSH errors properly and fix device reboot test
+- commits:
+  - body:
+- commits:
+  - hash: ee060ddc1807ecefeaebc39cfeaf0bc7b0ed1663
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Refactor Suite to allow multiple setup steps
+- commits:
+  - body:
+- commits:
+  - hash: 7aa3d37a916f2987d55fc1f1c80cb476f97ac6c1
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Allow OS to keep offline state
+- commits:
+  - body:
+- commits:
+  - hash: cb6b363b624610a5914c59800953f1ff490a06b9
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Allow tests to define subtests
+- commits:
+  - body:
+- commits:
+  - hash: 5cc2b9b2e7654e571197937be986cfed402bc75e
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Implete register tests
+- commits:
+  - body:
+- commits:
+  - hash: f6802ff2ad7598a8a8312a1838fdf3862d9c5ccc
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Pass down tmpdir
+- commits:
+  - body:
+- commits:
+  - hash: c4d3a12f4375ae65a768015c6caac3ba4f15b17b
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Implement DeviceApplicationActionable
+- commits:
+  - body: |-
+      The class is aimed at representing the action flow of deploying an
+      application onto a balena device. From cloning all the way to waiting
+      for the application to download.
+      One needs to see this class as chain where each node only
+      exposes the next possible set moves.
+- commits:
+  - hash: 66a4e39860d82828fa7e815b15283508925acf8a
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Implement the preload test
+- commits:
+  - body: This commit also bring docker in our container as it is needed by the preload
+      process.
+- commits:
+  - hash: 7151aac287c97078d74a4983a825ea7f2ea03d43
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Upgrade tap version to latest
+- commits:
+  - body:
+- commits:
+  - hash: 9b51cec5b5db1c95ce882fefb999801e339764ac
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Allow tests to register, test specific teardowns
+- commits:
+  - body:
+- commits:
+  - hash: ab1ef6264cd465c08fe64ff58362a68b51ccfe81
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Generalize our wait function
+- commits:
+  - body:
+- commits:
+  - hash: 4a20d939db9fd6b2ca1c763af094f478595c32ed
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Implement move device between applications test
+- commits:
+  - body:
+- commits:
+  - hash: e85aa55241c32888e691d25562abd0cf5429eb15
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Implement OS update test
+- commits:
+  - body:
+- commits:
+  - hash: 88627de4681ccb4b00bab6b01c56a13f472c7488
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Refactoring and speed improvments
+- commits:
+  - body:
+- commits:
+  - hash: b7097c17e270119fa24913380037413d1b04aa31
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Configure tests to bail on the first failed assert
+- commits:
+  - body:
+- commits:
+  - hash: f21a21b9112f69ff1ce23eac843805be09974ac7
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Improve waitUntil to be resilient to rejects
+- commits:
+  - body:
+- commits:
+  - hash: ec5ad65c14e4a96dd3ceea7dae2a89e65569171e
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Implement supervisor API tests
+- commits:
+  - body:
+- commits:
+  - hash: 78925851d02ec2e4f4aab053b4ce6f6c70c5a430
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Make sure the supervisor api is up before trying to trigger an update
+- commits:
+  - body:
+- commits:
+  - hash: 6548393f5006428bc5b41bc7eee1db5b6f3b3889
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: FIXUP on API implementation
+- commits:
+  - body:
+- commits:
+  - hash: 75fa3be07d8bbf32b58f320b86e535102d3fb1be
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-log: minor
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Re-work core test tree representation
+- commits:
+  - body: |-
+      In order to know all test requirments when we discover
+      them we need to maintain the whole tree in memory.
+      We need this to be able to specify contracts per test check weather we satisfy them
+      before we run the tests. This also cleans up the test API.
+- commits:
+  - hash: 440c85559e978f7ac33c5b25e74c107d01c193c8
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Implement tests for supervisor download strategies
+- commits:
+  - body:
+- commits:
+  - hash: 5d5608813f65dfb1c1196ad81342da69fa5bbf5a
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Remove testlodge suite as it is a relic now. Move to new worker architecture
+- commits:
+  - body:
+- commits:
+  - hash: 2f54f9325080b66c407165c7efb9a156bd516c31
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Allow users to expose their host ssh-agent to the framework
+- commits:
+  - body:
+- commits:
+  - hash: 40d489a46e928fac49775b09d3d8ef3b0f668aa0
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Clean Dockerfile up
+- commits:
+  - body:
+- commits:
+  - hash: e38caddb2a854803c02d4c6620dddc967790d605
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Get contracts internally
+- commits:
+  - body:
+- commits:
+  - hash: 345786f2395ec46c4c81e32250e8556e3a0531b9
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Do not add the tunneling overhead, just rely on retry if anything goes
+      wrong
+- commits:
+  - body:
+- commits:
+  - hash: 455917013155638bf0822da7cdfe3cb096e70e6e
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Give worker the ability to ssh to unmanaged devices
+- commits:
+  - body:
+- commits:
+  - hash: fd9179d290e50ddb372f97b4a10836c9332d601e
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Start implementing os test suite
+- commits:
+  - body: |-
+      Tests impletemented:
+      - boot-splash
+      - connectivity
+- commits:
+  - hash: 9eff3fcd7ab294bcc7e46e52bae684f8988cebe3
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Implement os contracts and skip functionality
+- commits:
+  - body:
+- commits:
+  - hash: 280c2f69896c9f8d383fde9455fd883cc28b8078
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Implment balenaOS testing suite
+- commits:
+  - body:
+- commits:
+  - hash: 8a4eea2e5b8889f54e8d474431f8a1179790bb97
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Prepare for move
+- commits:
+  - body:
+- version: 1.19.5
+- date: 2019-04-29T10:14:31Z
+- commits:
+  - hash: 87e9bc952747e5919769918672d0c2777e8503c1
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@balena.io>
+- commits:
+  - subject: Fix some formatting issues.
+- commits:
+  - body:
+- version: 1.19.4
+- date: 2019-04-26T09:40:19Z
+- commits:
+  - hash: 11edc8b4f7d716a482cc06f8b81c6037bb0a3dcc
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Rename e2e suite to testlodge
+- commits:
+  - body:
+- commits:
+  - hash: ca46836b206d9d46a586b8ee48c0b3e0f56ea2dd
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: 'Add TC40: Test Chrony and NTP time sync'
+- commits:
+  - body:
+- commits:
+  - hash: b47bac135d0637e012c0b672ad0b13f6d96f3202
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Add TC39 - Kernel module build
+- commits:
+  - body:
+- commits:
+  - hash: efd005607863c4079108298361c3d9531131fe0b
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Add TC42 - Local Mode
+- commits:
+  - body:
+- commits:
+  - hash: 825d87a96aee30c905590ee07a166e51957e7455
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Add TC35 - Provision on supported modems
+- commits:
+  - body:
+- commits:
+  - hash: 580c9f540637346e0c5867399a64ca8b7cd4d85d
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Add TC43 - Pinning device
+- commits:
+  - body:
+- commits:
+  - hash: 65f01dc21370056e095faa016ebd7d3b05c98bff
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Add TC28 - Test old to new resin host OS update (old hostapps enabled
+      OS updated to current hostapps enabled OS)
+- commits:
+  - body:
+- commits:
+  - hash: b07708db808d7b8c411f60b8b26ad28fefd16ba5
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Add TC33 - HTTP proxy test
+- commits:
+  - body:
+- commits:
+  - hash: 12e69a28199ee40db5a6c6d9f675504d8d888db7
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Add TC25 - SOCKS proxy test
+- commits:
+  - body:
+- commits:
+  - hash: ea19fc2adc0f6ddbf8df1afa7c2c4edf609421c1
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Add TC49 - Override lock
+- commits:
+  - body:
+- commits:
+  - hash: 93a53b792e17b721a756e0fdc58c2e5ab321ffbe
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Enable the rest of the tests
+- commits:
+  - body:
+- commits:
+  - hash: eccbb3eea8f880cfc593cc2fc645b59783b21096
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Mirror Testlodge titles
+- commits:
+  - body:
+- commits:
+  - hash: 627db8205441ad76d17b56a7c58ccb6699dbac52
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Add TC41 - Test Persistent Logging
+- commits:
+  - body:
+- commits:
+  - hash: 2d98518d7913fcbcbab2532221e7e5f841a485be
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Add TC09 - Normal provisioning without deltas
+- commits:
+  - body:
+- commits:
+  - hash: 816ce4e122aa603ea799f3203d59d2252cd8c136
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Add TC10 - Adding deltas to a running supervisor
+- commits:
+  - body:
+- commits:
+  - hash: 4f8b110a2c8e221fe2f9c61139363d1a798fa571
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Add TC11 - Provisioning a device with deltas already enabled
+- commits:
+  - body:
+- commits:
+  - hash: 4bc7b4e4f5466d8a30ed569c127d558642e7ef50
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Bugfixes
+- commits:
+  - body:
+- version: 1.19.3
+- date: 2019-04-08T13:59:49Z
+- commits:
+  - hash: 697f023b0d29d18a173a8665dfc34b5959acdc5a
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: 'README.md: Add documentation on running the framework'
+- commits:
+  - body:
+- version: 1.19.2
+- date: 2019-04-01T14:24:29Z
+- commits:
+  - hash: 1dc1f2a6bf94a9d9f7771f25169378b96b1745a7
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Provide run queue summary
+- commits:
+  - body: |-
+      When we start running we print a summary of our test plan.
+      Rename interactive tests to flag them clearly.
+- commits:
+  - hash: fd928c31c6085f06412c31d96bfd83fc95f957b1
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Update README
+- commits:
+  - body:
+- commits:
+  - hash: 09e5f29332abb80c9c13a65385b1a31ec59b4dfd
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Move base images to stretch to include required package versions
+- commits:
+  - body:
+- commits:
+  - hash: 9ce6d3d8844cc069ca709a8844dd016334836f2c
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Remove lodash lint enforcer
+- commits:
+  - body: Fix some formatting issues
+- version: 1.19.1
+- date: 2019-04-01T12:19:22Z
+- commits:
+  - hash: c81b02740c314a1aa88f6845ab994d0890c74bd4
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Enable prettier and reconfigure eslint to cope with our pretier
+- commits:
+  - body:
+- commits:
+  - hash: a1f9ed0d39a1a39aca0be58d51563aca8ab7fa58
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Revert to standard require style
+- commits:
+  - body:
+- commits:
+  - hash: ec338409b1672cb2a39bc332440899ce848e1508
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Use etcher-sdk when writing images
+- commits:
+  - body:
+- commits:
+  - hash: 7ed8939d0414637281678e91f6344cc69a3b040d
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Define remote worker
+- commits:
+  - body: |-
+      This worker expectes a worker API to be exposed on the define URL.
+      The definition for this API can be found here: https://github.com/balena-io/leviathan-worker/blob/master/lib/index.ts
+- commits:
+  - hash: b0a44dccebc1e78ef79cd6d50c6b51aec593d128
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Provide image locally to the docker container
+- commits:
+  - body:
+- commits:
+  - hash: 73088e45574225bcd329c6e464d6d8fa78b4ada7
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Extract version from the image itself
+- commits:
+  - body:
+- commits:
+  - hash: 8cffa15c74e6e9de5a70081436a8d003a6a9ddc0
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Ignore node_module from docker context
+- commits:
+  - body:
+- commits:
+  - hash: 57d7ba5316eb1094d7f9f4b9215dc7a102e08932
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Move to fp instance of lodash for clear syntax
+- commits:
+  - body:
+- version: 1.19.0
+- date: 2019-01-10T16:22:59Z
+- commits:
+  - hash: c5c20ec63ccb386ec9db7ff5e4098dc6639cea87
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Re-work tests structure
+- commits:
+  - body: Define suites with individual setup and teardown.
+- commits:
+  - hash: dd754076c48296b1fcedec105ae5a43a5c7cee21
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Introduce new classes to centralize functionality
+- commits:
+  - body: |-
+      New classes: Suite, Teardown.
+      The suite is a npm package now, so the work to deal with the npm dependencies
+      reside in the Suite class.
+      The teardown class will collect and run on request the functions registered.
+- commits:
+  - hash: d39cae7a58ccbecaf7d3ac94031f1cd9b69b2f30
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Refactor options, limitting to scope for most options
+- commits:
+  - body: |-
+      Options will now be mainly define in the user's test suite as ${suiteName}.conf
+      Framework wide options can be found in the Suite class
+      Refacto BalenaOS class
+      - Allow local fetch of images.
+      - Integrate with Jenkins configurations.
+- commits:
+  - hash: a1f632e18576c0f30a1f9561efca630e74c85265
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Instead of passing a private key around rely on a ssh agent
+- commits:
+  - body: The environment should provide a SSH_AUTH_SOCK where we can access a ssh-agent.
+- commits:
+  - hash: 8610b43790ca7f734ee32c8c976de7ee5a39256d
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Clean package.json dependencies
+- commits:
+  - body:
+- commits:
+  - hash: b0073e9ec00975e777f25b5b65529696b9669bb8
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Pass suite location directly to the framework
+- commits:
+  - body:
+- version: 1.18.8
+- date: 2018-12-11T15:39:25Z
+- commits:
+  - hash: 594ee6fe5ae8dfffc31d6849b1bc21d6e3966ef1
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Change the order of the tests
+- commits:
+  - body:
+- version: 1.18.7
+- date: 2018-12-10T08:34:28Z
+- commits:
+  - hash: ae9f75ed5f14514c1ea5594d70494b0d27067ce5
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Add test case to move device between applications
+- commits:
+  - body:
+- version: 1.18.6
+- date: 2018-11-30T07:19:40Z
+- commits:
+  - hash: 94effb63b42a5a329bcd3f471a55c16cc5e7812a
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Fix balena component for enabling delta due to providing a new component,
+      sync
+- commits:
+  - body:
+- commits:
+  - hash: 9c52f10555135f1fea3b2a6e7fae7ed599783896
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Fix balena component for bluetooth testing due to providing a new component,
+      sync
+- commits:
+  - body:
+- commits:
+  - hash: c322f1be6e301d3b22ab5316a39dd1d1717daa51
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - subject: Update reload supervisor test to accept resin and balena images
+- commits:
+  - body:
+- version: 1.18.5
+- date: 2018-11-28T22:29:02Z
+- commits:
+  - hash: a4e2772135d8ad6634110e5daa6857c597585235
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Provide search and replace function for files
+- commits:
+  - body:
+- commits:
+  - hash: 8d92a0fbce2f957184590a3fad05cc947952a3d6
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Fix syntax error when accesing object
+- commits:
+  - body:
+- commits:
+  - hash: e75605002fc3475795836549272aecca357f2bf6
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Provide another resinio component, sync
+- commits:
+  - body:
+- commits:
+  - hash: 7663a9d52a14802bdf62f500ff17284d7770b12c
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Automate resin sync test
+- commits:
+  - body: This test uses the remote sync ability provided by `resin-sync`
+- version: 1.18.4
+- date: 2018-11-27T18:16:03Z
+- commits:
+  - hash: 58ba88204ea188d89b57a345c8b2252a877b7fde
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Use ssh written purely in node
+- commits:
+  - body: Hopefully this will make the connection more reliable
+- commits:
+  - hash: 3f09f2bc8ff6907609f26e270048fbde9a75bcdf
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Refactor SSH connection
+- commits:
+  - body: |-
+      Before requesting an SSH connection from the resin-proxy check if we can succesfully establish
+      a tunnel to the device, only then attempt the SSH con. This allows us to get an HTTP reponse from
+      the socket to establish whether can connect or not.
+- commits:
+  - hash: 31ef106be949cb29bd5d73060fc1e04de6609e11
+- version: 1.18.3
+- date: 2018-11-27T13:51:33Z
+- commits:
+  - hash: efcbdeb27cafcc078d83c202782d4fbf96c20089
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Update os-file-format test due to balena rename
+- commits:
+  - body:
+- commits:
+  - hash: 0ecb68485009eaaddfd930857f59710b2494349b
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Update device-reportOsVersion test due to balena rename
+- commits:
+  - body:
+- version: 1.18.2
+- date: 2018-11-07T09:32:10Z
+- commits:
+  - hash: e00fa1a363aa5155f140c51c963a95feaa7a25cb
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Use internal balena-requests for API calls
+- commits:
+  - body:
+- version: 1.18.1
+- date: 2018-11-05T14:54:48Z
+- commits:
+  - hash: a82a73c78110b01e4bd57819e26a7fd685078dea
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Make request native so we can extract more data on failures
+- commits:
+  - body:
+- commits:
+  - hash: 36eeac0b33b7ea4a97fbb96dcd7416938a5a72e4
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Refactor for redability
+- commits:
+  - body:
+- version: 1.18.0
+- date: 2018-10-30T15:11:26Z
+- commits:
+  - hash: 4c71735f1bda133fc61bf2c266727b6140fff73f
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: The big rename from Resin.io to Balena
+- commits:
+  - body:
+- commits:
+  - hash: 8024ae39eac76e399730b27ec9f1a44a7bcd7f07
+- commits:
+  - author: Paulo Castro
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Paulo Castro <paulo@balena.io>
+- commits:
+  - subject: Update package.json for new resin-semver release
+- commits:
+  - body:
+- version: 1.17.12
+- date: 2018-10-25T11:49:34Z
+- commits:
+  - hash: cf17882666c81b51163d48ec6d2f7709b71af2e8
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Now that we properly check SSH states, retries should not be necessary
+- commits:
+  - body:
+- commits:
+  - hash: 71d8f0f7b5ffd82124508e137be430d72079c57e
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Provide repl interface
+- commits:
+  - body: |-
+      Provide repl hook that can be inserted anywhere in the code.
+      Users can also can set the RESINOS_TESTS_REPL_ON_FAILURE env var
+      to add the hook after each test failure.
+- commits:
+  - hash: 3ae65a0e626b4308734baeacf080402716f56a47
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: To send escape sequences correctly we need to inherit stdin
+- commits:
+  - body:
+- commits:
+  - hash: 58d0ef1e1f0714064bc344e3b5462c3d67403776
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: We are looking for images from staging not production
+- commits:
+  - body:
+- version: 1.17.11
+- date: 2018-10-25T10:38:58Z
+- commits:
+  - hash: 9fad6eb6da2ff3a0c64adcd35b0e5835e9275fd8
+- commits:
+  - author: Paulo Castro
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Paulo Castro <paulo@balena.io>
+- commits:
+  - subject: Update package.json for new resin-semver release
+- commits:
+  - body:
+- version: 1.17.10
+- date: 2018-10-18T15:48:14Z
+- commits:
+  - hash: e6078b328ee0e0f7565c580fdbdfea17804e66fb
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Parameterize worker as a top level option
+- commits:
+  - body:
+- version: 1.17.9
+- date: 2018-10-17T14:44:47Z
+- commits:
+  - hash: 96b977635ec31f9056a4702734c35fa2a84d90d2
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: ResinIO ssh connection requires a certain device state
+- commits:
+  - body: HostOS verison to be greater than 2.7.5 and the device to be connected to
+      the vpn
+- commits:
+  - hash: 90fe257ac00d07a0d6915978864c008ead27815b
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Semi-automate the bluetooth test
+- commits:
+  - body:
+- version: 1.17.8
+- date: 2018-10-17T11:39:18Z
+- commits:
+  - hash: 72cd3090686fc2c41195025b55f5bfe8cc1b7860
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Fix etcher progress bar
+- commits:
+  - body:
+- version: 1.17.7
+- date: 2018-10-17T09:18:21Z
+- commits:
+  - hash: c0f12b0da5d4a373bbafb8dceea1e68860070d72
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Check only on the definition of interactive tests not on a specific value
+- commits:
+  - body:
+- commits:
+  - hash: e47ef5e565c23c3bcd39890417f4a759d878e190
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Allow the use of variables that contain whitespaces
+- commits:
+  - body:
+- commits:
+  - hash: 14369428b15a671cfc3b549af7c79018b83ae88f
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Fix semi-tests due to update of submodule contracts
+- commits:
+  - body:
+- version: 1.17.6
+- date: 2018-10-12T13:58:16Z
+- commits:
+  - hash: a99d026aa13c09a0aa3f91e06e5b135ce909a7c7
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Update contracts submodule
+- commits:
+  - body:
+- commits:
+  - hash: fc954a7bb45bc8820b0d0b2cf16f3b06d7387dbe
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Update tests to latest changes from submodule contracts
+- commits:
+  - body:
+- version: 1.17.5
+- date: 2018-10-12T13:16:35Z
+- commits:
+  - hash: f4b675af34efe3804ed295bd404d9dc851b2d018
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Factor out common push code
+- commits:
+  - body:
+- version: 1.17.4
+- date: 2018-10-12T12:22:45Z
+- commits:
+  - hash: dd48290239b3aeaba211ce6bba484aa800ffd6a1
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Resolve version properly
+- commits:
+  - body: |-
+      The way we handle version today is wrong because build tags are not
+      taken into account by the satisfies function of semver.
+      Users can now specify keywords like: 'latest', 'recommended' or 'default'
+      to select the desired version.
+- commits:
+  - hash: 998675417f1af17ddb2d36b557181ded3643ef1a
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Fix wrong variable name
+- commits:
+  - body:
+- commits:
+  - hash: e590d6ad708423346056f74e48d2b2a43bcd1cae
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Fix exit code when first script fails
+- commits:
+  - body:
+- version: 1.17.3
+- date: 2018-10-11T14:49:08Z
+- commits:
+  - hash: bf1a7160153f85e7d2e3513e38c7269fcfe5032b
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Fix hostapp update to work on updating from old version to new
+- commits:
+  - body:
+- version: 1.17.2
+- date: 2018-10-11T13:57:20Z
+- commits:
+  - hash: 5d084975ff889837887e012be81462ae12c97bbf
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Name ssh key label same as the application name
+- commits:
+  - body:
+- version: 1.17.1
+- date: 2018-10-11T13:21:49Z
+- commits:
+  - hash: 1fd47898f58d18dee7852993fab7aea19d8d67ab
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Provide build status badge
+- commits:
+  - body:
+- version: 1.17.0
+- date: 2018-10-11T12:41:45Z
+- commits:
+  - hash: 78d9007611d6cc916c1ca545460f01da062065b5
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Add support for testbot infrastructure
+- commits:
+  - body: Add JSDoc annotation for clarity
+- version: 1.16.12
+- date: 2018-10-10T10:55:44Z
+- commits:
+  - hash: a70c9d5433044437db4f065194b444847c93e6c6
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Refactor code to accomodate for the testbot worker
+- commits:
+  - body:
+- version: 1.16.11
+- date: 2018-10-08T21:36:26Z
+- commits:
+  - hash: b0b1e09998edefa4e71f92a1cb61103253c01ec4
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Fix multiple parallel runs on the same machine
+- commits:
+  - body: Small code refactor
+- version: 1.16.10
+- date: 2018-10-08T14:03:00Z
+- commits:
+  - hash: 2d67dd25468a2f00a258e192507fd1de918b6fe2
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Fix delta due to resin-sdk changes
+- commits:
+  - body:
+- version: 1.16.9
+- date: 2018-10-08T12:55:02Z
+- commits:
+  - hash: cea0cc911b547531e778d8d0575328b818e844c6
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Revamp the README and remove outdated information
+- commits:
+  - body:
+- version: 1.16.8
+- date: 2018-10-08T12:30:47Z
+- commits:
+  - hash: 24003fb2505e87a1300ead5990da7422f3650c60
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Automate resin-progress test
+- commits:
+  - body:
+- version: 1.16.7
+- date: 2018-10-08T11:53:29Z
+- commits:
+  - hash: b7b789e2309ecd27b37644751f20128caef6a97c
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Automate supervisor update through the api
+- commits:
+  - body:
+- version: 1.16.6
+- date: 2018-10-04T23:19:58Z
+- commits:
+  - hash: d43353677483e32abd3aa55fe0a9556b70392a8f
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Trim ssh output
+- commits:
+  - body:
+- commits:
+  - hash: e930c4fb44627a6763bd61c3cfa247ca55a35d8b
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Automate supervisor update testcase
+- commits:
+  - body:
+- version: 1.16.5
+- date: 2018-10-04T23:12:15Z
+- commits:
+  - hash: 46e55795edd9833ba137e0bbdb8cecfff0c8ece0
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Allow exception to bubble up
+- commits:
+  - body:
+- commits:
+  - hash: 55e881682dc22f5ee26bdf8652c7de3602764780
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Fix ssh output
+- commits:
+  - body:
+- commits:
+  - hash: 9f974afe36419791170a55bfc11d96b16cea4ad5
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Re-work pushing application
+- commits:
+  - body: |-
+      * Factor out git operations
+      * Automate multi application
+      * Improve single application
+- version: 1.16.4
+- date: 2018-10-04T18:52:08Z
+- commits:
+  - hash: 8b6b7fe373a8d072d01d09de46a921238b82ef3a
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Retry SSH connection if connection drops internally
+- commits:
+  - body:
+- version: 1.16.3
+- date: 2018-10-04T14:25:25Z
+- commits:
+  - hash: 12a8d9970aed4eda854aa3e0b818cfc1d9207f45
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Remove circleci from Project
+- commits:
+  - body:
+- commits:
+  - hash: ae8527475c55f87ca3153753dcc073499552ee98
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: When runnning in a CI do not allocate a tty 1
+- commits:
+  - body:
+- commits:
+  - hash: 0d82ba43f97d518407a79d7260bacba4b3b9a40d
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Fix reboot detection
+- commits:
+  - body: Make reboot independent of platform speed
+- commits:
+  - hash: bbcdc02778d26e1ebcbca8010e7e36997cf54a54
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Waiting for the proper implementation of push-container
+- commits:
+  - body:
+- version: 1.16.2
+- date: 2018-09-20T14:59:03Z
+- commits:
+  - hash: ba32430ebb004fe5386df93844a60f23814ca15d
+- commits:
+  - author: Lucian Buzzo
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>
+- commits:
+  - subject: 'dependencies: Update resin-semver version to support Balena OS'
+- commits:
+  - body: 'Connects to #242'
+- version: 1.16.1
+- date: 2018-09-05T15:54:01Z
+- commits:
+  - hash: 11d4168d68f03a51323cb92017c19a253c85c380
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Refactor effort
+- commits:
+  - body: |-
+      * Improve logging
+      * Better error handling
+      * Various bugfixes
+- version: 1.16.0
+- date: 2018-09-04T13:41:49Z
+- commits:
+  - hash: adaed1866247638d9f9a416d9c26152e8adf012b
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Add test to check the device reports the hostOS version
+- commits:
+  - body:
+- version: 1.15.13
+- date: 2018-09-01T11:14:38Z
+- commits:
+  - hash: eea8f42baa6222256496d1a0b0d647deeeea5dbe
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Define OS concept
+- commits:
+  - body: |-
+      Create OS component which provides the required configuration to run a specific OS.
+      This class will be closely related (coupled) to the worker class. The flash method in the
+      worker class will use the OS class to configure the image.
+      The two interfaces should be kept in sync.
+      Because of the move of the download function we changed the way we retrive the filename.
+- commits:
+  - hash: 5844aa6dbd3831b31e3f9e398a59e269ea3f70c9
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Test supervisor update through the API
+- commits:
+  - body:
+- version: 1.15.12
+- date: 2018-08-24T13:46:55Z
+- commits:
+  - hash: 0c1c3bfaabce976d463ad89155a362518863a556
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Switch to resin-semver module
+- commits:
+  - body:
+- version: 1.15.11
+- date: 2018-08-21T14:51:34Z
+- commits:
+  - hash: 8ff2f538c7b9d4b00427ddccb0c1a193aa04563d
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Use COPY rather than ADD in Dockerfile
+- commits:
+  - body:
+- version: 1.15.10
+- date: 2018-08-20T13:40:48Z
+- commits:
+  - hash: 22dc2e42f5878354bd472f8a4e5ff2ea2e9ea4e8
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Bump resin-sdk to v10.0.4
+- commits:
+  - body:
+- commits:
+  - hash: 5330acfb72ac6e40b9148b304a7e896da158ed4f
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: To creat an application takes an object argument
+- commits:
+  - body:
+- commits:
+  - hash: b411eb2a889faa6946cedc2b9f8bb37f06a10425
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Add kvm support to speed qemu up
+- commits:
+  - body: Without kvm qemu does not connect the vpn
+- version: 1.15.9
+- date: 2018-07-04T21:20:39Z
+- commits:
+  - hash: c70fee099aeb5a9f3499506005cc970bb0dd050e
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Move from ava to node-tap
+- commits:
+  - body: |-
+      The use of ava is becoming more of a hassle than anything.
+      Ava is taking a lot of the freedom we have away and we had to
+      push back on this until ava cracked.
+      Node-tap seems to be a much better fit for this project as it is light-weight and
+      highly customizable.
+- version: 1.15.8
+- date: 2018-07-04T09:51:41Z
+- commits:
+  - hash: 5fe10cb732aa33f42bfef2a5f7cbb34b1fa2f4ca
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: 'Fix: ResinCI configure'
+- commits:
+  - body:
+- version: 1.15.7
+- date: 2018-06-29T11:49:51Z
+- commits:
+  - hash: 2f05e5b1b62650c00314dd241e81d37599ca656e
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Getting device OS config requires resinOS version now
+- commits:
+  - body:
+- commits:
+  - hash: 670a60eeea940295e257cb595a43fff7cf5c7fd0
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Use proper device key we registrate a device
+- commits:
+  - body:
+- version: 1.15.6
+- date: 2018-06-01T17:25:00Z
+- commits:
+  - hash: 8d6adaf2d252b6cf1ef5fd3f921658cc676286bc
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Refactor device initialization logic as worker classes
+- commits:
+  - body: All credits to Theodor :P
+- version: 1.15.5
+- date: 2018-05-31T19:22:09Z
+- commits:
+  - hash: e30a737e8cd2513e744da977835d4cd3b6d93ed6
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Split tests into their own files
+- commits:
+  - body: As a step forward towards moving them to the actual Yocto layers.
+- version: 1.15.4
+- date: 2018-05-31T13:10:41Z
+- commits:
+  - hash: ab49ac6f100461162f118a51906f46ff59af4844
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Remove all bash code
+- commits:
+  - body: Move all this funcionality in node.
+- version: 1.15.3
+- date: 2018-05-24T12:43:38Z
+- commits:
+  - hash: 44a7ba733012068b4ee2ab418b26608b4ca37525
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Use API keys instead of authenticating with credentials
+- commits:
+  - body:
+- commits:
+  - hash: cefe908500aeb62a782e85576fcd7396fa740542
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Fix pensieve output
+- commits:
+  - body:
+- commits:
+  - hash: b1d2cbc442b30190dcd6f00201b78a52c2830a0e
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Bugfixes
+- commits:
+  - body:
+- version: 1.15.2
+- date: 2018-05-02T15:54:02Z
+- commits:
+  - hash: 72e8a0352df364342a030b946a47a0498f725593
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Add pensieve backend to publish test results
+- commits:
+  - body:
+- version: 1.15.1
+- date: 2018-05-02T00:47:22Z
+- commits:
+  - hash: fd49f097aa709093d4582550477dbf7240890dfc
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Produce, consume and format TAP output
+- commits:
+  - body: |-
+      - Bump ava to fix issues with the TAP output
+      - Format output as markdown text to integrate with Pensieve
+- commits:
+  - hash: f208b6ae40c46a882fdc357e7cf84102a24f4c37
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Add a delay to separate the auto sections of tests from the manual section
+- commits:
+  - body: If any of the automatic tests are skipped there will be a race condition
+      between ava output and manual tests output
+- version: 1.15.0
+- date: 2018-05-01T13:36:38Z
+- commits:
+  - hash: 887960f0c84b3c7e361675e2040e11c203e1968b
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Add test to check image filename format
+- commits:
+  - body:
+- commits:
+  - hash: 8e924b75521309f194a831fd1b73a8d589d0199b
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Visual fixes for semi-tests
+- commits:
+  - body:
+- commits:
+  - hash: 5290cbec0dcc3849ce8b417b918d80af42b9ee80
+- version: 1.14.0
+- date: 2018-04-20T19:15:45Z
+- commits:
+  - hash: f46943fb69234d99f4e4a4cde6224809f9f9300d
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Refactor graphics semi-tests
+- commits:
+  - body:
+- version: 1.13.0
+- date: 2018-04-20T18:32:03Z
+- commits:
+  - hash: 42636354f4e56da464e630956c16f35c4b66443b
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Refactor supervisor semi-tests
+- commits:
+  - body:
+- version: 1.12.0
+- date: 2018-04-20T16:32:56Z
+- commits:
+  - hash: fe474baa4efa641042e021d340929e85c75314ae
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Refactor resinhup semi-tests
+- commits:
+  - body:
+- version: 1.11.0
+- date: 2018-04-20T15:40:50Z
+- commits:
+  - hash: 56b990697186ac44664b0c857b4fcaa68917d233
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Adding vim and rsync for installing
+- commits:
+  - body: '* Configuring git identity'
+- version: 1.10.0
+- date: 2018-04-20T13:54:05Z
+- commits:
+  - hash: ae354278679f3561e84fff0cda83888c6a056a53
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Add function to get the dashboard URL of the device
+- commits:
+  - body:
+- commits:
+  - hash: a83212c5c823b23d3e8d90957d4d151dfd26c5fa
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Refactor development experience semi-tests
+- commits:
+  - body:
+- version: 1.9.0
+- date: 2018-04-17T14:47:12Z
+- commits:
+  - hash: ea5886c375633830066d11a215752c05c7a7ef96
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Enable interactive tests using a config env var
+- commits:
+  - body:
+- version: 1.8.0
+- date: 2018-04-16T13:37:59Z
+- commits:
+  - hash: bebc4e0bfd6aa12435132fbeee9d5e224fe7c3ee
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Add semi multicontainer test
+- commits:
+  - body:
+- commits:
+  - hash: cf1fed2aa9b3ace9b76b493d63e569afac3918bc
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Various fixes
+- commits:
+  - body:
+- commits:
+  - hash: ee756db51c6b33648ae9f92928675e0a1a65bc1f
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Remove trailing characters
+- commits:
+  - body:
+- version: 1.7.3
+- date: 2018-04-13T10:01:35Z
+- commits:
+  - hash: ba4c54e1cebfa888f86f542cd1d2a1827985739f
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Implemenet SSH key removal by label
+- commits:
+  - body: |-
+      * Move SSH key remove in teardown to fix concurrent runs of the project
+      * Make sure bash exports all variables
+- commits:
+  - hash: 0f9cd3343837c91481641a8fe52bcf8f20e70a2c
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - subject: Merge branch 'master' into parallel_fix
+- commits:
+  - body:
+- version: 1.7.2
+- date: 2018-04-12T23:28:04Z
+- commits:
+  - hash: 7dee598516e14a3c7a3ff36dfdcfa6449e45d544
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Make Circle CI ignore verson commits generated by VersionBot
+- commits:
+  - body: |-
+      So we don't trigger a whole new build every time we try to merge
+      something.
+- commits:
+  - hash: 8e40f4e07687a9179e051f9151ac669a66c70dd9
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - subject: Merge branch 'master' into ignore-version-commits
+- commits:
+  - body:
+- version: 1.7.1
+- date: 2018-04-12T19:16:05Z
+- commits:
+  - hash: f954702e0713d80d15abb73822b5e4cbf93b89cd
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Bump resin-sdk to support multi-contianer architecture
+- commits:
+  - body:
+- commits:
+  - hash: 4af65f943a0633827c05b502a8eb934b89b7c6cc
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Increse no output timeout
+- commits:
+  - body:
+- commits:
+  - hash: f38e16685ec97f4a09f4736aee3c932534507946
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: The suite requires the supervisor to be up and running
+- commits:
+  - body: This happens when the devices status is updated and becomes 'Idle'
+- commits:
+  - hash: fe92f32ecb348c8671ff9ba2f45c0de7c36328d1
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Adapt code to the new multi-contianer architecture
+- commits:
+  - body:
+- commits:
+  - hash: aa764ecf353208cffc24711fee86f97c9addeae7
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Provide way to wait for the completion of progress
+- commits:
+  - body:
+- commits:
+  - hash: 1825f172be5baccbf6ebb6b6032afb698c7ab9e6
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Remove superfluous async definitions
+- commits:
+  - body:
+- version: 1.7.0
+- date: 2018-03-27T14:06:04Z
+- commits:
+  - hash: a14eac59b3ad9a820c862be416e281692b8be781
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Wifi credentials were not parsed
+- commits:
+  - body:
+- commits:
+  - hash: 76d886f16c33676dbae0be33b59a1ce073c09611
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Refactor semi-tests on bluetooth
+- commits:
+  - body:
+- commits:
+  - hash: 3d9ddf7e36c3448e078bdb9347c25eec9cdf2d88
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Refactor semi-test that depends on device-type
+- commits:
+  - body:
+- commits:
+  - hash: 1baf40ed2b79cdf0e7e0266907ed8cc28c2ccbb5
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Refactor semi-test that enters and syncs application
+- commits:
+  - body:
+- commits:
+  - hash: 3af8f66e25f1b1c081403d8ab613af7498c40b8a
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Refactor semi-test on supervisor
+- commits:
+  - body:
+- commits:
+  - hash: 46a883500a71a2ce2a6fbda926ec0c69ca1a869b
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Refactor semi-test that tests the kernel boot logo and the splash screen
+- commits:
+  - body:
+- version: 1.6.0
+- date: 2018-03-16T10:24:28Z
+- commits:
+  - hash: a8c510925c38cc13fe934316885b961b6eb8db08
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Provision device with deltas enabled
+- commits:
+  - body:
+- version: 1.5.2
+- date: 2018-03-15T14:52:09Z
+- commits:
+  - hash: f680378b7b0d1b894fa4012d7b962b491394e8dd
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Refactor the resin SDK component
+- commits:
+  - body: |-
+      * Allow the SDK to connect to variable apis
+      * Fetch donwload from download API
+- version: 1.5.1
+- date: 2018-03-12T16:26:33Z
+- commits:
+  - hash: ed618b7ed41434c98cc54b4c9c79b01aafe46937
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Remove Resin CLI prepare instructions
+- commits:
+  - body:
+- commits:
+  - hash: 989dbfbe0a494503af937cb5a605d9d8a7d9f3fa
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - subject: Merge branch 'master' into remove-cli-mentions
+- commits:
+  - body:
+- version: 1.5.0
+- date: 2018-03-06T10:11:55Z
+- commits:
+  - hash: 87a5da380cb4a6447bd577571df8d0ab5c0791d2
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Remove duplicate teardown code
+- commits:
+  - body:
+- commits:
+  - hash: d96513dfb5e7a08355d660e90b66e1df13452c6a
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Fix bugs in Makefile
+- commits:
+  - body:
+- commits:
+  - hash: dae366ceb1be174095e57a8a2f08984d338d2f2b
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Do not expand the version variable
+- commits:
+  - body:
+- commits:
+  - hash: d25263982f5684e631805e42b3375bd4c0ec9f13
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Refactor code for readability
+- commits:
+  - body: '*Add file to ignore for specific IDE'
+- version: 1.4.4
+- date: 2018-03-02T20:53:16Z
+- commits:
+  - hash: 3c12d3a6baebf482118e3aff5bbcc35604a37b5a
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Implement hostapp update testcase
+- commits:
+  - body: '* Increases the timeout of circleci to 20m as some commands take longer
+      to run'
+- commits:
+  - hash: bc68353f0e43ca5f07733496ee599e46e1be78da
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - subject: Merge branch 'master' into hostapps_update
+- commits:
+  - body:
+- version: 1.4.3
+- date: 2018-03-02T19:17:05Z
+- commits:
+  - hash: 8c641231aa8ba34d7f88a97832bcc3aa7dd38e8a
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Dynamically pass environment to Docker
+- commits:
+  - body:
+- version: 1.4.2
+- date: 2018-03-02T18:38:46Z
+- commits:
+  - hash: 049e1363bf38a9b45780ca10ec1748fa4e98f593
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Make the teardown function robust to flaky network
+- commits:
+  - body:
+- version: 1.4.1
+- date: 2018-03-02T17:10:30Z
+- commits:
+  - hash: 74868430249d05321c91e5ff7303a7b5121a992d
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Fix wifi configuration support
+- commits:
+  - body:
+- commits:
+  - hash: 71120a9e0464acf6abeda8289e70aab01ab7df89
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - subject: Merge branch 'master' into wifi_support
+- commits:
+  - body:
+- version: 1.4.0
+- date: 2018-03-02T16:29:23Z
+- commits:
+  - hash: 554b338dbcdeeab9fe4dc4fa21b5e103d1a55f0d
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Configure SSH keys in container to be able to clone and push
+- commits:
+  - body: application without additional steps
+- commits:
+  - hash: 2c66408c2ff95a3238b8564481151a969fed1bc9
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Add logout call to the SDK
+- commits:
+  - body:
+- commits:
+  - hash: ccb64292f24b04601db98a90089faf08bd6f1392
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Slight flow re-work of the project
+- commits:
+  - body: |-
+      Create a way to resolve variable name before we run the project.
+      Create a way to teardown the project.
+- commits:
+  - hash: da80a2d35afd55dbe33f764e7e202dc988646dc2
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Place device configuration in "options"
+- commits:
+  - body: |-
+      This is a step forward to start accepting custom configuration values
+      from the environment to be able to tackle certain provisioning variants.
+- commits:
+  - hash: 71e53cedc5be75deb04ef0ab462df21285bf4a43
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Use contracts to determine whether to run bluetooth tests or not
+- commits:
+  - body: |-
+      This commit introduces a git submodule. You may need to do `git
+      submodule init && git submodule update` to fetch it before being able to
+      give this a go.
+- version: 1.3.2
+- date: 2018-02-22T13:34:20Z
+- commits:
+  - hash: 1b151d28cea339634fc4e548051a1a3b1b4adcfd
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Do not share application name between tests, so we can run test instances
+      in parallel
+- commits:
+  - body:
+- commits:
+  - hash: 97d9896b937124d6ecb11f2c141f3a7366145d89
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Integrate ESLint
+- commits:
+  - body:
+- commits:
+  - hash: 9d9f74a4a73a6467cae5d141541f6ff77efa084e
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Run tests serially
+- commits:
+  - body:
+- commits:
+  - hash: ac52ab642e9297f83761e2c45f756da3498ca7d7
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Move the project back to javascript
+- commits:
+  - body: |-
+      The only reason this project wsa using typescript was for the async / await support,
+      but this is supported since noce v8.9. We will just use that from now on and move
+      back to javascript.
+- commits:
+  - hash: 6299b42fb775045015ba898fc7a9db50bc072a8c
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Make temporary directory configurable using an env var
+- commits:
+  - body:
+- version: 1.3.0
+- date: 2018-02-19T14:48:50Z
+- commits:
+  - hash: 547cb15f9eae0de81f486a412a9a54d593412543
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Installing resin-cli inside container
+- commits:
+  - body: '*Providing make target to enter running container'
+- version: 1.2.0
+- date: 2018-02-16T16:52:13Z
+- commits:
+  - hash: ffd9c7d2c113e328574fd13889d29cbacd14fa9c
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Include semi-manual test cases from TestLodge
+- commits:
+  - body:
+- version: 1.1.0
+- date: 2018-02-14T17:53:01Z
+- commits:
+  - hash: 0173c47f74dc234d586f93818aee5fe1c6c88a09
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      change-type: minor
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Stop Ava to abort test on a single failure
+- commits:
+  - body:
+- commits:
+  - hash: 620c067ba586e5c77db0ee0aee6ce095becb65c8
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Allow user confirmation through IPC on serial mode
+- commits:
+  - body:
+- version: 1.0.8
+- date: 2018-02-08T23:23:56Z
+- commits:
+  - hash: 4532a702d347eef9b216b978668da499c9938c6f
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Execute Ava CLI through a Node.js wrapper
+- commits:
+  - body: |-
+      This will make is easier to intercept Ava's stdin for semi-automation
+      test writing purposes.
+      The `lib/runner.js` file is not a TypeScript file since running the
+      entry point with `ts-node` yields some incomprehensible null-related
+      issues with completely out of sense line numbers.
+- version: 1.0.7
+- date: 2018-02-08T18:47:45Z
+- commits:
+  - hash: 22f9b3489fa1ab17ecf99e0b614de6413d5cf801
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Run all tests serially
+- commits:
+  - body: |-
+      Lets do it for all tests for now, given it makes it way easier to
+      implement semi-automated test cases.
+      We can look at parallelising some for speed purposes later on.
+- version: 1.0.6
+- date: 2018-02-06T17:02:12Z
+- commits:
+  - hash: a8e41d6963b1f5e3a5448c462f795282cd17b7ea
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Integrate ssh util with various components
+- commits:
+  - body:
+- version: 1.0.5
+- date: 2018-02-06T14:40:42Z
+- commits:
+  - hash: 912b971f34c89367fd66d95727ca56e499dbb3d4
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Refactor the sdk component
+- commits:
+  - body: '* Combine wait functions into one and relocate it'
+- version: 1.0.4
+- date: 2018-02-01T13:54:24Z
+- commits:
+  - hash: fdaaae44cd06804f5d57aff3466cb29e9d55a54e
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Upgrade SDK to bypass API bug with older versions
+- commits:
+  - body:
+- version: 1.0.3
+- date: 2018-01-24T18:10:16Z
+- commits:
+  - hash: efda8b3ecf8ce5f77549f148da7d96ac2cf72647
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Push application test should not run in parallell with other ones
+- commits:
+  - body:
+- commits:
+  - hash: 5057facfca2bfee970070265d9bf6b8de3fb4d30
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Fix typo
+- commits:
+  - body:
+- commits:
+  - hash: a603ee5cc5900d0028e6821c85ac804e52a09564
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Rework 'push an application' test
+- commits:
+  - body: |-
+      * Handle SSH keys internally
+      * Avoid using ssh-agent by using GIT_SSH_COMMAND (requires git 2.10+)
+      * Fix the way we construct remote url
+      * Simple-git connects our process to stdout/stderr
+      which is required to keep the builder connected
+      * Implement waitForDeviceStatus, this function waits
+      for a device to reach a given state
+- commits:
+  - hash: af33ed6a7f4bc33fc9b9e3c2c76789a9cde7486c
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Make our framework aware when it runs inside a CI engine.
+- commits:
+  - body:
+- commits:
+  - hash: ba9adf27ff7789ce914c8f52e454bcc80244368d
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Rework download progress
+- commits:
+  - body: |-
+      * Add progress bar
+      * Use sdk progress tracker
+- commits:
+  - hash: b38c5d07dac96d5d987368271f2d93bfcc6f86e2
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Include lint configuration
+- commits:
+  - body:
+- commits:
+  - hash: 49be09945ad69a49d9a416b923991044b1cb64ab
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Add rule to check coding style
+- commits:
+  - body:
+- commits:
+  - hash: f9fbe34c4077f4c20ecf21eefcaaab9c76ba36e2
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Make circleci use our own build configuration
+- commits:
+  - body:
+- commits:
+  - hash: 4ac4dee919f1c0462d2b03f740a3bc8b4199fd2b
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Improve Dockerfile
+- commits:
+  - body: |-
+      * Improve caching by running `npm install` in a different stage of the build
+      * Refactor
+- version: 1.0.2
+- date: 2017-12-03T01:06:00Z
+- commits:
+  - hash: 5fc6dffb96eaf4d4092f4705aeffd291ff1f5a24
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Remove dollarsign in lint command instructions
+- commits:
+  - body:
+- commits:
+  - hash: f965e887f34aae7ec6d00733a3ef79511de53d52
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Add a basic README
+- commits:
+  - body:
+- commits:
+  - hash: 69ab43d2221f38f42e6f2e68973eecf760fe1747
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Bridge device type environment variable to Docker container
+- commits:
+  - body:
+- commits:
+  - hash: 2958b684e69a98f9cfa3dc6f342431faea7ca0ad
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Get rid of env.list
+- commits:
+  - body: We will bridge the relevant env vars from the environment
+- commits:
+  - hash: ef0af3fe567eea6533c11b089a5e625e7d73d7e5
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Fix various TypeScript related issues
+- commits:
+  - body:
+- commits:
+  - hash: 461bfe71cf8c7dabaeedc0044ee51ae3970e1591
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Add source code license blocks
+- commits:
+  - body:
+- commits:
+  - hash: f57a4430eb65f5bc73417fa425dffa674e84c1b3
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Enable correct tests
+- commits:
+  - body:
+- commits:
+  - hash: 2c51258de5e0e7a7e7f262bcf5626c6101f84626
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Add qemux86-64 support
+- commits:
+  - body:
+- version: 1.0.1
+- date: 2017-11-29T14:13:26Z
+- commits:
+  - hash: 8a641513aee2b22221c232940fdd6331d7778270
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Ava does not support t.context in before blocks
+- commits:
+  - body:
+- commits:
+  - hash: 8452f7b7954544e56e3c2c5bd3a210e1c4b6d980
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Preprovision resin.io devices and properly wait for a uuid
+- commits:
+  - body: |-
+      This change allows us to delete the `provDevice` global variable, and
+      the enable back all the test cases.
+- commits:
+  - hash: 741f03a5103b735f62066b0211404b2cc80e8ed3
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Use namespaced env vars
+- commits:
+  - body: To avoid collisions.
+- commits:
+  - hash: 26e106a165fbf436b8f533ccebbbaf77475b2e3b
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Don't wait for stdin on provision before continuing
+- commits:
+  - body: |-
+      We can't access stdin from Ava, so we'll rely on polling the API for
+      now.
+- commits:
+  - hash: 22c6b3883ea75698f9c95dd4c984fcffeddcd2ac
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Use a locally scoped temporary directory
+- commits:
+  - body:
+- commits:
+  - hash: 9fd7228f88012e8f0915d3421a3591bac7735163
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Minor logging improvements
+- commits:
+  - body:
+- commits:
+  - hash: 22bd5f73a8765c1becf0c96fa6171156b9bd540f
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Unmount drive before opening it in Etcher writer
+- commits:
+  - body:
+- commits:
+  - hash: 565f05c70691b1961209ddf78089bfdb1e341e5f
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Get all options from environment variables
+- commits:
+  - body:
+- commits:
+  - hash: 2ea280edfe5455b9457454d7c0b49cbfa56271f5
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Add missing percentage to Etcher writer logs
+- commits:
+  - body:
+- commits:
+  - hash: 7d8011fb8a03a611cc4916fa4b3c49aec8c5a4d6
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - subject: Merge branch 'master' into writer-percentage
+- commits:
+  - body:
+- commits:
+  - hash: e3350001ee7414c7d5a49884fc90c1ae101f3de2
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Log provisioning process to stdout
+- commits:
+  - body:
+- commits:
+  - hash: 1027c19086593b976d05a8f2d2e10abe248da580
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Pipe to progress stream when downloading OS
+- commits:
+  - body:
+- commits:
+  - hash: 1ce78c5ba46fc338daccb72f0f8ebbcf3d902567
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Various fixes to make everything run fine on TypeScript
+- commits:
+  - body:
+- commits:
+  - hash: 4fe7c62a3bc6e4d097214b8a88c8f436e4d25e09
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Start using TypeScript async/await
+- commits:
+  - body:
+- commits:
+  - hash: c49599b9b2cfb8fcf4c5f946b759b1404bbaf375
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Expand .gitignore
+- commits:
+  - body:
+- commits:
+  - hash: 34c4171c75e0c1bc5ff3c462cdebfd43235cddb9
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      fixes: https://github.com/resin-io/resinos-tests/issues/18
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Switch to TypeScript
+- commits:
+  - body:
+- commits:
+  - hash: e27229fa46cabb6cec18437f04d81531cd9505d3
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      change-type: patch
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Add a device-type component with a default implementation
+- commits:
+  - body: |-
+      A "device-type" component implements a "provision" function that given a
+      writer, an image, and some options:
+      - Flashes the image (in whatever way that makes)
+      - Provisions the device (in whatever way that makes sense)
+      After the provision function runs, we can expect a device to be up and
+      running.
+      We provide a default implementation that writes the image to a disk, and
+      waits for the test runner person to manually remove the SD Card and
+      complete the provisioning process.
+      This commit also introduces `utils.requireComponent()`, which will try
+      to find a proper implementation, or otherwise default to `default.js`.
+- version: 1.0.0
+- date: 2017-11-22T14:57:48Z
+- commits:
+  - hash: af0307eea299294d9b87af4852d57c298137ffd0
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Configure repository for VersionBot integration
+- commits:
+  - body:
+- commits:
+  - hash: 0b11577e98ff5fd4192acc7ba63345d83f149fbc
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: 'Dockerfile: Fix docker build the image correctly'
+- commits:
+  - body:
+- commits:
+  - hash: be24697ac9b16258471930b74464b24c1c7ed6f0
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Use credentials instead of session token to authenticate
+- commits:
+  - body:
+- commits:
+  - hash: edd8f0af4bdc0b3bf41815e6181e67b23a41052b
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      fixes: https://github.com/resin-io/resinos-tests/issues/47
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Switch to the Ava test framework
+- commits:
+  - body:
+- commits:
+  - hash: 816f15844f74fa81ec8beb305af44ea17cfad150
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Rename src/ to lib/
+- commits:
+  - body:
+- commits:
+  - hash: 9d24de6bd41ae7eb84c769424926b6ccb4bc5648
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Simplify test hierarchy
+- commits:
+  - body:
+- commits:
+  - hash: f6b5e9822d3969adbee5ff575b677042b53cff60
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Get rid of the global assetDir variable
+- commits:
+  - body:
+- commits:
+  - hash: aa1c8c4b87af0e3fa9193cb4673a8e7bf228fe43
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Don't refer to component instances directly
+- commits:
+  - body: |-
+      This change better reflects the high level way that we expect tests to
+      be written.
+- commits:
+  - hash: 0388ee809b606521ceaca57dd29c92a278d1f187
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Unify provisioning code in main.js
+- commits:
+  - body:
+- commits:
+  - hash: edece33dcff2a5e7d1128640c44f7d06d8fc6566
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Use SDK interface functions instead of inspecting device properties
+- commits:
+  - body: For encapsulation purposes. The current code is assuming SDK output.
+- commits:
+  - hash: d147be4692530e8bfd36a073c688cb5debe7adf5
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Move resinOS image configuration routines to components/resinos
+- commits:
+  - body:
+- commits:
+  - hash: d4ba2374820de4259bd550c3240b7ced8ecbb09f
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Present a clear interface to the resin.io SDK component
+- commits:
+  - body: |-
+      The resin.io platform has an interface, which consists of functions such
+      as download device type OS, create an application, etc.
+      This interface is implemented by the Resin SDK. In the future, we will
+      implement the same interface using the Resin CLI, and even the Dashboard
+      by using a browser driver technology.
+- commits:
+  - hash: 556cbbadb98825ed3da6e1a3c95f0bdc51a01f3b
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      see: https://github.com/resin-io/resinos-tests/pull/34
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Add resin-image-fs as a package.json dependency
+- commits:
+  - body:
+- commits:
+  - hash: 62aa23bd69b2c20a4406063f4d6ebae0c84458b6
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Get rid of node-lkl
+- commits:
+  - body:
+- commits:
+  - hash: 0b35b62ec4560433aab7a37947b747c0f28b31e8
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Add .editorconfig file
+- commits:
+  - body:
+- commits:
+  - hash: b1be96dbbd843d5eb599fce5428b836676e8d3cc
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Inline provisioning functions
+- commits:
+  - body:
+- commits:
+  - hash: 087860e883065b2e92c34171747321b376f3be3a
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Get rid of global.assetDir in image.js
+- commits:
+  - body:
+- commits:
+  - hash: 74e4879b2f0aa0bd9c807222922f6f6d72712b4b
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Get rid of mocha.opts and setup.js
+- commits:
+  - body:
+- commits:
+  - hash: 6461314005b2e6e872a7a2ea83d04e1d461dd16a
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Remove unused resin-cli-form dependency
+- commits:
+  - body:
+- commits:
+  - hash: 5864fd03416eaccffdfe682d0ec9cf228f3bb276
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Minor updates to package.json
+- commits:
+  - body:
+- commits:
+  - hash: 4f5658b36015ce61b6ee588a5fad4633f55e253c
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Add the actual running command for tests on circleCI
+- commits:
+  - body:
+- commits:
+  - hash: 94ff22c3c52c9f803ca1c7a774470154e5b61f78
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Add CircleCI config file for Continous Integration
+- commits:
+  - body: '[Fix #13]'
+- commits:
+  - hash: 46e5031147eb3ae9b44bc8f68567bcef2c6c89e0
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Creating Makefile to run the tests
+- commits:
+  - body: '[Fix #8]'
+- commits:
+  - hash: 8309e0591280790b1f4cf3c604f6f0f704b13119
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Remove most global variables
+- commits:
+  - body:
+- commits:
+  - hash: f0e1f26d2a8e08395b4b8b8c5b71b9b754e8cfde
+- commits:
+  - author: Juan Cruz Viotti
+- commits:
+  - footers:
+      fixes: https://github.com/resin-os/resinos-tests/issues/12
+- commits:
+  - footers:
+      signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
+- commits:
+  - subject: Add ESLint
+- commits:
+  - body: |-
+      Run the linter with the following command:
+      ```
+      npm test
+      ```
+- commits:
+  - hash: 6ae5ef33d92aab8ae34f51860f61fdb89b80e5bb
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Tests take session token as environment variable to authenticate
+- commits:
+  - body: |-
+      Use application name and credentials for wifi settings from environment list
+      [Fix #5]
+- commits:
+  - hash: 4b44b5b0359393c987e82db5f36239690822e727
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: test
+- commits:
+  - body:
+- commits:
+  - hash: f0b04dbbbfa965488ed8b437fbf8711a2046fac2
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Bump resin-sdk to v7.0.0
+- commits:
+  - body:
+- commits:
+  - hash: 9ff8587ed0b27609ab300402658a72db8d889271
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Fix resin.models.os.getConfig to work properly
+- commits:
+  - body:
+- commits:
+  - hash: 0af684fbcf126a4b78f8b89cdbdc68bfe0c0ae5f
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Increase tests timeout
+- commits:
+  - body: '[Fix #10]'
+- commits:
+  - hash: 41c516c9951afe87f5a92a666b100c389aa91d88
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Fix dependencies in Dockerfile
+- commits:
+  - body: '[Fix #7]'
+- commits:
+  - hash: 86beeb475ef87838e54f851faadc4424ee303f68
+- commits:
+  - author: Horia Delicoti
+- commits:
+  - footers:
+      signed-off-by: Horia Delicoti <horia.delicoti@gmail.com>
+- commits:
+  - subject: Update LICENCE
+- commits:
+  - body: '[Fixes #11]'
+- commits:
+  - hash: 929a8761b9e6523bccdafc9a1454cedc8a1a606d
+- commits:
+  - author: Theodor Gherzan
+- commits:
+  - footers:
+      signed-off-by: Theodor Gherzan <theodor@resin.io>
+- commits:
+  - subject: Initial testing framework
+- commits:
+  - body:


### PR DESCRIPTION
Following process outlined here (restricted access):
https://jel.ly.fish/pattern-enable-nested-changelogs-repos-consuming-repo-cf7bcc8

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>