### PR TITLE
core: suiteSubprocess: replace this.state.log w/ console.log

### DIFF
--- a/core/lib/common/suiteSubprocess.js
+++ b/core/lib/common/suiteSubprocess.js
@@ -33,7 +33,7 @@ const suiteConfig = require(config.get('leviathan.uploads.config'));
 async function removeArtifacts() {
 	const artifactsPath = config.get('leviathan.artifacts');
 	if (fs.existsSync(artifactsPath)) {
-		this.state.log(`Removing artifacts from previous tests...`);
+		console.log(`Removing artifacts from previous tests...`);
 		fs.emptyDirSync(artifactsPath);
 	}
 }


### PR DESCRIPTION
This fixes the error:
  TypeError: Cannot read property 'state' of undefined

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>