### PR TITLE
client: throw errors instead of blanket handling

### DIFF
--- a/client/bin/multi-client.js
+++ b/client/bin/multi-client.js
@@ -291,202 +291,193 @@ class NonInteractiveState {
 		});
 	});
 
-	try {
-		await ensureDir(yargs.workdir);
+	await ensureDir(yargs.workdir);
 
-		// Blessed setup for pretty terminal output
+	// Blessed setup for pretty terminal output
 
-		let runConfigs = require(yargs.config);
+	let runConfigs = require(yargs.config);
 
-		const validate = ajv.compile(schema);
+	const validate = ajv.compile(schema);
 
-		if (!validate(runConfigs)) {
-			throw new Error(
-				`Invalid configuration -> ${ajv.errorsText(validate.errors)}`,
-			);
-		}
+	if (!validate(runConfigs)) {
+		throw new Error(
+			`Invalid configuration -> ${ajv.errorsText(validate.errors)}`,
+		);
+	}
 
-		// runConfig needs to be iterable to handle scenarios even when only one config is provided in config.js
-		runConfigs = Array.isArray(runConfigs) ? runConfigs : [runConfigs];
+	// runConfig needs to be iterable to handle scenarios even when only one config is provided in config.js
+	runConfigs = Array.isArray(runConfigs) ? runConfigs : [runConfigs];
 
-		state.info('Computing Run Queue');
+	state.info('Computing Run Queue');
 
-		const balenaCloud = new BalenaCloudInteractor(balena);
-		// Iterates through test jobs and pushes jobs to available testbot workers
-		for (const runConfig of runConfigs) {
-			if (runConfig.workers instanceof Array) {
-				runConfig.workers.forEach((worker) => {
-					runQueue.push({
-						suiteConfig: runConfig,
-						matchingDevices: [worker],
-						workers: null,
-						workerPrefix: null,
-						array: true,
-					});
-				});
-			} else if (runConfig.workers instanceof Object) {
-				await balenaCloud.authenticate(runConfig.workers.apiKey);
-				const matchingDevices = await balenaCloud.selectDevicesWithDUT(
-					runConfig.workers.balenaApplication,
-					runConfig.deviceType,
-				);
-
-				//  Throw an error if no matching workers are found.
-				if (matchingDevices.length === 0) {
-					throw new Error(
-						`No workers found for deviceType: ${runConfig.deviceType}`,
-					);
-				}
-
+	const balenaCloud = new BalenaCloudInteractor(balena);
+	// Iterates through test jobs and pushes jobs to available testbot workers
+	for (const runConfig of runConfigs) {
+		if (runConfig.workers instanceof Array) {
+			runConfig.workers.forEach((worker) => {
 				runQueue.push({
 					suiteConfig: runConfig,
+					matchingDevices: [worker],
 					workers: null,
-					matchingDevices: matchingDevices,
 					workerPrefix: null,
+					array: true,
+				});
+			});
+		} else if (runConfig.workers instanceof Object) {
+			await balenaCloud.authenticate(runConfig.workers.apiKey);
+			const matchingDevices = await balenaCloud.selectDevicesWithDUT(
+				runConfig.workers.balenaApplication,
+				runConfig.deviceType,
+			);
+
+			//  Throw an error if no matching workers are found.
+			if (matchingDevices.length === 0) {
+				throw new Error(
+					`No workers found for deviceType: ${runConfig.deviceType}`,
+				);
+			}
+
+			runQueue.push({
+				suiteConfig: runConfig,
+				workers: null,
+				matchingDevices: matchingDevices,
+				workerPrefix: null,
+			});
+		}
+	}
+	state.info(
+		`[Running Queue] Suites currently in queue: ${runQueue.map(
+			(run) => path.parse(run.suiteConfig.suite).base,
+		)}`,
+	);
+	const busyWorkers = [];
+	let suiteRunning = false;
+	// While jobs are present the runQueue
+	while (runQueue.length > 0) {
+		// TEMP WORKAROUND: Only start a suite if one is not already running
+		if (suiteRunning === false) {
+			const job = runQueue.pop();
+			// If matching workers for the job are available then allot them a job
+			for (var device of job.matchingDevices) {
+				// check if device is idle & public URL is reachable
+				var deviceUrl = '';
+				if (!job.array) {
+					deviceUrl = await balenaCloud.resolveDeviceUrl(device);
+				} else {
+					deviceUrl = device;
+				}
+				try {
+					let status = await rp.get(
+						new url.URL('/state', deviceUrl).toString(),
+					);
+					if (status === 'IDLE') {
+						// make sure that the worker being targetted isn't already about to be used by another child process
+						if (!busyWorkers.includes(deviceUrl)) {
+							// Create single client and break from loop to job the job 👍
+							job.workers = deviceUrl;
+							if (!job.array) {
+								job.workerPrefix = device.fileNamePrefix();
+							}
+							break;
+						}
+					}
+				} catch (err) {
+					state.info(
+						`Couldn't retrieve ${device.tags ? device.tags.DUT : device
+						} worker's state. Querying ${deviceUrl} and received ${err.name}: ${err.statusCode
+						}`,
+					);
+				}
+			}
+
+			if (job.workers === null) {
+				// No idle workers currently - the job is pushed to the back of the queue
+				await require('bluebird').delay(25000);
+				runQueue.unshift(job);
+			} else {
+				// Start the job on the assigned worker
+				state.attachPanel(job);
+				suiteRunning = true;
+				const child = fork(
+					path.join(__dirname, 'single-client'),
+					[
+						'-c',
+						job.suiteConfig instanceof Object
+							? JSON.stringify(job.suiteConfig)
+							: job.suiteConfig,
+						'-u',
+						job.workers,
+					],
+					{
+						stdio: 'pipe',
+						env: {
+							...process.env,
+							CI: true,
+						},
+					},
+				);
+
+				// after creating child process, add the worker to the busy workers array
+				busyWorkers.push(job.workers);
+
+				let status = await rp.get(new url.URL('/start', deviceUrl).toString());
+
+				// child state
+				children[child.pid] = {
+					_child: child,
+					outputPath: `${yargs.workdir}/${new url.URL(job.workers).hostname || child.pid
+						}.out`,
+					exitCode: 1,
+				};
+
+				child.on('message', ({ type, data }) => {
+					switch (type) {
+						case 'log':
+							job.log(data);
+							break;
+						case 'status':
+							job.status(data);
+							break;
+						case 'info':
+							job.info(data);
+							break;
+						case 'error':
+							job.log(data.message);
+							break;
+					}
+				});
+
+				child.on('error', console.error);
+				child.stdout.on('data', job.log);
+				child.stderr.on('data', job.log);
+
+				job.info(`WORKER URL: ${job.workers}`);
+
+				child.on('exit', (code) => {
+					children[child.pid].code = code;
+					if (job.teardown) {
+						job.teardown();
+					}
+					// Global Fail fast configuration: if a child process exits with a non-zero code,
+					if (job.suiteConfig.debug) {
+						if (code !== 0 && job.suiteConfig.debug.globalFailFast ? job.suiteConfig.debug.globalFailFast : false) {
+							state.info("Global failfast triggered. Killing all child processes.");
+							Object.values(children).forEach((child) => {
+								child.code = 777
+								child._child.kill();
+							})
+							process.exitCode = 777;
+							process.kill(process.pid, 'SIGINT');
+						}
+					}
+					// remove the worker from the busy array once the job is finished
+					busyWorkers.splice(busyWorkers.indexOf(job.workers));
+					suiteRunning = false;
 				});
 			}
+		} else {
+			// if suite running, wait before trying again
+			await require('bluebird').delay(25000);
 		}
-		state.info(
-			`[Running Queue] Suites currently in queue: ${runQueue.map(
-				(run) => path.parse(run.suiteConfig.suite).base,
-			)}`,
-		);
-		const busyWorkers = [];
-		let suiteRunning = false;
-		// While jobs are present the runQueue
-		while (runQueue.length > 0) {
-			// TEMP WORKAROUND: Only start a suite if one is not already running
-			if (suiteRunning === false) {
-				const job = runQueue.pop();
-				// If matching workers for the job are available then allot them a job
-				for (var device of job.matchingDevices) {
-					// check if device is idle & public URL is reachable
-					var deviceUrl = '';
-					if (!job.array) {
-						deviceUrl = await balenaCloud.resolveDeviceUrl(device);
-					} else {
-						deviceUrl = device;
-					}
-					try {
-						let status = await rp.get(
-							new url.URL('/state', deviceUrl).toString(),
-						);
-						if (status === 'IDLE') {
-							// make sure that the worker being targetted isn't already about to be used by another child process
-							if (!busyWorkers.includes(deviceUrl)) {
-								// Create single client and break from loop to job the job 👍
-								job.workers = deviceUrl;
-								if (!job.array) {
-									job.workerPrefix = device.fileNamePrefix();
-								}
-								break;
-							}
-						}
-					} catch (err) {
-						state.info(
-							`Couldn't retrieve ${device.tags ? device.tags.DUT : device
-							} worker's state. Querying ${deviceUrl} and received ${err.name}: ${err.statusCode
-							}`,
-						);
-					}
-				}
-
-				if (job.workers === null) {
-					// No idle workers currently - the job is pushed to the back of the queue
-					await require('bluebird').delay(25000);
-					runQueue.unshift(job);
-				} else {
-					// Start the job on the assigned worker
-					state.attachPanel(job);
-					suiteRunning = true;
-					const child = fork(
-						path.join(__dirname, 'single-client'),
-						[
-							'-c',
-							job.suiteConfig instanceof Object
-								? JSON.stringify(job.suiteConfig)
-								: job.suiteConfig,
-							'-u',
-							job.workers,
-						],
-						{
-							stdio: 'pipe',
-							env: {
-								...process.env,
-								CI: true,
-							},
-						},
-					);
-
-					// after creating child process, add the worker to the busy workers array
-					busyWorkers.push(job.workers);
-
-					let status = await rp.get(new url.URL('/start', deviceUrl).toString());
-
-					// child state
-					children[child.pid] = {
-						_child: child,
-						outputPath: `${yargs.workdir}/${new url.URL(job.workers).hostname || child.pid
-							}.out`,
-						exitCode: 1,
-					};
-
-					child.on('message', ({ type, data }) => {
-						switch (type) {
-							case 'log':
-								job.log(data);
-								break;
-							case 'status':
-								job.status(data);
-								break;
-							case 'info':
-								job.info(data);
-								break;
-							case 'error':
-								job.log(data.message);
-								break;
-						}
-					});
-
-					child.on('error', console.error);
-					child.stdout.on('data', job.log);
-					child.stderr.on('data', job.log);
-
-					job.info(`WORKER URL: ${job.workers}`);
-
-					child.on('exit', (code) => {
-						children[child.pid].code = code;
-						if (job.teardown) {
-							job.teardown();
-						}
-						// Global Fail fast configuration: if a child process exits with a non-zero code,
-						if (job.suiteConfig.debug) {
-							if (code !== 0 && job.suiteConfig.debug.globalFailFast ? job.suiteConfig.debug.globalFailFast : false) {
-								state.info("Global failfast triggered. Killing all child processes.");
-								Object.values(children).forEach((child) => {
-									child.code = 777
-									child._child.kill();
-								})
-								process.exitCode = 777;
-								process.kill(process.pid, 'SIGINT');
-							}
-						}
-						// remove the worker from the busy array once the job is finished
-						busyWorkers.splice(busyWorkers.indexOf(job.workers));
-						suiteRunning = false;
-					});
-				}
-			} else {
-				// if suite running, wait before trying again
-				await require('bluebird').delay(25000);
-			}
-		}
-	} catch (e) {
-		state.info(
-			`Client Error: ${e} \n Killing process in 10 seconds...`,
-		);
-		await require('bluebird').delay(10000);
-		process.exitCode = process.exitCode || 999;
-		process.kill(process.pid, 'SIGINT');
 	}
 })();


### PR DESCRIPTION
Remove try/catch block surrounding client code that blanket handles all exceptions, and makes debugging and log messages worse.

When we don't have a valid way to handle an exception, just throw it. The traceback is more useful than the handler.

Change-type: patch