### PR TITLE
Avoid conflicting docker subnets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,13 @@ testbot:## Alias for 'make test WORKER_TYPE=testbot'
 stop: $(DOCKERCOMPOSE) ## Stop and remove any existing containers and volumes
 	-$(DOCKERCOMPOSE) down --remove-orphans --rmi all --volumes
 
+subnet: ## Generate a unique subnet for the leviathan services network and write it to .env
+	@sed '/WORKER_BRIDGE_SUBNET/d' .env > .env.new
+	@mv .env.new .env
+	echo WORKER_BRIDGE_SUBNET=$(shell for octet in $$(seq 32 56) ; do docker network inspect \
+		$$(docker network ls -q) | jq -r '.[].IPAM.Config[].Subnet' | grep -q "172\.$${octet}\." || \
+		{ echo 172.$${octet}.0.0/16 ; exit 0 ; } ; done) >> .env
+
 down: stop ## Alias for 'make stop'
 
 clean: stop ## Alias for 'make stop'

--- a/core/entry.sh
+++ b/core/entry.sh
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 rm -rf /var/run/docker 2>/dev/null || true
 rm -f /var/run/docker.sock 2>/dev/null || true
 rm -f /var/run/docker.pid 2>/dev/null || true
 
-dockerd &
+dockerd --bip 172.64.0.1/16 &
 
 eval $(ssh-agent)
 node lib/main.js

--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -15,6 +15,8 @@ services:
       - BALENACLOUD_APP_NAME=${BALENACLOUD_APP_NAME}
     depends_on:
       - core
+    networks:
+      - default
 
   core:
     privileged: true # preload requires docker-in-docker
@@ -25,10 +27,19 @@ services:
     tmpfs:
       - /var/run # use tmpfs docker-in-docker pid files
       - /var/lib/docker # use tmpfs for docker-in-docker data root
-    restart: 'no'
+    restart: "no"
     devices:
       - /dev:/dev # required for creating losetup devices during preload
+    networks:
+      - default
 
 volumes:
   core-storage:
   reports-storage:
+
+networks:
+  default:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: ${WORKER_BRIDGE_SUBNET:-172.56.0.0/16}

--- a/docker-compose.qemu.yml
+++ b/docker-compose.qemu.yml
@@ -33,6 +33,8 @@ services:
       - QEMU_MEMORY=${QEMU_MEMORY}
       - QEMU_DEBUG=${QEMU_DEBUG}
     restart: 'no'
+    networks:
+      - default
 
   core:
     depends_on:


### PR DESCRIPTION
The `make subnet` command can be called on Jenkins and similar to generate
a unique subnet that is not in use.

The default is a higher-than-default subnet for developer workstations.

The DinD daemon for the core service is also defaulting to a non-default address for the bridge.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
See: https://github.com/balena-os/leviathan/pull/842