### PR TITLE
split swtpm service into separate compose file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,15 @@ BUILDARGS := --progress=plain --parallel --pull
 UPARGS := --force-recreate --remove-orphans
 
 QEMUCOMPOSEFILE := docker-compose.qemu.yml
+SECUREBOOTCOMPOSEFILE := docker-compose.secureboot.yml
 CLIENTCOMPOSEFILE := docker-compose.client.yml
 
 # only use the qemu compose file if worker type is qemu
 ifeq ($(WORKER_TYPE),qemu)
 COMPOSE_FILE := $(CLIENTCOMPOSEFILE):$(QEMUCOMPOSEFILE)
+ifeq ($(QEMU_SECUREBOOT),1)
+COMPOSE_FILE := $(COMPOSE_FILE):$(SECUREBOOTCOMPOSEFILE)
+endif
 else
 COMPOSE_FILE := $(CLIENTCOMPOSEFILE)
 endif

--- a/docker-compose.qemu.yml
+++ b/docker-compose.qemu.yml
@@ -1,14 +1,6 @@
 version: "2"
 
 services:
-  swtpm:
-    build: swtpm
-    restart: always
-    volumes:
-      - swtpm:/var/tpm0
-    entrypoint:
-      - swtpm
-    command: socket --tpmstate dir=/var/tpm0 --ctrl type=unixio,path=/var/tpm0/swtpm.sock --tpm2
   worker:
     image: bh.cr/balena/leviathan-worker-${BALENA_ARCH:-amd64}/${WORKER_RELEASE:-2.6.13}
     depends_on:
@@ -28,7 +20,6 @@ services:
     volumes:
       - "core-storage:/data"
       - "reports-storage:/reports"
-      - "swtpm:/var/tpm0"
     environment:
       - UDEV=0
       - WORKER_TYPE=qemu
@@ -43,6 +34,3 @@ services:
   core:
     depends_on:
       - worker
-
-volumes:
-  swtpm:

--- a/docker-compose.secureboot.yml
+++ b/docker-compose.secureboot.yml
@@ -1,0 +1,21 @@
+version: "2"
+
+volumes:
+  swtpm:
+
+services:
+  swtpm:
+    build: swtpm
+    restart: always
+    volumes:
+      - swtpm:/var/tpm0
+    entrypoint:
+      - swtpm
+    command: socket --tpmstate dir=/var/tpm0 --ctrl type=unixio,path=/var/tpm0/swtpm.sock --tpm2
+  worker:
+    volumes:
+      - "swtpm:/var/tpm0"
+    depends_on:
+      - swtpm
+    environment:
+      - QEMU_SECUREBOOT=1


### PR DESCRIPTION
Not all platforms support secure boot, notably aarch64 using tianocore firmware. Additionally, swtpm may not be available for all platforms. Accordingly, move the swtpm service to a separate compose file that is only used when secure boot is enabled.

Fixes: https://github.com/balena-os/leviathan-worker/actions/runs/3842807262/jobs/6745900340

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>