### PR TITLE
minor: Transfer complete suiteConfig to core

### DIFF
--- a/client/bin/single-client.js
+++ b/client/bin/single-client.js
@@ -11,27 +11,9 @@ const yargs = require('yargs')
 		alias: 'help',
 		description: 'display help message',
 	})
-	.option('d', {
-		alias: 'deviceType',
-		description: 'name of the device type we are testing',
-		required: true,
-		type: 'string',
-	})
-	.option('s', {
-		alias: 'suite',
-		description: 'path to test suite',
-		required: true,
-		type: 'string',
-	})
-	.option('i', {
-		alias: 'image',
-		description: 'path to unconfigured OS image',
-		required: true,
-		type: 'string',
-	})
 	.option('c', {
-		alias: 'config',
-		description: 'path to configuration file',
+		alias: 'suiteConfig',
+		description: 'Config for the suite as a JSON string',
 		required: true,
 		type: 'string',
 	})
@@ -56,5 +38,6 @@ const yargs = require('yargs')
 
 	await ensureDir(client.workdir);
 	client.pipe(createWriteStream(join(client.workdir, 'log')));
-	await client.run(yargs.deviceType, yargs.suite, yargs.config, yargs.image);
+
+	await client.run(JSON.parse(yargs.suiteConfig));
 })();

--- a/core/lib/common/suite.js
+++ b/core/lib/common/suite.js
@@ -82,45 +82,45 @@ function cleanObject(object) {
 
 class Suite {
 	constructor() {
-		const conf = require(config.get('leviathan.uploads.config'));
+		const suiteConfig = require(config.get('leviathan.uploads.config'));
 		this.rootPath = path.join(__dirname, '..');
 		const options = {
 			id,
 			packdir: config.get('leviathan.workdir'),
-			tmpdir: conf.tmpdir || tmpdir(),
-			replOnFailure: conf.repl,
+			tmpdir: suiteConfig.config.tmpdir || tmpdir(),
+			replOnFailure: suiteConfig.config.repl,
 			balena: {
 				application: {
 					env: {
-						delta: conf.supervisorDelta || false,
+						delta: suiteConfig.config.supervisorDelta || false,
 					},
 				},
-				apiKey: conf.balenaApiKey,
-				apiUrl: conf.balenaApiUrl,
-				organization: conf.organization,
+				apiKey: suiteConfig.config.balenaApiKey,
+				apiUrl: suiteConfig.config.balenaApiUrl,
+				organization: suiteConfig.config.organization,
 			},
 			balenaOS: {
 				config: {
 					uuid: uid(),
 				},
 				download: {
-					version: conf.downloadVersion,
+					version: suiteConfig.config.downloadVersion,
 				},
 				network: {
-					wired: conf.networkWired,
-					wireless: conf.networkWireless,
+					wired: suiteConfig.config.networkWired,
+					wireless: suiteConfig.config.networkWireless,
 				},
 			},
 		};
 
 		// Setting the correct API environment for CLI calls
-		exec(`echo "balenaUrl: '${conf.balenaApiUrl}'" > ~/.balenarc.yml`);
+		exec(`echo "balenaUrl: '${suiteConfig.config.balenaApiUrl}'" > ~/.balenarc.yml`);
 
-		// In the future, deprecate the options object completely to create a mega-conf
+		// In the future, deprecate the options object completely to create a mega-suiteConfig
 		// Breaking changes will need to be done to both test suites + helpers
 		this.options = {
 			...options,
-			...conf,
+			...suiteConfig,
 		};
 		cleanObject(this.options);
 
@@ -145,10 +145,10 @@ class Suite {
 		};
 
 		try {
-			this.deviceType = require(`../../contracts/contracts/hw.device-type/${conf.deviceType}/contract.json`);
+			this.deviceType = require(`../../contracts/contracts/hw.device-type/${suiteConfig.deviceType}/contract.json`);
 		} catch (e) {
 			if (e.code === 'MODULE_NOT_FOUND') {
-				throw new Error(`Invalid/Unsupported device type: ${conf.deviceType}`);
+				throw new Error(`Invalid/Unsupported device type: ${suiteConfig.deviceType}`);
 			} else {
 				throw e;
 			}

--- a/suites/e2e/suite.js
+++ b/suites/e2e/suite.js
@@ -110,7 +110,7 @@ module.exports = {
 				{
 					deviceType: this.suite.deviceType.slug,
 					network: this.suite.options.balenaOS.network,
-					image: this.suite.options.image === 'false' ? `${await this.context
+					image: this.suite.options.image === false ? `${await this.context
 						.get()
 						.sdk.fetchOS(
 							this.suite.options.balenaOS.download.version,


### PR DESCRIPTION
Previously, we use to only pass `config` object of the suite config (config.js) to the tests. The journey of this config looks something like this, `multi-client --> single-client --> suite.js (core) --> test.js (core) --> suite.js (of the actual test)`

It's complex and in addition to that confusion, we pass only a part of the config.js. 

Why do this, when you can pass the complete config that the user provided with everything in it and let the core decide what to do with the information? 

This helps in scaling new features and configuration through our config.js in addition to making it super simple for users to read the config available to them to be used in their tests (using `this.suite`)

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
