### PR TITLE
docker-compose.client.yml: Fix running tests on SELinux enabled hosts

### DIFF
--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -4,9 +4,9 @@ services:
   client:
     build: ./client
     volumes:
-      - "${WORKSPACE:-./workspace}:/usr/src/app/workspace:ro"
+      - "${WORKSPACE:-./workspace}:/usr/src/app/workspace:Z"
       - "${REPORTS:-./workspace/reports}:/usr/src/app/reports:rw"
-      - "${SUITES:-./suites}:/usr/src/app/suites:ro"
+      - "${SUITES:-./suites}:/usr/src/app/suites:Z"
     environment:
       - WORKER_TYPE=${WORKER_TYPE}
       - DEVICE_TYPE=${DEVICE_TYPE}


### PR DESCRIPTION
Trying to run the tests on SELinux enabled hosts will fail with permission denied for the volumes defined.

For details on these options see
https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label

Change-type: patch
Signed-off-by: Florin Sarbu <florin@balena.io>