### PR TITLE
core: catch ssh errors correctly

### DIFF
--- a/core/lib/common/utils.js
+++ b/core/lib/common/utils.js
@@ -65,16 +65,22 @@ module.exports = {
 	executeCommandOverSSH: async (command, config) => {
 		return Bluebird.using(getSSHClientDisposer(config), (client) => {
 			return new Bluebird(async (resolve, reject) => {
-				client.connection.on('error', (err) => {
-					reject(err);
-				});
-				resolve(
-					await client.exec(command, [], {
-						stream: 'both',
-					}),
-				);
-			});
-		});
+				try{
+					client.connection.on('error', (err) => {
+						console.log(`Connection err: ${err.message}`)
+						reject(err);
+					});
+
+					resolve(
+						await client.exec(command, [], {
+							stream: 'both',
+						}),
+					);
+				} catch(e){
+					reject(e)
+				}
+			})
+		})
 	},
 
 	/**


### PR DESCRIPTION
Catch unhandled errors within `executeCommandOverSSH` function. 

When this function is used during the `reboot` function, there is a high probability that SSH attempts are going to be made while the DUT is offline, or the DUT will drop offline while the SSH connection is active. This can sometimes lead to `node-ssh` and `ssh2` packages throwing various errors, including `unable to exec` and `no response from server`. 

Sometimes, these errors would not be caught and handled - I think it depended on when exactly the DUT went offline/when the attempt to SSH was made. The unhandled error leads to the entire test suite crashing, and a large crashdump of unhelpful logs. 

Here, I've attempted to catch all errors that might occur in the function, and then reject the promise.

Tested with testbot + rpi3 as the DUT. I ran this test in a loop https://github.com/balena-os/meta-balena/blob/master/tests/suites/os/tests/fsck/index.js over and over, as it has a `reboot` in it, and I've often seen the pi3 fail during this test. 

Without this PR, the crashes were reproduced regularly. With the changes made in this PR, the crashes didn't happen in ~30 runs of the test

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>
Resolves: https://github.com/balena-os/meta-balena/issues/2671