### PR TITLE
minor: Add Leviathan Test Helpers

### DIFF
--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -52,7 +52,6 @@ const exec = Bluebird.promisify(require('child_process').exec);
 const spawn = require('child_process').spawn;
 const { createGzip, createGunzip } = require('zlib');
 const tar = require('tar-fs');
-const { getSdk } = require('balena-sdk');
 
 function id() {
 	return `${Math.random().toString(36).substring(2, 10)}`;

--- a/core/lib/main.js
+++ b/core/lib/main.js
@@ -18,7 +18,6 @@
 
 const Bluebird = require('bluebird');
 const { fork } = require('child_process');
-const { getFilesFromDirectory } = require('./common/utils');
 const config = require('./config.js');
 const express = require('express');
 const expressWebSocket = require('express-ws');
@@ -34,6 +33,32 @@ const { createGzip, createGunzip } = require('zlib');
 const setReportsHandler = require('./reports');
 const MachineState = require('./state');
 const { createWriteStream } = require('fs');
+
+async function getFilesFromDirectory(basePath, ignore = []) {
+	let files = [];
+
+	const entries = await fs.readdir(basePath);
+
+	for (const entry of entries) {
+		if (ignore.includes(entry)) {
+			continue;
+		}
+
+		const stat = await fs.stat(join(basePath, entry));
+
+		if (stat.isFile()) {
+			files.push(join(basePath, entry));
+		}
+
+		if (stat.isDirectory()) {
+			files = files.concat(
+				await getFilesFromDirectory(join(basePath, entry), ignore),
+			);
+		}
+	}
+
+	return files;
+}
 
 async function setup() {
 	let suite = null;

--- a/suites/e2e/package.json
+++ b/suites/e2e/package.json
@@ -1,8 +1,9 @@
 {
 	"dependencies": {
-		"balena-image-fs": "^7.0.6",
-		"bluebird": "^3.5.3",
-		"fs-extra": "^8.1.0",
+		"@balena/leviathan-test-helpers": "^1.4.1",
+		"balena-image-fs": "^7.2.0",
+		"bluebird": "^3.7.2",
+		"fs-extra": "^11.1.1",
 		"assert": "^2.0.0"
 	}
 }

--- a/suites/e2e/suite.js
+++ b/suites/e2e/suite.js
@@ -8,6 +8,7 @@
 const fse = require('fs-extra');
 const { join } = require('path');
 const { homedir } = require('os');
+const { Worker, BalenaOS, Sdk, utils } = require('@balena/leviathan-test-helpers');
 
 // required for unwrapping images
 const imagefs = require('balena-image-fs');
@@ -63,19 +64,19 @@ module.exports = {
 	title: 'Testbot Diagnostics',
 	run: async function (test) {
 		// The worker class contains methods to interact with the DUT, such as flashing, or executing a command on the device
-		const Worker = this.require('common/worker');
+		// const Worker = this.require('common/worker');
 		// The balenaOS class contains information on the OS image to be flashed, and methods to configure it
-		const BalenaOS = this.require('components/os/balenaos');
+		// const BalenaOS = this.require('components/os/balenaos');
 		// The `BalenaSDK` class contains an instance of the balena sdk, as well as some helper methods to interact with a device via the cloud.
-		const Balena = this.require('components/balena/sdk');
+		// const Balena = this.require('components/balena/sdk');
 		await fse.ensureDir(this.suite.options.tmpdir);
 
 		// The suite contex is an object that is shared across all tests. Setting something into the context makes it accessible by every test
 		this.suite.context.set({
-			utils: this.require('common/utils'),
+			utils: utils,
 			sshKeyPath: join(homedir(), 'id'),
 			sshKeyLabel: this.suite.options.id,
-			sdk: new Balena(this.suite.options.balena.apiUrl, this.getLogger()),
+			sdk: new Sdk(this.suite.options?.balena?.apiUrl, this.getLogger()),
 			link: `${this.suite.options.balenaOS.config.uuid.slice(0, 7)}.local`,
 			worker: new Worker(
 				this.suite.deviceType.slug,

--- a/suites/e2e/tests/always-fail/index.js
+++ b/suites/e2e/tests/always-fail/index.js
@@ -36,6 +36,7 @@ module.exports = {
     {
       title: 'Kill the device under test',
       run: async function (test) {
+        // This function doesn't exist anywhere and should be failing the test every time.
         await this.worker.instantKill("💥");
         test.notOk(
           true,


### PR DESCRIPTION
To reduce Core's dependencies and in the end, simplify Leviathan architecture. We are taking the first steps to use the leviathan test helpers package in the e2e test suite. This will aid in removing Core's helpers #977 and helps provide a testbed to stabilize changes made in the test-helpers package. 

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>
