### PR TITLE
patch: Add support to search DUTs in multiple fleets

### DIFF
--- a/client/bin/multi-client.js
+++ b/client/bin/multi-client.js
@@ -328,21 +328,11 @@ class NonInteractiveState {
 				});
 			} else if (runConfig.workers instanceof Object) {
 				await balenaCloud.authenticate(runConfig.workers.apiKey);
-				if (Array.isArray(runConfig.workers.balenaApplication)) {
-					const matchingDevices = runConfig.workers.balenaApplication.map(async () => {
-						await balenaCloud.selectDevicesWithDUT(
-							runConfig.workers.balenaApplication,
-							runConfig.deviceType,
-						)
-					})
-				} else {
-					const matchingDevices = await balenaCloud.selectDevicesWithDUT(
-						runConfig.workers.balenaApplication,
-						runConfig.deviceType,
-					)
+				let balenaApplications = Array.isArray(runConfig.workers.balenaApplication) ? runConfig.workers.balenaApplication : [runConfig.workers.balenaApplication];
+				let matchingDevices = []
+				for (const balenaApplication of balenaApplications) {
+					matchingDevices = [...(await balenaCloud.selectDevicesWithDUT(balenaApplication, runConfig.deviceType)), ...matchingDevices]
 				}
-
-				console.log(matchingDevices)
 
 				//  Throw an error if no matching workers are found.
 				if (matchingDevices.length === 0) {

--- a/client/bin/multi-client.js
+++ b/client/bin/multi-client.js
@@ -328,10 +328,21 @@ class NonInteractiveState {
 				});
 			} else if (runConfig.workers instanceof Object) {
 				await balenaCloud.authenticate(runConfig.workers.apiKey);
-				const matchingDevices = await balenaCloud.selectDevicesWithDUT(
-					runConfig.workers.balenaApplication,
-					runConfig.deviceType,
-				);
+				if (Array.isArray(runConfig.workers.balenaApplication)) {
+					const matchingDevices = runConfig.workers.balenaApplication.map(async () => {
+						await balenaCloud.selectDevicesWithDUT(
+							runConfig.workers.balenaApplication,
+							runConfig.deviceType,
+						)
+					})
+				} else {
+					const matchingDevices = await balenaCloud.selectDevicesWithDUT(
+						runConfig.workers.balenaApplication,
+						runConfig.deviceType,
+					)
+				}
+
+				console.log(matchingDevices)
 
 				//  Throw an error if no matching workers are found.
 				if (matchingDevices.length === 0) {
@@ -358,7 +369,7 @@ class NonInteractiveState {
 		// While jobs are present the runQueue
 		while (runQueue.length > 0) {
 			// TEMP WORKAROUND: Only start a suite if one is not already running
-			if(suiteRunning === false){
+			if (suiteRunning === false) {
 				const job = runQueue.pop();
 				// If matching workers for the job are available then allot them a job
 				for (var device of job.matchingDevices) {

--- a/client/lib/schemas/multi-client-config.js
+++ b/client/lib/schemas/multi-client-config.js
@@ -33,7 +33,17 @@ const innerSchema = {
 					type: 'object',
 					properties: {
 						balenaApplication: {
-							type: 'string',
+							oneOf: [
+								{
+									type: 'array', 
+									items: {
+										type: 'string',
+									} 
+								},
+								{
+									type: 'string',
+								},
+							],
 						},
 						apiKey: {
 							type: 'string',


### PR DESCRIPTION
Haven't tested it, since I needed another fleet to test this in but I am confident it should work fine. 
To search in more than one fleet for potential workers, create an array of fleet slugs in the worker object. That's the solution. Again though, I need to test this before getting it through and probably it would be better if we could write tests for it as well. 

Context: https://balena.zulipchat.com/#narrow/stream/345889-loop.2Fbalena-os/topic/London.20test.20rig.20EOL/near/308002887
Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
