### PR TITLE
renovate: Remove v prefix from leviathan-worker github-tags

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,7 @@
       "matchStrings": ["{WORKER_RELEASE:-(?<currentValue>.*?)}"],
       "depNameTemplate": "balena-os/leviathan-worker",
       "datasourceTemplate": "github-tags",
-      "versioningTemplate": "semver-coerced"
+      "extractVersionTemplate": "^v(?<version>.*)$"
     }
   ]
 }


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>