### PR TITLE
core: Increase the default timeout for worker connections to 30s

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -55,7 +55,7 @@ jobs:
             WORKER_TYPE: qemu
           - DEVICE_TYPE: generic-aarch64
             WORKER_TYPE: qemu
-          - DEVICE_TYPE: raspberrypi4-64
+          - DEVICE_TYPE: raspberrypi3
             WORKER_TYPE: testbot
 
     steps:

--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -45,8 +45,9 @@ const path = require('path');
 const once = require('lodash/once');
 const pipeline = Bluebird.promisify(require('stream').pipeline);
 const request = require('request');
-const rp = require('request-promise');
-
+const rp = require('request-promise').defaults({
+    timeout: 30 * 1000
+});
 const exec = Bluebird.promisify(require('child_process').exec);
 const spawn = require('child_process').spawn;
 const { createGzip, createGunzip } = require('zlib');


### PR DESCRIPTION
This is a further attempt to avoid ETIMEOUT errors when running on GH actions and connecting to real testbots.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
See: https://github.com/balena-os/leviathan/issues/792