### PR TITLE
Revert "worker: Pin to stable release 2.5.10 prior to md support"

### DIFF
--- a/docker-compose.qemu.yml
+++ b/docker-compose.qemu.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: Dockerfile.template
       args:
         - BALENA_ARCH=${BALENA_ARCH:-amd64}
-        - WORKER_RELEASE=${WORKER_RELEASE:-2.5.10}
+        - WORKER_RELEASE=${WORKER_RELEASE:-latest}
     device_cgroup_rules:
       # https://www.kernel.org/doc/Documentation/admin-guide/devices.txt
       # loopback devices

--- a/worker/Dockerfile.template
+++ b/worker/Dockerfile.template
@@ -1,4 +1,4 @@
 ARG BALENA_ARCH=%%BALENA_ARCH%%
-ARG WORKER_RELEASE=2.5.10
+ARG WORKER_RELEASE=latest
 # https://hub.balena.io/organizations/balena/blocks/leviathan-worker-amd64/releases
 FROM bh.cr/balena/leviathan-worker-${BALENA_ARCH}/${WORKER_RELEASE}


### PR DESCRIPTION
This reverts commit 3b6ce13734e98e981492e01bc874c0a439cb1536.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>