### PR TITLE
worker: Deprecate the WORKER_RELEASE env var

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,8 +2,13 @@
   "extends": ["github>balena-io/renovate-config//.github/renovate"],
   "regexManagers": [
     {
-      "fileMatch": ["(^|/)(?:docker-)?compose[^/]*\\.ya?ml$"],
-      "matchStrings": ["{WORKER_RELEASE:-(?<currentValue>.*?)}"],
+      "fileMatch": [
+        "(^|\\/)(?:docker-)?compose[^/]*\\.ya?ml$",
+        "(^|\\/)Dockerfile(\\.[[:alnum:]]+)?$"
+      ],
+      "matchStrings": [
+        "bh\\.cr/balena/leviathan-worker(-[^/]+)?/(?<currentValue>.*?)\\n"
+      ],
       "depNameTemplate": "balena-os/leviathan-worker",
       "datasourceTemplate": "github-tags",
       "extractVersionTemplate": "^v(?<version>.*)$"

--- a/docker-compose.qemu.yml
+++ b/docker-compose.qemu.yml
@@ -2,7 +2,7 @@ version: "2"
 
 services:
   worker:
-    image: bh.cr/balena/leviathan-worker-${BALENA_ARCH:-amd64}/${WORKER_RELEASE:-2.6.13}
+    image: bh.cr/balena/leviathan-worker-${BALENA_ARCH:-amd64}/2.6.13
     device_cgroup_rules:
       # https://www.kernel.org/doc/Documentation/admin-guide/devices.txt
       # loopback devices


### PR DESCRIPTION
Instead the worker e2e suite will use sed to replace the worker release at runtime.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
Depends-on: https://github.com/balena-os/leviathan-worker/pull/41