### PR TITLE
worker: qemu: add new qemu firmware paths

### DIFF
--- a/worker/lib/workers/qemu.ts
+++ b/worker/lib/workers/qemu.ts
@@ -203,6 +203,11 @@ class QemuWorker extends EventEmitter implements Leviathan.Worker {
 					vars: '/usr/share/OVMF/OVMF_VARS.fd',
 				},
 				{
+					// alpine, qemu
+					code: '/usr/share/qemu/edk2-x86_64-code.fd',
+					vars: '/usr/share/qemu/edk2-x86_64-i386-vars.fd',
+				},
+				{
 					// archlinux
 					code: '/usr/share/ovmf/x64/OVMF_CODE.fd',
 					vars: '/usr/share/ovmf/x64/OVMF_VARS.fd',
@@ -210,9 +215,14 @@ class QemuWorker extends EventEmitter implements Leviathan.Worker {
 			],
 			aarch64: [
 				{
-					// alpine
+					// alpine, ovmf
 					code: '/usr/share/OVMF/QEMU_EFI.fd',
 					vars: '/usr/share/OVMF/QEMU_VARS.fd',
+				},
+				{
+					// alpine, qemu
+					code: '/usr/share/qemu/edk2-aarch64-code.fd',
+					vars: '/usr/share/qemu/edk2-arm-vars.fd',
 				},
 				{
 					// fedora


### PR DESCRIPTION
Search for firmware shipped as part of QEMU package to enable
cross-platform emulation with UEFI.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>