### PR TITLE
swtpm: store state in tmpfs

### DIFF
--- a/docker-compose.secureboot.yml
+++ b/docker-compose.secureboot.yml
@@ -9,14 +9,17 @@ services:
     restart: always
     volumes:
       - swtpm:/var/tpm0
+    tmpfs:
+      - /tmp
     entrypoint:
       - /bin/sh
       - -c
     command:
       - |
+        mkdir -p /tmp/tpm0
         while true; do
           swtpm socket \
-            --tpmstate dir=/var/tpm0 \
+            --tpmstate dir=/tmp/tpm0 \
             --ctrl type=unixio,path=/var/tpm0/swtpm.sock \
             --tpm2
         done


### PR DESCRIPTION
swtpm stores state in the directory specified in the --tpmstate argument

If the same state directory/files are used for multiple installations, the available space can be filled, and the installer will fail with the error "insufficient space for NV allocation".

Move swtpm state to tmpfs to create new state files every run.

Change-type: patch