### PR TITLE
worker: qemu: remove debug print statements

### DIFF
--- a/worker/lib/workers/qemu.ts
+++ b/worker/lib/workers/qemu.ts
@@ -245,8 +245,6 @@ class QemuWorker extends EventEmitter implements Leviathan.Worker {
 	}
 
 	public async powerOn(): Promise<void> {
-		console.log('QEMU: powerOn');
-
 		let vncport = null;
 		let qmpPort = null;
 
@@ -376,7 +374,6 @@ class QemuWorker extends EventEmitter implements Leviathan.Worker {
 	}
 
 	public async powerOff(): Promise<void> {
-		console.log('QEMU: powerOff');
 		return new Promise((resolve, reject) => {
 			if (this.qemuProc && !this.qemuProc.killed) {
 				// don't return until the process is dead


### PR DESCRIPTION
Log statements for powerOn/powerOff were added for debugging when
refactoring the QEMU worker to operate w/out libvirt. Remove these.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>