### PR TITLE
Restore worker release env var

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,7 @@
     {
       "fileMatch": ["(^|/)(?:docker-)?compose[^/]*\\.ya?ml$"],
       "matchStrings": [
-        "bh.cr/balena/leviathan-worker(-[^/]+)?/(?<currentValue>.*?)\\n"
+        "{WORKER_RELEASE:-(?<currentValue>.*?)}"
       ],
       "depNameTemplate": "balena-os/leviathan-worker",
       "datasourceTemplate": "github-tags",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,5 +9,6 @@
       "datasourceTemplate": "github-tags",
       "versioningTemplate": "semver-coerced"
     }
-  ]
+  ],
+  "enabled": false
 }

--- a/docker-compose.qemu.yml
+++ b/docker-compose.qemu.yml
@@ -2,7 +2,7 @@ version: "2"
 
 services:
   worker:
-    image: bh.cr/balena/leviathan-worker-${BALENA_ARCH:-amd64}/2.6.11
+    image: bh.cr/balena/leviathan-worker-${BALENA_ARCH:-amd64}/${WORKER_RELEASE:-2.6.11}
     device_cgroup_rules:
       # https://www.kernel.org/doc/Documentation/admin-guide/devices.txt
       # loopback devices


### PR DESCRIPTION
This env var is still used by the leviathan-worker project for e3e tests against draft worker releases.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>