### PR TITLE
enable bridge networking for all containers

### DIFF
--- a/client/config/default.js
+++ b/client/config/default.js
@@ -1,6 +1,6 @@
 module.exports = {
 	core: {
-		host: process.env.CORE_HOST || 'localhost',
+		host: process.env.CORE_HOST || 'core',
 		port: process.env.CORE_PORT || 2000
 	},
 	balena: {

--- a/core/Dockerfile.template
+++ b/core/Dockerfile.template
@@ -27,7 +27,9 @@ RUN apk add --no-cache nodejs~=12.22 \
 		       skopeo \
 		       openssh-client \
 			   socat \
-			   rsync
+			   rsync \
+			   docker \
+			   bind-tools
 
 WORKDIR /usr/app
 
@@ -42,6 +44,6 @@ RUN ln -sf /usr/app/node_modules/balena-cli/bin/balena /usr/bin/balena && \
 COPY contracts contracts
 COPY lib lib
 COPY config config
-COPY entry.sh ./
+COPY entry.sh entry.sh
 
 CMD [ "./entry.sh" ]

--- a/core/entry.sh
+++ b/core/entry.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
 
+rm -rf /var/run/docker 2>/dev/null || true
+rm -f /var/run/docker.sock 2>/dev/null || true
+rm -f /var/run/docker.pid 2>/dev/null || true
+
+dockerd &
+
 eval $(ssh-agent)
 node lib/main.js

--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -8,7 +8,6 @@ services:
       - "${REPORTS:-./workspace/reports}:/usr/src/app/reports:rw"
       - "${SUITES:-./suites}:/usr/src/app/suites:ro"
     environment:
-      - CORE_PORT # default 2000, change this to avoid port conflicts
       - WORKER_PORT # allow this env var to be used in config.js
       - BALENACLOUD_API_KEY # allow this env var to be used in config.js
       - BALENACLOUD_ORG # allow this env var to be used in config.js
@@ -17,9 +16,9 @@ services:
       - WORKER_TYPE # allow this env var to be used in config.js
     depends_on:
       - core
-    network_mode: host
 
   core:
+    privileged: true
     build:
       context: ./core
       dockerfile: Dockerfile.template
@@ -28,11 +27,11 @@ services:
     volumes:
       - core-storage:/data
       - reports-storage:/reports
-      - /var/run/docker.sock:/var/run/docker.sock
+    tmpfs:
+      - /var/run
+      - /var/lib/docker
     environment:
-      - UDEV=0
-      - CORE_PORT # default 2000, change this to avoid port conflicts
-    network_mode: host
+      - UDEV=1
     restart: 'no'
 
 volumes:

--- a/docker-compose.qemu.yml
+++ b/docker-compose.qemu.yml
@@ -14,7 +14,6 @@ services:
       - "c 10:* rmw"
     cap_add:
       - NET_ADMIN # allow network setup
-    network_mode: host
     volumes:
       - "core-storage:/data"
       - "reports-storage:/reports"

--- a/suites/config.js
+++ b/suites/config.js
@@ -10,5 +10,5 @@ module.exports = [{
     organization: process.env.BALENACLOUD_ORG
   },
   image: false,
-  workers: ['http://localhost']
+  workers: ['http://worker']
 }];

--- a/suites/e2e/tests/power-cycle/index.js
+++ b/suites/e2e/tests/power-cycle/index.js
@@ -62,6 +62,7 @@ module.exports = {
 			title: 'Is the DUT reachable?',
 			run: async function (test) {
 
+				await this.worker.on();
 				await this.worker.addSSHKey(this.sshKeyPath);
 
 				// create tunnels
@@ -70,7 +71,6 @@ module.exports = {
 					this.link,
 				);
 
-				await this.worker.on();
 				this.log('Waiting for device to be reachable');
 				test.equal(
 					await this.context

--- a/worker/Dockerfile.template
+++ b/worker/Dockerfile.template
@@ -49,7 +49,7 @@ RUN mkdir -p /etc/qemu \
 WORKDIR /usr/app
 
 COPY config config
-COPY entry.sh .
+COPY entry.sh entry.sh
 
 COPY --from=node-build /tmp/node/package.json .
 COPY --from=node-build /tmp/node/node_modules node_modules


### PR DESCRIPTION
Switch to bridge networking for core, client and worker

- avoids all port conflicts when multiple copies of the stack are running on the same host

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>