### PR TITLE
core: worker: make ip() async

### DIFF
--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -232,11 +232,13 @@ module.exports = class Worker {
 		);
 	}
 
-	ip(target) {
+	async ip(target) {
 		// ip of DUT - used to talk to it
 		// if testbot/local testbot, then we dont wan't the ip, as we use SSH tunneling to talk to it - so return 127.0.0.1
 		// if qemu, return the ip - as we talk to the DUT directly
-		return this.url.includes(`worker`) ? this.getDutIp(target) : `127.0.0.1`;
+		return this.url.includes(`worker`)
+			? this.getDutIp(target)
+			: Promise.resolve(`127.0.0.1`);
 	}
 
 	async teardown() {


### PR DESCRIPTION
This method currently returns either a promise or a string, which breaks
code expecting a promise. Switch to async, and always return a promise.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>