### PR TITLE
compose: client: explicitly enable udev

### DIFF
--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -8,6 +8,7 @@ services:
       - "${REPORTS:-./workspace/reports}:/usr/src/app/reports:rw"
       - "${SUITES:-./suites}:/usr/src/app/suites:ro"
     environment:
+      - UDEV=1
       - WORKER_TYPE=${WORKER_TYPE}
       - DEVICE_TYPE=${DEVICE_TYPE}
       - BALENACLOUD_API_KEY=${BALENACLOUD_API_KEY}


### PR DESCRIPTION
Testbot workers require udev to be running while qemu workers manage
devices themselves, and require udev to be disabled. Explicitly add the
UDEV env var to the compose file for testbot workers, to be consistent
with the qemu compose file.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>