### PR TITLE
catch error in executeCommandInhostOs

### DIFF
--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -300,7 +300,14 @@ module.exports = class Worker {
 
 		return retry(
 			async () => {
-				const result = await utils.executeCommandOverSSH(command, config);
+				let result = {}
+				try {
+					result = await utils.executeCommandOverSSH(command, config);
+				} catch (err){
+					console.error(err)
+					console.log(`Error while performing SSH command "${command}", will retry...`);
+					throw new Error(err);
+				}
 
 				if (typeof result.code === 'number' && result.code !== 0) {
 					throw new Error(


### PR DESCRIPTION
catch error thrown when execute command over ssh fails

This may not fix the errors we are seeing, but will at least provide more information

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>
See: https://github.com/balena-os/meta-balena/issues/2671