### PR TITLE
Do not assume qemu DUT arch will match the host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,12 @@
-SHELL = /bin/bash
-CLIENTDIR := ./client
-COREDIR := ./core
-WORKERDIR := ./worker
-ENV_FILE := .env
 
-# import a local .env file if it exists
--include $(ENV_FILE)
+# if there is an .env file ensure the make args and env vars take priority
+# and then import all vars from the file
+ifneq (,$(wildcard .env))
+include $(shell t=$$(mktemp) ; cat .env 2>/dev/null > $$t ; printenv >> $$t ; echo $$t)
+endif
 
-# required variables that do not have a BALENA prefix
-export WORKSPACE ?= ./workspace
-export REPORTS ?= ./workspace/reports
-export SUITES ?= ./suites
-export DEVICE_TYPE ?= genericx86-64-ext
-export WORKER_TYPE ?= testbot
-
-ENV_VARS := WORKSPACE REPORTS SUITES DEVICE_TYPE WORKER_TYPE $(filter BALENA%,$(.VARIABLES))
+# export all variables to child processes by default
+export
 
 # optional docker-compose args
 BUILDARGS := --parallel --progress=plain
@@ -25,33 +17,28 @@ CLIENTCOMPOSEFILE := docker-compose.client.yml
 
 # only use the qemu compose file if worker type is qemu
 ifeq ($(WORKER_TYPE),qemu)
-export COMPOSE_FILE := $(CLIENTCOMPOSEFILE):$(QEMUCOMPOSEFILE)
+COMPOSE_FILE := $(CLIENTCOMPOSEFILE):$(QEMUCOMPOSEFILE)
 else
-export COMPOSE_FILE := $(CLIENTCOMPOSEFILE)
+COMPOSE_FILE := $(CLIENTCOMPOSEFILE)
 endif
 
 # for qemu workers we need to set the BALENA_ARCH to pull the correct balenalib image
 ifeq ($(shell uname -m),aarch64)
-export BALENA_ARCH ?= aarch64
-export QEMU_ARCH ?= aarch64
+BALENA_ARCH ?= aarch64
+QEMU_ARCH ?= aarch64
 else
-export BALENA_ARCH ?= amd64
-export QEMU_ARCH ?= x86_64
+BALENA_ARCH ?= amd64
+QEMU_ARCH ?= x86_64
 endif
 
-export COMPOSE_DOCKER_CLI_BUILD := 1
-export DOCKER_BUILDKIT := 1
-export DOCKERD_EXTRA_ARGS :=
+COMPOSE_DOCKER_CLI_BUILD := 1
+DOCKER_BUILDKIT := 1
+DOCKERD_EXTRA_ARGS :=
 
 # BUILD_TAG is a unique Jenkins environment variable
 ifneq ($(BUILD_TAG),)
-export COMPOSE_PROJECT := $(BUILD_TAG)
+COMPOSE_PROJECT := $(BUILD_TAG)
 endif
-
-env:
-	$(shell rm $(ENV_FILE))
-	$(foreach v, $(ENV_VARS), $(file >>$(ENV_FILE),$(v)=$($(v))))
-	@cat $(ENV_FILE)
 
 DOCKERCOMPOSE := ./bin/docker-compose
 
@@ -68,13 +55,16 @@ $(DOCKERCOMPOSE):
 help: ## Print help message
 	@echo -e "$$(grep -hE '^\S+:.*##' $(MAKEFILE_LIST) | sed -e 's/:.*##\s*/:/' -e 's/^\(.\+\):\(.*\)/\\x1b[36m\1\\x1b[m:\2/' | column -c2 -t -s :)"
 
-config: $(DOCKERCOMPOSE) env ## Print flattened docker-compose definition
+printenv:
+	@printenv
+
+config: $(DOCKERCOMPOSE) ## Print flattened docker-compose definition
 	$(DOCKERCOMPOSE) config
 
-build: $(DOCKERCOMPOSE) env ## Build the required images
+build: $(DOCKERCOMPOSE) ## Build the required images
 	$(DOCKERCOMPOSE) build $(BUILDARGS)
 
-test: $(DOCKERCOMPOSE) build env ## Run the test suites
+test: $(DOCKERCOMPOSE) build ## Run the test suites
 	$(DOCKERCOMPOSE) up $(UPARGS) --exit-code-from client
 
 local-test: ## Alias for 'make test WORKER_TYPE=qemu'
@@ -86,7 +76,7 @@ qemu: ## Alias for 'make test WORKER_TYPE=qemu'
 testbot:## Alias for 'make test WORKER_TYPE=testbot'
 	$(MAKE) test WORKER_TYPE=testbot
 
-stop: $(DOCKERCOMPOSE) env ## Stop and remove any existing containers and volumes
+stop: $(DOCKERCOMPOSE) ## Stop and remove any existing containers and volumes
 	$(DOCKERCOMPOSE) down --remove-orphans --rmi all --volumes
 
 down: stop ## Alias for 'make stop'

--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,14 @@ else
 COMPOSE_FILE := $(CLIENTCOMPOSEFILE)
 endif
 
-# for qemu workers we need to set the BALENA_ARCH to pull the correct balenalib image
+# for arm64 hosts we need to set the BALENA_ARCH to pull the correct balenalib worker image
 ifeq ($(shell uname -m),aarch64)
 BALENA_ARCH ?= aarch64
+endif
+
+# for generic-aarch64 we need to set the qemu architecture
+ifeq ($(DEVICE_TYPE),generic-aarch64)
 QEMU_ARCH ?= aarch64
-else
-BALENA_ARCH ?= amd64
-QEMU_ARCH ?= x86_64
 endif
 
 COMPOSE_DOCKER_CLI_BUILD := 1

--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -7,8 +7,12 @@ services:
       - "${WORKSPACE:-./workspace}:/usr/src/app/workspace:ro"
       - "${REPORTS:-./workspace/reports}:/usr/src/app/reports:rw"
       - "${SUITES:-./suites}:/usr/src/app/suites:ro"
-    env_file:
-      - .env
+    environment:
+      - WORKER_TYPE=${WORKER_TYPE}
+      - DEVICE_TYPE=${DEVICE_TYPE}
+      - BALENACLOUD_API_KEY=${BALENACLOUD_API_KEY}
+      - BALENACLOUD_ORG=${BALENACLOUD_ORG}
+      - BALENACLOUD_APP_NAME=${BALENACLOUD_APP_NAME}
     depends_on:
       - core
 

--- a/worker/Dockerfile.template
+++ b/worker/Dockerfile.template
@@ -34,9 +34,7 @@ RUN apk add --no-cache \
   libusb-dev dbus-dev eudev-dev \
   gstreamer-tools gst-plugins-base gst-plugins-bad gst-plugins-good \
   bridge bridge-utils iproute2 dnsmasq iptables \
-  qemu-img qemu-system-x86_64 \
-    && rm /usr/share/qemu/edk2* `# remove huge edk2 firmware` \
-  && (apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.12/community ovmf || true)
+  qemu-img qemu-system-x86_64 qemu-system-aarch64
 
 RUN apk add uhubctl --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing || true
 

--- a/worker/config/default.js
+++ b/worker/config/default.js
@@ -14,7 +14,7 @@ module.exports = {
 			qemu: {
 				architecture: process.env.QEMU_ARCH || 'x86_64',
 				cpus: process.env.QEMU_CPUS || '4',
-				memory: process.env.QEMU_MEMORY || '2G',
+				memory: process.env.QEMU_MEMORY || '512M',
 				debug: process.env.QEMU_DEBUG || false,
 				network: {
 					autoconfigure: true,

--- a/worker/lib/workers/qemu.ts
+++ b/worker/lib/workers/qemu.ts
@@ -343,6 +343,8 @@ class QemuWorker extends EventEmitter implements Leviathan.Worker {
 			args = args.concat(gfxArgs);
 		}
 
+		console.debug("QEMU args:\n", args);
+
 		return new Promise((resolve, reject) => {
 			let options = {};
 			if (this.qemuOptions.debug) {

--- a/worker/lib/workers/qemu.ts
+++ b/worker/lib/workers/qemu.ts
@@ -203,6 +203,11 @@ class QemuWorker extends EventEmitter implements Leviathan.Worker {
 					vars: '/usr/share/OVMF/OVMF_VARS.fd',
 				},
 				{
+					// alpine, qemu
+					code: '/usr/share/qemu/edk2-x86_64-code.fd',
+					vars: '/usr/share/qemu/edk2-x86_64-i386-vars.fd',
+				},
+				{
 					// archlinux
 					code: '/usr/share/ovmf/x64/OVMF_CODE.fd',
 					vars: '/usr/share/ovmf/x64/OVMF_VARS.fd',
@@ -210,9 +215,14 @@ class QemuWorker extends EventEmitter implements Leviathan.Worker {
 			],
 			aarch64: [
 				{
-					// alpine
+					// alpine, ovmf
 					code: '/usr/share/OVMF/QEMU_EFI.fd',
 					vars: '/usr/share/OVMF/QEMU_VARS.fd',
+				},
+				{
+					// alpine, qemu
+					code: '/usr/share/qemu/edk2-aarch64-code.fd',
+					vars: '/usr/share/qemu/edk2-arm-vars.fd',
 				},
 				{
 					// fedora


### PR DESCRIPTION
When KVM is not used we can easily emulate generic-aarch64
on x86_64 hosts so avoid tying the host and target architectures
together in the Makefile.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>