### PR TITLE
Secure boot testing

### DIFF
--- a/docker-compose.qemu.yml
+++ b/docker-compose.qemu.yml
@@ -32,3 +32,5 @@ services:
   core:
     depends_on:
       - worker
+    environment:
+      - FLASHER_SECUREBOOT=${FLASHER_SECUREBOOT}

--- a/docker-compose.secureboot.yml
+++ b/docker-compose.secureboot.yml
@@ -10,8 +10,17 @@ services:
     volumes:
       - swtpm:/var/tpm0
     entrypoint:
-      - swtpm
-    command: socket --tpmstate dir=/var/tpm0 --ctrl type=unixio,path=/var/tpm0/swtpm.sock --tpm2
+      - /bin/sh
+      - -c
+    command:
+      - |
+        while true; do
+          swtpm socket \
+            --tpmstate dir=/var/tpm0 \
+            --ctrl type=unixio,path=/var/tpm0/swtpm.sock \
+            --tpm2
+        done
+
   worker:
     volumes:
       - "swtpm:/var/tpm0"


### PR DESCRIPTION
These are a couple supporting changes necessary for secure boot testing.

The first commit stops the test run from aborting on container exit. The second passes through an environment variable that allows for preconfiguring a flasher image to opt-in to secure boot. 