### PR TITLE
patch: Improve archivelogs journalctl command

### DIFF
--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -656,7 +656,7 @@ module.exports = class Worker {
 	async archiveLogs(
 		title,
 		target,
-		command = 'journalctl --no-pager --no-hostname -a -b all',
+		command = "journalctl --no-pager --no-hostname --list-boots | awk '{print $1}' | xargs -I{} sh -c 'set -x; journalctl --no-pager --no-hostname -a -b {} || true;'",
 	) {
 		const logFilePath = `/tmp/${command.split(' ')[0]}-${id()}.log`;
 		this.logger.log(
@@ -666,7 +666,7 @@ module.exports = class Worker {
 			const commandOutput = await this.executeCommandInHostOS(
 				`${command}`,
 				target,
-				{ interval: 10000, tries: 3 },
+				{ interval: 5000, max_tries: 3 },
 			);
 			fs.writeFileSync(logFilePath, commandOutput);
 			await archiver.add(title, logFilePath);


### PR DESCRIPTION
During etcherPro testing we witnessed, the current implementation of journalctl command failing. Hence, we came up with a command that potentially would be backward compatible for all versions.

Additionally, timeouts were incorrectly being overridden by the archivelogs helper leading to a timeout of potentially 50 minutes if it fails. Fixed that to do only 3 retires of 5 seconds each. 

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
