### PR TITLE
core: Reduce retries on fetching IP address of DUT

### DIFF
--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -220,7 +220,7 @@ module.exports = class Worker {
 		target,
 		timeout = {
 			interval: 1000,
-			tries: 120,
+			tries: 30,
 		},
 	) {
 		return retry(


### PR DESCRIPTION
…ss of the DUT

Instead of retrying to get the DUT IP address 120 times on a 1 seconds interval, let's reduce it to 30 times because the resolveLocalTarget itself will timeout too in 15 seconds: https://github.com/balena-os/leviathan-worker/blob/master/lib/helpers/index.ts#L162

So reducing the retries number to 30 will effectly bring the total combined timeout to a maximum of 8 minutes.

Change-type: patch
Signed-off-by: Florin Sarbu <florin@balena.io>