### PR TITLE
Record environment variables to file for client env

### DIFF
--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -7,13 +7,8 @@ services:
       - "${WORKSPACE:-./workspace}:/usr/src/app/workspace:ro"
       - "${REPORTS:-./workspace/reports}:/usr/src/app/reports:rw"
       - "${SUITES:-./suites}:/usr/src/app/suites:ro"
-    environment:
-      - WORKER_PORT # allow this env var to be used in config.js
-      - BALENACLOUD_API_KEY # allow this env var to be used in config.js
-      - BALENACLOUD_ORG # allow this env var to be used in config.js
-      - BALENACLOUD_APP_NAME # allow this env var to be used in config.js
-      - DEVICE_TYPE # allow this env var to be used in config.js
-      - WORKER_TYPE # allow this env var to be used in config.js
+    env_file:
+      - .env
     depends_on:
       - core
 


### PR DESCRIPTION
Limit the environment variables passed to the client container by matching any of the following:

```
WORKSPACE
REPORTS
SUITES
DEVICE_TYPE
WORKER_TYPE
BALENA*
```

These can be provided either as an argument to make, or exported to the environment, or pre-written to the .env file.

### priority 1: env file
```bash
$ echo SUITES=/path/to/suites >> .env
$ echo BALENACLOUD_APP_NAME=balena/testbot >> .env
$ make env

WORKSPACE=./workspace
REPORTS=./workspace/reports
SUITES=/path/to/suites
DEVICE_TYPE=genericx86-64-ext
WORKER_TYPE=testbot
BALENACLOUD_APP_NAME=balena/testbot
```

###  priority 2: make arguments
```bash
$ make env SUITES=/path/to/suites BALENACLOUD_APP_NAME=balena/testbot

WORKSPACE=./workspace
REPORTS=./workspace/reports
SUITES=/path/to/suites
DEVICE_TYPE=genericx86-64-ext
WORKER_TYPE=testbot
BALENACLOUD_APP_NAME=balena/testbot
```

###  priority 3: environment variables
```bash
$ export SUITES=/path/to/suites
$ export BALENACLOUD_APP_NAME=balena/testbot
$ make env

WORKSPACE=./workspace
REPORTS=./workspace/reports
SUITES=/path/to/suites
DEVICE_TYPE=genericx86-64-ext
WORKER_TYPE=testbot
BALENACLOUD_APP_NAME=balena/testbot
```

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
Resolves: https://github.com/balena-os/leviathan/issues/726