### PR TITLE
patch: Fix contracts name

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "core/contracts/contracts"]
+[submodule "contracts/contracts"]
 	path = core/contracts/contracts
 	url = https://github.com/balena-io/contracts.git


### PR DESCRIPTION
With the patch #810, we were seeing the following error on pulling the contracts. 

```
➜  leviathan-push git:(master) git submodule update --init --recursive
Submodule 'core/contracts/contracts' (https://github.com/balena-io/contracts.git) registered for path 'core/contracts/contracts'
error: submodule git dir '/home/vipulgupta2048/work/leviathan-push/.git/modules/core/contracts/contracts' is inside git dir '/home/vipulgupta2048/work/leviathan-push/.git/modules/core/contracts'
fatal: refusing to create/use '/home/vipulgupta2048/work/leviathan-push/.git/modules/core/contracts/contracts' in another submodule's git dir
Failed to clone 'core/contracts/contracts'. Retry scheduled
error: submodule git dir '/home/vipulgupta2048/work/leviathan-push/.git/modules/core/contracts/contracts' is inside git dir '/home/vipulgupta2048/work/leviathan-push/.git/modules/core/contracts'
fatal: refusing to create/use '/home/vipulgupta2048/work/leviathan-push/.git/modules/core/contracts/contracts' in another submodule's git dir
Failed to clone 'core/contracts/contracts' a second time, aborting
```

Thankfully, this Stackoverflow question made the error clear: https://stackoverflow.com/questions/64898200/git-refusing-to-create-use-dir-in-other-submodules-dir


Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
