### PR TITLE
reduce ssh retries

### DIFF
--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -333,7 +333,7 @@ module.exports = class Worker {
 				return result.stdout;
 			},
 			{
-				max_tries: 5 * 60,
+				max_tries: 30,
 				interval: 1000,
 				throw_original: true,
 			},


### PR DESCRIPTION
reduce from 300 retries to 30 

Could be more of an aggressive reduction, but lets see how this affects things first

resolves: https://github.com/balena-os/leviathan/issues/793 https://github.com/balena-os/leviathan/issues/787

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>