### PR TITLE
compose: qemu: enable loopback and metadata devices

### DIFF
--- a/docker-compose.qemu.yml
+++ b/docker-compose.qemu.yml
@@ -9,11 +9,17 @@ services:
         - BALENA_ARCH=${BALENA_ARCH:-amd64}
         - WORKER_RELEASE=${WORKER_RELEASE:-latest}
     device_cgroup_rules:
+      # https://www.kernel.org/doc/Documentation/admin-guide/devices.txt
+      # loopback devices
+      - "b 7:* rmw"
+      # metadata devices
+      - "b 9:* rmw"
       # allow dynamic creation and access of qemu required misc chardev nodes
       # this includes /dev/kvm, and /dev/net/tun
       - "c 10:* rmw"
     cap_add:
       - NET_ADMIN # allow network setup
+      - SYS_ADMIN # privileged IOCTLs, such as used by mdadm
     volumes:
       - "core-storage:/data"
       - "reports-storage:/reports"


### PR DESCRIPTION
Copied from https://github.com/balena-os/leviathan-worker/pull/21

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>