### PR TITLE
core: worker: add retryOptions to executeCommand methods

### DIFF
--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -293,7 +293,7 @@ module.exports = class Worker {
 	 *
 	 * @category helper
 	 */
-	async executeCommandInHostOS(command, target) {
+	async executeCommandInHostOS(command, target, retryOptions={}) {
 		command = command instanceof Array ? command.join(' ') : command;
 		let config = {};
 		// depending on if the target argument is a .local uuid or not, SSH via the proxy or directly
@@ -336,11 +336,12 @@ module.exports = class Worker {
 				max_tries: 5 * 60,
 				interval: 1000,
 				throw_original: true,
+				...retryOptions,
 			},
 		);
 	}
 
-	async executeCommandInWorkerHost(command) {
+	async executeCommandInWorkerHost(command, retryOptions={}) {
 		let config = {
 			host: this.workerHost,
 			port: this.workerPort,
@@ -372,12 +373,13 @@ module.exports = class Worker {
 				max_tries: 30,
 				interval: 5000,
 				throw_original: true,
+				...retryOptions,
 			},
 		);
 	}
 
 	// executes command in the worker container
-	async executeCommandInWorker(command) {
+	async executeCommandInWorker(command, retryOptions={}) {
 		return retry(
 			async () => {
 				let containerId = await this.executeCommandInWorkerHost(
@@ -392,6 +394,7 @@ module.exports = class Worker {
 				max_tries: 10,
 				interval: 1000,
 				throw_original: true,
+				...retryOptions,
 			},
 		);
 	}


### PR DESCRIPTION
The executeCommand family of methods default to retrying on failure. In
some cases, such as in the ssh-auth test in the cloud test suite, we
expect failures to happen, and want them to be raised immediately. Other
situations might demand adjusting the number of retries and interval to
fit specific tests. Add a retryOptions object to these methods to allow
for this behavior to be configured.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>