### PR TITLE
make: Allow passed env vars to replace any .env values

### DIFF
--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -7,8 +7,12 @@ services:
       - "${WORKSPACE:-./workspace}:/usr/src/app/workspace:ro"
       - "${REPORTS:-./workspace/reports}:/usr/src/app/reports:rw"
       - "${SUITES:-./suites}:/usr/src/app/suites:ro"
-    env_file:
-      - .env
+    environment:
+      - WORKER_TYPE=${WORKER_TYPE}
+      - DEVICE_TYPE=${DEVICE_TYPE}
+      - BALENACLOUD_API_KEY=${BALENACLOUD_API_KEY}
+      - BALENACLOUD_ORG=${BALENACLOUD_ORG}
+      - BALENACLOUD_APP_NAME=${BALENACLOUD_APP_NAME}
     depends_on:
       - core
 


### PR DESCRIPTION
Reproduced the issue with a clean leviathan clone.

The priorities for variables have been adjusted as follows:

```bash
# 1. make arguments
make printenv SUITES=/path/to/suites | grep ^SUITES=             
SUITES=/path/to/suites

# 2. environment variables
SUITES=/path/to/suites make printenv | grep ^SUITES= 
SUITES=/path/to/suites

# 3. .env file
echo SUITES=/path/to/suites >> .env
make printenv | grep ^SUITES=
SUITES=/path/to/suites    
```

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
Extends: https://github.com/balena-os/leviathan/pull/733