### PR TITLE
compose: qemu: add swtpm service

### DIFF
--- a/docker-compose.qemu.yml
+++ b/docker-compose.qemu.yml
@@ -1,8 +1,18 @@
 version: "2"
 
 services:
+  swtpm:
+    build: swtpm
+    restart: always
+    volumes:
+      - swtpm:/var/tpm0
+    entrypoint:
+      - swtpm
+    command: socket --tpmstate dir=/var/tpm0 --ctrl type=unixio,path=/var/tpm0/swtpm.sock --tpm2
   worker:
-    image: bh.cr/balena/leviathan-worker-${BALENA_ARCH:-amd64}/2.6.13
+    image: bh.cr/balena/leviathan-worker-${BALENA_ARCH:-amd64}/${WORKER_RELEASE:-2.6.13}
+    depends_on:
+      - swtpm
     device_cgroup_rules:
       # https://www.kernel.org/doc/Documentation/admin-guide/devices.txt
       # loopback devices
@@ -18,6 +28,7 @@ services:
     volumes:
       - "core-storage:/data"
       - "reports-storage:/reports"
+      - "swtpm:/var/tpm0"
     environment:
       - UDEV=0
       - WORKER_TYPE=qemu
@@ -34,5 +45,4 @@ services:
       - worker
 
 volumes:
-  core-storage:
-  reports-storage:
+  swtpm:

--- a/swtpm/Dockerfile
+++ b/swtpm/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine:3.17.0
+
+RUN apk add --update --no-cache swtpm


### PR DESCRIPTION
QEMU is capable of using an emulated software TPM exposed via socket. A TPM is necessary for full disk encryption (FDE), so add a service to provide this to the QEMU worker.

Signed-off-by: Joseph Kogut <joseph@balena.io>