### PR TITLE
makefile: Use Jenkins BUILD_TAG to create unique compose project names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ export COMPOSE_DOCKER_CLI_BUILD := 1
 export DOCKER_BUILDKIT := 1
 export DOCKERD_EXTRA_ARGS :=
 
+ifneq ($(BUILD_TAG),)
+export COMPOSE_PROJECT := $(BUILD_TAG)
+endif
+
 DOCKERCOMPOSE := ./bin/docker-compose
 
 # install docker-compose as a run script

--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -33,6 +33,7 @@ services:
       - UDEV=0
       - CORE_PORT # default 2000, change this to avoid port conflicts
     network_mode: host
+    restart: 'no'
 
 volumes:
   core-storage:

--- a/docker-compose.qemu.yml
+++ b/docker-compose.qemu.yml
@@ -23,6 +23,11 @@ services:
       - WORKER_TYPE=qemu
       - SCREEN_CAPTURE=true
       - WORKER_PORT # default 80 and must match client config.js workers
+    restart: 'no'
+
+  core:
+    depends_on:
+      - worker
 
 volumes:
   core-storage:


### PR DESCRIPTION
The compose project name is used to prefix all components of the
docker-compose stack, like volumes, networks, containers, etc.

If we are running on Jenkins it would be best to avoid having all builds
using the same default prefix "leviathan-" since they are sharing
a docker host.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>