### PR TITLE
os/balenaos: Remove hidden attribute from DUT wireless connection file

### DIFF
--- a/core/lib/components/os/balenaos.js
+++ b/core/lib/components/os/balenaos.js
@@ -96,7 +96,6 @@ const injectNetworkConfiguration = async (image, configuration, partition = 1) =
 		'id=balena-wifi',
 		'type=wifi',
 		'[wifi]',
-		'hidden=true',
 		'mode=infrastructure',
 		`ssid=${configuration.wireless.ssid}`,
 		'[ipv4]',


### PR DESCRIPTION
The testbot AP is visible and is discovered during a scan. Let's remove the hidden attribute as it may cause problems for the 243390-rpi wireless tests.

Change-type: patch
Changelog-entry: Remove hidden attribute from DUT wireless connection file

Connects-to: https://github.com/balena-os/meta-balena/pull/2802