### PR TITLE
increase timeout on local push sv ping

### DIFF
--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -522,7 +522,7 @@ module.exports = class Worker {
 				(await rp({
 					method: 'GET',
 					uri: `http://${ip}:48484/ping`,
-					timeout: 5000
+					timeout: 5000 * 5
 				})) === 'OK'
 			);
 		}, false);


### PR DESCRIPTION
The GET request to the DUT supervisor endpoint has a timeout of 5 seconds  - when doing this request to the tx2 DUT, there is a high chance of this timeout being exceeded, causing the `pushContainerToDut()` function to fail.

Increased it - currently testing it out

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>