### PR TITLE
Revert "Avoid conflicting docker subnets"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,13 +88,6 @@ testbot:## Alias for 'make test WORKER_TYPE=testbot'
 stop: $(DOCKERCOMPOSE) ## Stop and remove any existing containers and volumes
 	-$(DOCKERCOMPOSE) down --remove-orphans --rmi all --volumes
 
-subnet: ## Generate a unique subnet for the leviathan services network and write it to .env
-	@sed '/WORKER_BRIDGE_SUBNET/d' .env > .env.new
-	@mv .env.new .env
-	echo WORKER_BRIDGE_SUBNET=$(shell for octet in $$(seq 32 56) ; do docker network inspect \
-		$$(docker network ls -q) | jq -r '.[].IPAM.Config[].Subnet' | grep -q "172\.$${octet}\." || \
-		{ echo 172.$${octet}.0.0/16 ; exit 0 ; } ; done) >> .env
-
 down: stop ## Alias for 'make stop'
 
 clean: stop ## Alias for 'make stop'

--- a/core/entry.sh
+++ b/core/entry.sh
@@ -1,10 +1,10 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 rm -rf /var/run/docker 2>/dev/null || true
 rm -f /var/run/docker.sock 2>/dev/null || true
 rm -f /var/run/docker.pid 2>/dev/null || true
 
-dockerd --bip 172.64.0.1/16 &
+dockerd &
 
 eval $(ssh-agent)
 node lib/main.js

--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -15,8 +15,6 @@ services:
       - BALENACLOUD_APP_NAME=${BALENACLOUD_APP_NAME}
     depends_on:
       - core
-    networks:
-      - default
 
   core:
     privileged: true # preload requires docker-in-docker
@@ -27,19 +25,10 @@ services:
     tmpfs:
       - /var/run # use tmpfs docker-in-docker pid files
       - /var/lib/docker # use tmpfs for docker-in-docker data root
-    restart: "no"
+    restart: 'no'
     devices:
       - /dev:/dev # required for creating losetup devices during preload
-    networks:
-      - default
 
 volumes:
   core-storage:
   reports-storage:
-
-networks:
-  default:
-    driver: bridge
-    ipam:
-      config:
-        - subnet: ${WORKER_BRIDGE_SUBNET:-172.56.0.0/16}

--- a/docker-compose.qemu.yml
+++ b/docker-compose.qemu.yml
@@ -33,8 +33,6 @@ services:
       - QEMU_MEMORY=${QEMU_MEMORY}
       - QEMU_DEBUG=${QEMU_DEBUG}
     restart: 'no'
-    networks:
-      - default
 
   core:
     depends_on:


### PR DESCRIPTION
Reverts balena-os/leviathan#856
Jobs are still facing this error and blocked 

```
Successfully tagged jenkins-leviathan-v2-template-9916_core:latest
./bin/docker-compose up --force-recreate --remove-orphans --exit-code-from client
Network jenkins-leviathan-v2-template-9916_default  Creating
Network jenkins-leviathan-v2-template-9916_default  Error
failed to create network jenkins-leviathan-v2-template-9916_default: Error response from daemon: Pool overlaps with other one on this address space
make: *** [Makefile:77: test] Error 1
+ status=FAILURE
+ make down
```

Need to figure out what's going wrong. 