### PR TITLE
patch: Remove Express server port config

### DIFF
--- a/core/config/default.js
+++ b/core/config/default.js
@@ -3,9 +3,6 @@ const mapValues = require('lodash/mapValues');
 const { join } = require('path');
 
 module.exports = {
-  express: {
-    port: process.env.CORE_PORT || 2000
-  },
   leviathan: {
     artifacts: '/tmp/artifacts',    // To store artifacts meant to be reported as results at the end of the suite
     downloads: '/data/downloads',    // To store/download assets needed for the suite (non-persistent) 

--- a/core/lib/main.js
+++ b/core/lib/main.js
@@ -359,7 +359,7 @@ async function setup() {
 }
 
 (async function main() {
-	const port = config.get('express.port');
+	const port = process.env.CORE_PORT || 2000
 
 	const server = await setup();
 


### PR DESCRIPTION
No longer needed to be configured using `default.js` configuration file. 

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
