### PR TITLE
core: utils: reduce waitUntil interval

### DIFF
--- a/core/lib/common/utils.js
+++ b/core/lib/common/utils.js
@@ -95,8 +95,8 @@ module.exports = {
 	waitUntil: async (
 		promise,
 		rejectionFail = false,
-		_times = 20,
-		_delay = 30000,
+		_times = 2 * 60 * 4, // 2m
+		_delay = 250,
 	) => {
 		const _waitUntil = async (timesR) => {
 			if (timesR === 0) {


### PR DESCRIPTION
Now that most uses of waitUntil() have explicit intervals and timeouts,
reduce the default interval to 250ms, and the timeout to 2m, to remove
excessive unintentional waits in new tests without explicit options.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>