### PR TITLE
delete client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ build: $(DOCKERCOMPOSE) ## Build the required images
 	$(DOCKERCOMPOSE) build $(BUILDARGS)
 
 test: $(DOCKERCOMPOSE) build ## Run the test suites
-	$(DOCKERCOMPOSE) up $(UPARGS) --exit-code-from client
+	$(DOCKERCOMPOSE) up $(UPARGS) --exit-code-from core
 
 local-test: ## Alias for 'make test WORKER_TYPE=qemu'
 	$(MAKE) test WORKER_TYPE=qemu

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -18,6 +18,10 @@ RUN apk add --no-cache \
 		util-linux
 
 COPY package*.json ./
+COPY tsconfig.json tsconfig.json
+COPY contracts contracts
+COPY lib lib
+COPY config config
 
 ENV npm_config_unsafe_perm true
 
@@ -30,13 +34,12 @@ RUN apk add --no-cache --virtual .build-deps \
 	npm ci && \
 	apk del .build-deps
 
+RUN npm run build
+
 # Install balena binary
 RUN ln -sf /usr/app/node_modules/balena-cli/bin/balena /usr/bin/balena && \
     balena version
 
-COPY contracts contracts
-COPY lib lib
-COPY config config
 COPY entry.sh entry.sh
 
 CMD [ "/usr/app/entry.sh" ]

--- a/core/entry.sh
+++ b/core/entry.sh
@@ -7,4 +7,5 @@ rm -f /var/run/docker.pid 2>/dev/null || true
 dockerd &
 
 eval $(ssh-agent)
-node lib/main.js
+
+cd /usr/app/build && node lib/main-alt.js

--- a/core/entry.sh
+++ b/core/entry.sh
@@ -8,4 +8,4 @@ dockerd &
 
 eval $(ssh-agent)
 
-cd /usr/app/build && node lib/main-alt.js
+cd /usr/app/build && node lib/main.js

--- a/core/lib/balena.ts
+++ b/core/lib/balena.ts
@@ -1,0 +1,91 @@
+import { BalenaSDK, DeviceTag } from 'balena-sdk';
+
+/**
+ * Contains information about the workers with tags that they have
+ */
+export class DeviceInfo {
+	constructor(
+		public readonly deviceId: number,
+		public readonly tags: { [key: string]: string },
+	) {}
+
+	/**
+	 * @returns unique worker prefix by joining values of DUT and model tag. Example: `raspberrypi3-64-RPi3_A`
+	 */
+	fileNamePrefix() {
+		return ['DUT', 'model']
+			.filter((tagName) => this.tags.hasOwnProperty(tagName))
+			.map((tagName) => this.tags[tagName].replace(/\s*[,;]?\s+/, '_'))
+			.join('-');
+	}
+}
+
+/**
+ * Groups unique devices containing tags with their value into a array containing DeviceInfo objects
+ */
+export function groupTagsData(allAppTags: DeviceTag[]): DeviceInfo[] {
+	const value: DeviceInfo[] = [];
+	return allAppTags.reduce((res, tagData) => {
+		const deviceId = (tagData.device as any).__id;
+		let data = res.find((info) => info.deviceId === deviceId);
+		if (data == null) {
+			data = new DeviceInfo(deviceId, {});
+			value.push(data);
+		}
+		data.tags[tagData.tag_key] = tagData.value;
+		return value;
+	}, value);
+}
+
+/**
+ * Interacts with balenaCloud for the client
+ */
+export class BalenaCloudInteractor {
+	constructor(private sdk: BalenaSDK) {}
+	/**
+	 * Authenticate balenaSDK with API key
+	 */
+	async authenticate(apiKey: string) {
+		await this.sdk.auth.loginWithToken(apiKey);
+	}
+
+	/**
+	 * @returns list of online devices containing the DUT tag with device type being tested as the value
+	 */
+	async selectDevicesWithDUT(
+		appName: string,
+		dutType: string,
+	): Promise<DeviceInfo[]> {
+		const selectedDevices = [];
+		const tags = await this.sdk.models.device.tags.getAllByApplication(appName);
+		const taggedDevices = groupTagsData(tags).filter(
+			(device) => device.tags['DUT'] === dutType,
+		);
+		for (const taggedDevice of taggedDevices) {
+			const online = await this.sdk.models.device.isOnline(
+				taggedDevice.deviceId,
+			);
+			if (online) {
+				selectedDevices.push(taggedDevice);
+			}
+		}
+		return selectedDevices;
+	}
+
+	/**
+	 * @throws error when public url for the device type is not accessible
+	 */
+	async checkDeviceUrl(device: DeviceInfo) {
+		const enabled = await this.sdk.models.device.hasDeviceUrl(device.deviceId);
+		if (!enabled) {
+			throw new Error('Worker not publicly available. Panicking...');
+		}
+	}
+
+	/**
+	 * @returns device's public URL
+	 */
+	async resolveDeviceUrl(device: DeviceInfo): Promise<string> {
+		return this.sdk.models.device.getDeviceUrl(device.deviceId);
+	}
+}

--- a/core/lib/common/suite.js
+++ b/core/lib/common/suite.js
@@ -145,7 +145,7 @@ class Suite {
 		};
 
 		try {
-			this.deviceType = require(`../../contracts/contracts/hw.device-type/${conf.deviceType}/contract.json`);
+			this.deviceType = require(`/usr/app/contracts/contracts/hw.device-type/${conf.deviceType}/contract.json`);
 		} catch (e) {
 			if (e.code === 'MODULE_NOT_FOUND') {
 				throw new Error(`Invalid/Unsupported device type: ${conf.deviceType}`);

--- a/core/lib/main.js
+++ b/core/lib/main.js
@@ -1,369 +1,96 @@
-/*
- * Copyright 2017 balena
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+import { BalenaCloudInteractor } from './balena';
 
-'use strict';
 
-const Bluebird = require('bluebird');
 const { fork } = require('child_process');
-const { getFilesFromDirectory } = require('./common/utils');
 const config = require('config');
-const express = require('express');
-const expressWebSocket = require('express-ws');
-const { ensureDir, pathExists, remove } = require('fs-extra');
-const md5 = require('md5-file/promise');
-const { fs, crypto } = require('mz');
-const { basename, join } = require('path');
-const tar = require('tar-fs');
-const pipeline = Bluebird.promisify(require('stream').pipeline);
-const WebSocket = require('ws');
-const { parse } = require('url'); // eslint-disable-line
-const { createGzip, createGunzip } = require('zlib');
-const setReportsHandler = require('./reports');
-const MachineState = require('./state');
 const { createWriteStream } = require('fs');
 
-async function setup() {
-	let suite = null;
-	const upload = {};
-	const app = express();
+const { getSdk } = require('balena-sdk');
+const logPath = `/reports/worker.log`;
+const logStream = createWriteStream(logPath);
 
-	const state = new MachineState();
+// need to take out the config part to give to the suite
+(async () => {
+    let runConfig = require('/usr/src/app/workspace/config.js');
+    console.log(runConfig);
+    runConfig = (runConfig instanceof Array) ? runConfig[0] : runConfig
+    let workerUrl = '';
+    if(!runConfig.workers instanceof Array){
+        for(let i = 0; i<10; i++){
+            const balena = getSdk({
+                apiurl: "https://api.balena-cloud.com/",
+            });
 
-	expressWebSocket(app, null, {
-		perMessageDeflate: false,
-	});
+            console.log(`Getting URL of worker`);
+            const balenaCloud = new BalenaCloudInteractor(balena);
+            await balenaCloud.authenticate(runConfig.workers.apiKey);
+            const matchingDevices = await balenaCloud.selectDevicesWithDUT(
+                runConfig.workers.balenaApplication,
+                runConfig.deviceType,
+            );
+            //  Throw an error if no matching workers are found.
+            if (matchingDevices.length === 0) {
+                throw new Error(
+                    `No workers found for deviceType: ${runConfig.deviceType}`,
+                );
+            }
 
-	setReportsHandler(app);
+            for (var device of matchingDevices) {
+                // check if device is idle & public URL is reachable
+                deviceUrl = await balenaCloud.resolveDeviceUrl(device);
+                try {
+                    let status = await rp.get(
+                        new url.URL('/state', deviceUrl).toString(),
+                    );
+                    if (status === 'IDLE') {
+                        // reserve the device 
+                        await rp.get(new url.URL('/start', deviceUrl).toString());
+                        workerUrl = deviceUrl;
+                        break
+                    }
+                } catch (err) {
+                    state.info(
+                        `Couldn't retrieve ${
+                            device.tags ? device.tags.DUT : device
+                        } worker's state. Querying ${deviceUrl} and received ${err.name}: ${
+                            err.statusCode
+                        }`,
+                    );
+                }
+            }
+            if(workerUrl !== ''){
+                break
+            }
+            await require('bluebird').delay(25000);
+        }
+    } else {
+        workerUrl = runConfig.workers[0]
+    }
 
-	app.post('/upload', async (req, res) => {
-		upload.retry = false;
-		state.busy();
-		res.writeHead(202, {
-			'Content-Type': 'text/event-stream',
-			Connection: 'keep-alive',
-		});
+    runConfig.config["worker"] = workerUrl;
+    runConfig.config["deviceType"] = runConfig.deviceType;
 
-		try {
-			if (parseFloat(req.headers['x-token']) !== upload.token) {
-				throw new Error('Unauthorized upload');
-			}
+    // 
+    // fork suite - should give config as an arg
+    let suite = fork('./lib/common/suite', {
+        stdio: 'inherit',
+    });
 
-			const artifact = {
-				name: req.headers['x-artifact'],
-				path: config.get('leviathan.uploads')[req.headers['x-artifact-id']],
-				hash: req.headers['x-artifact-hash'],
-			};
-			const ignore = ['node_modules'];
+    const suiteExitCode = await new Promise((resolve, reject) => {
+        suite.on('error', reject);
+        suite.on('exit', code => {
+            console.log(`Suite exiting with code: ${code}`);
+            resolve(code);
+        });
+    });
 
-			let hash = null;
-			if (await pathExists(artifact.path)) {
-				const stat = await fs.stat(artifact.path);
-
-				if (stat.isFile()) {
-					hash = await md5(artifact.path);
-				}
-				if (stat.isDirectory()) {
-					const struct = await getFilesFromDirectory(artifact.path, ignore);
-
-					const expand = await Promise.all(
-						struct.map(async entry => {
-							return {
-								path: entry.replace(
-									join(artifact.path, '/'),
-									join(artifact.name, '/'),
-								),
-								md5: await md5(entry),
-							};
-						}),
-					);
-
-					expand.sort((a, b) => {
-						const splitA = a.path.split('/');
-						const splitB = b.path.split('/');
-						return splitA.every((sub, i) => {
-							return sub <= splitB[i];
-						})
-							? -1
-							: 1;
-					});
-					hash = crypto
-						.Hash('md5')
-						.update(
-							expand.reduce((acc, value) => {
-								return acc + value.md5;
-							}, ''),
-						)
-						.digest('hex');
-				}
-			}
-			if (hash === artifact.hash) {
-				res.write('upload: cache');
-				upload.success = true;
-			} else {
-				res.write('upload: start');
-				// Make sure we start clean
-				await remove(artifact.path);
-				const line = pipeline(
-					req,
-					createGunzip(),
-					tar.extract(config.get('leviathan.workdir')),
-				).catch(err => {
-					throw err;
-				});
-
-				await line;
-				upload.success = true;
-				res.write('upload: done');
-			}
-		} catch (e) {
-			console.log(`Error detected: ${e}`);
-			upload.error = e;
-			upload.success = false;
-		} finally {
-			delete upload.token;
-			res.end();
-		}
-	});
-
-	app.ws('/start', async (ws, req) => {
-		state.busy();
-
-		const logPath = `/reports/worker.log`;
-		const logStream = createWriteStream(logPath);
-		const reconnect = parse(req.originalUrl).query === 'reconnect'; // eslint-disable-line
-		const running = suite != null;
-
-		// Keep the socket alive
-		const interval = setInterval(function timeout() {
-			if (ws.readyState === WebSocket.OPEN) {
-				ws.ping('heartbeat');
-			}
-		}, 1000);
-
-		// Handler definitions
-		const stdHandler = data => {
-			if (ws.readyState === WebSocket.OPEN) {
-				ws.send(
-					JSON.stringify({
-						type: 'log',
-						data: data.toString('utf-8').trimEnd(),
-					}),
-				);
-				logStream.write(`${data.toString('utf-8')}`, 'utf8');
-			}
-		};
-		const msgHandler = message => {
-			if (ws.readyState === WebSocket.OPEN) {
-				ws.send(JSON.stringify(message));
-			}
-			logStream.write(`${message.data.toString(`utf-8`)}`, 'utf8');
-		};
-
-		let suiteStarted = false;
-		try {
-			ws.on('error', console.error);
-			ws.on('close', () => {
-				clearInterval(interval);
-				state.idle();
-			});
-
-			if (running && !reconnect) {
-				throw new Error(
-					'Already running a suite. Please stop it or try again later.',
-				);
-			}
-
-			if (!running || !reconnect) {
-				if (process.env.LOCAL !== `local`) {
-					for (const uploadName in config.get('leviathan.uploads')) {
-						// put retry request here instead
-						upload.attempts = 0;
-						upload.retry = true;
-						upload.success = null;
-						while (upload.retry === true) {
-							upload.attempts = upload.attempts + 1;
-							if (upload.attempts > 3) {
-								throw new Error(
-									`Upload failed too many times: ${upload.attempts}`,
-								);
-							}
-							upload.token = Math.random();
-							ws.send(
-								JSON.stringify({
-									type: 'upload',
-									data: {
-										id: uploadName,
-										name: basename(config.get('leviathan.uploads')[uploadName]),
-										token: upload.token,
-										attempt: upload.attempts,
-									},
-								}),
-							);
-
-							// Wait for the upload to be received and finished
-							await new Promise((resolve, reject) => {
-								const timeout = setTimeout(() => {
-									clearInterval(interval);
-									clearTimeout(timeout);
-									reject(new Error('Upload timed out'));
-								}, 1200000);
-								const interval = setInterval(() => {
-									// upload.token is deleted when the upload has been done
-									if (upload.token == null) {
-										clearInterval(interval);
-										clearTimeout(timeout);
-										if (upload.success === true) {
-											upload.retry = false;
-											upload.attempts = 0;
-										} else {
-											upload.retry = true;
-										}
-										resolve();
-									}
-								}, 2000);
-								ws.once('close', () => {
-									clearInterval(interval);
-									clearTimeout(timeout);
-								});
-							});
-						}
-					}
-				}
-
-				// The reason we need to fork is because many 3rd party libariers output to stdout
-				// so we need to capture that
-				suite = fork('./lib/common/suite', {
-					stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
-				});
-				suiteStarted = true;
-			}
-
-			ws.on('message', message => {
-				try {
-					const { type, data } = JSON.parse(message);
-
-					if (type === 'input') {
-						suite.stdin.write(Buffer.from(data));
-					}
-				} catch (e) {
-					console.error(e);
-				}
-			});
-
-			suite.stdout.on('data', stdHandler);
-			suite.stderr.on('data', stdHandler);
-			suite.on('message', msgHandler);
-
-			if (reconnect) {
-				suite.send({ action: 'reconnect' });
-			}
-
-			const suiteExitCode = await new Promise((resolve, reject) => {
-				ws.on('close', () => {
-					// Make sure we get the handlers off to prevent a memory leak from happening
-					if (suite != null) {
-						suite.stdout.off('data', stdHandler);
-						suite.stderr.off('data', stdHandler);
-						suite.off('message', msgHandler);
-					}
-					resolve();
-				});
-				suite.on('error', reject);
-				suite.on('exit', code => {
-					console.log(`exit`);
-					resolve(code);
-				});
-			});
-
-			console.log(`Suite exit code is: ${suiteExitCode}`);
-			const success = suiteExitCode === 0;
-			ws.send(
-				JSON.stringify({
-					type: 'status',
-					data: { success },
-				}),
-			);
-
-			if (success) {
-				state.success();
-			} else {
-				state.failed();
-			}
-		} catch (e) {
-			state.failed();
-			if (ws.readyState === WebSocket.OPEN) {
-				ws.send(JSON.stringify({ type: 'error', data: { message: e.stack } }));
-			}
-		} finally {
-			ws.close();
-			logStream.end();
-			if (suiteStarted) {
-				suite = null;
-			}
-		}
-	});
-
-	app.get('/artifacts', async (_req, res) => {
-		try {
-			await ensureDir(config.get('leviathan.artifacts'));
-			tar
-				.pack(config.get('leviathan.artifacts'), {
-					readable: true,
-					writable: true,
-				})
-				.pipe(createGzip())
-				.pipe(res);
-		} catch (e) {
-			res.status(500).send(e.stack);
-		}
-	});
-
-	app.get('/state', async (_req, res) => {
-		try {
-			res.status(200).send(state.getState());
-		} catch (e) {
-			res.status(500).send(e.stack);
-		}
-	});
-
-	app.post('/stop', async (_req, res) => {
-		try {
-			if (suite != null) {
-				suite.on('exit', () => {
-					res.send('OK');
-				});
-				suite.kill('SIGINT');
-				suite = null;
-			} else {
-				res.send('OK');
-			}
-		} catch (e) {
-			res.status(500).send(e.stack);
-		}
-	});
-
-	return app;
-}
-
-(async function main() {
-	const port = config.get('express.port');
-
-	const server = await setup();
-
-	server.listen(port, () => {
-		console.log(`Listening on port ${port}`);
-	});
+    const success = suiteExitCode === 0;
+    if(success){
+        console.log(`Result: PASS`)
+        process.exitCode = 0
+    } else {
+        console.log(`Result: FAIL`)
+        process.exitCode = 1
+    }
+    process.exit()
 })();

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -27531,8 +27531,7 @@
 		"typescript": {
 			"version": "4.5.4",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-			"integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
-			"dev": true
+			"integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg=="
 		},
 		"uglify-js": {
 			"version": "3.14.5",

--- a/core/package.json
+++ b/core/package.json
@@ -2,6 +2,7 @@
 	"scripts": {
 		"lint:fix": "balena-lint -e js -e ts --fix lib/**/*",
 		"lint": "balena-lint -u -e js -e ts --tests lib/**/*",
+		"build": "tsc",
 		"start": "node lib/main.js",
 		"docs": "rimraf ../docs/ && npx typedoc --tsconfig tsconfig.json"
 	},
@@ -23,6 +24,7 @@
 		"lodash": "^4.17.10",
 		"md5-file": "^4.0.0",
 		"mz": "^2.7.0",
+		"typescript": "^4.4.4",
 		"node-ssh": "^5.1.2",
 		"npm": "^6.14.6",
 		"pensieve-sdk": "^1.0.0",
@@ -41,7 +43,6 @@
 		"@balena/lint": "^6.2.0",
 		"rimraf": "^3.0.2",
 		"typedoc": "^0.21.2",
-		"typedoc-plugin-pages-fork": "0.0.1",
-		"typescript": "^4.4.4"
+		"typedoc-plugin-pages-fork": "0.0.1"
 	}
 }

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -1,39 +1,25 @@
 {
   "compilerOptions": {
-    "typeRoots": [
-      "typings",
-      "node_modules/@types"
-    ],
     "module": "commonjs",
-    "target": "es2019",
-    "allowJs": true,
+    "target": "es5",
     "outDir": "build",
-    "strict": true,
-    "preserveConstEnums": true,
-    "declaration": true,
-    "pretty": true,
-    "sourceMap": true,
-    "skipLibCheck": true,
-    "resolveJsonModule": true,
-    "strictNullChecks": true,
     "noImplicitAny": true,
+    "noUnusedParameters": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true
+    "preserveConstEnums": true,
+    "removeComments": true,
+    "resolveJsonModule": true,
+    "sourceMap": true,
+    "strictNullChecks": true,
+    "strictBindCallApply": true,
+    "allowJs": true
   },
-  "exclude": [
-    "node_modules/**",
+  "include": [
+    "lib/**/*.*",  
+    "config/**/*.*",
+    "contracts/**/*.*"
   ],
-  "typedocOptions": {
-    "name": "Leviathan Helpers",
-    "entryPoints": ["lib/common", "lib/components"],
-    "out": "../docs/",
-    "theme": "pages-plugin",
-    "excludeExternals": true,
-    "excludePrivate": true,
-    "excludeProtected": true,
-    // "excludeNotDocumented": true,
-    "categorizeByGroup": true,
-    "categoryOrder": ["helper", "*"],
-    "highlightTheme": "slack-ochin",
-  }
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -1,34 +1,18 @@
 version: "2"
 
 services:
-  client:
-    build: ./client
-    volumes:
-      - "${WORKSPACE:-./workspace}:/usr/src/app/workspace:ro"
-      - "${REPORTS:-./workspace/reports}:/usr/src/app/reports:rw"
-      - "${SUITES:-./suites}:/usr/src/app/suites:ro"
-    environment:
-      - WORKER_PORT # allow this env var to be used in config.js
-      - BALENACLOUD_API_KEY # allow this env var to be used in config.js
-      - BALENACLOUD_ORG # allow this env var to be used in config.js
-      - BALENACLOUD_APP_NAME # allow this env var to be used in config.js
-      - DEVICE_TYPE # allow this env var to be used in config.js
-      - WORKER_TYPE # allow this env var to be used in config.js
-    depends_on:
-      - core
-
   core:
-    privileged: true # preload requires docker-in-docker
-    build: core
+    privileged: true
+    build:
+      context: ./core
     volumes:
-      - core-storage:/data
-      - reports-storage:/reports
+      - "${WORKSPACE:-./workspace}:/usr/src/app/workspace:rw"
+      - "${DATA:-./workspace/data}:/data:rw"
+      - "${REPORTS:-./workspace/reports}:/reports:rw"
     tmpfs:
       - /var/run # use tmpfs docker-in-docker pid files
       - /var/lib/docker # use tmpfs for docker-in-docker data root
     restart: 'no'
-    devices:
-      - /dev:/dev # required for creating losetup devices during preload
 
 volumes:
   core-storage:

--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -3,16 +3,24 @@ version: "2"
 services:
   core:
     privileged: true
-    build:
-      context: ./core
+    build: core
     volumes:
       - "${WORKSPACE:-./workspace}:/usr/src/app/workspace:rw"
       - "${DATA:-./workspace/data}:/data:rw"
       - "${REPORTS:-./workspace/reports}:/reports:rw"
+    environment:
+      - WORKER_PORT # allow this env var to be used in config.js
+      - BALENACLOUD_API_KEY # allow this env var to be used in config.js
+      - BALENACLOUD_ORG # allow this env var to be used in config.js
+      - BALENACLOUD_APP_NAME # allow this env var to be used in config.js
+      - DEVICE_TYPE # allow this env var to be used in config.js
+      - WORKER_TYPE # allow this env var to be used in config.js
     tmpfs:
       - /var/run # use tmpfs docker-in-docker pid files
       - /var/lib/docker # use tmpfs for docker-in-docker data root
     restart: 'no'
+    devices:
+      - /dev:/dev # required for creating losetup devices during preload
 
 volumes:
   core-storage:


### PR DESCRIPTION
As core is on the same machine as client, a lot of the client code is redundant. Moved the code that searches for a free balena device in an app into the core, and deleted most of the rest. 

To use, in your `workspace` directory, everything is the same - you just have to add a folder called `/data` in it, and add your suite and os image there. Then you can run tests as you normally would have, but there's no client. 

Todo:

- Cleanup / deletion of other stuff thats now redundant
- The client was the one in charge of running multiple suites in parallel. We lost that ability when we moved the core off of the worker (without creating multiple copies of core) - we haven't really figured out the solution to this yet

Change-type: minor
Signed-off-by: Ryan Cooke <ryan@balena.io>