### PR TITLE
core: Allow passing --env to balena push from pushContainerToDUT

### DIFF
--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -513,7 +513,7 @@ module.exports = class Worker {
 	 *
 	 * @category helper
 	 */
-	async pushContainerToDUT(target, source, containerName) {
+	async pushContainerToDUT(target, source, containerName, env) {
 		let ip = await this.ip(target);
 		await utils.waitUntil(async () => {
 			console.log('Waiting for supervisor to be reachable before local push...')
@@ -541,7 +541,9 @@ module.exports = class Worker {
 				source,
 				'--nolive',
 				'--detached',
-				'--debug'
+				'--debug',
+				'--env',
+				env
 			], { stdio: 'inherit' });
 
 			pushProc.on('exit', (code) => {


### PR DESCRIPTION
We need to accommodate for being able to pass env variables to pushContainerToDUT which in turn will pass them to balena push. This is useful in cases where we need to use variables in the docker compose file of the container that is to be pushed to the DUT.

Change-type: patch
Signed-off-by: Florin Sarbu <florin@balena.io>