### PR TITLE
Revert "docker-compose: stop using the default docker bridge"

### DIFF
--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -15,8 +15,6 @@ services:
       - BALENACLOUD_APP_NAME=${BALENACLOUD_APP_NAME}
     depends_on:
       - core
-    networks:
-      - virtual-bridge
 
   core:
     privileged: true # preload requires docker-in-docker
@@ -30,18 +28,7 @@ services:
     restart: 'no'
     devices:
       - /dev:/dev # required for creating losetup devices during preload
-    networks:
-      - virtual-bridge
 
 volumes:
   core-storage:
   reports-storage:
-
-networks:
-  virtual-bridge:
-    driver: bridge
-    ipam:
-      driver: default
-      config:
-        - subnet: 172.56.0.0/16
-          gateway: 172.56.100.1

--- a/docker-compose.qemu.yml
+++ b/docker-compose.qemu.yml
@@ -33,8 +33,6 @@ services:
       - QEMU_MEMORY=${QEMU_MEMORY}
       - QEMU_DEBUG=${QEMU_DEBUG}
     restart: 'no'
-    networks:
-      - virtual-bridge
 
   core:
     depends_on:
@@ -43,12 +41,3 @@ services:
 volumes:
   core-storage:
   reports-storage:
-
-networks:
-  virtual-bridge:
-    driver: bridge
-    ipam:
-      driver: default
-      config:
-        - subnet: 172.56.0.0/16
-          gateway: 172.56.100.1


### PR DESCRIPTION
This reverts commit eb69ff445fe0cac4f2060e67fa6994e61c3ca4b9.

Hardcoding the bridge address like this results in conflicts when multiple instances are running on one jenkins node.

A new solution for local workstation testing will have to be considered.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>