### PR TITLE
patch: Output final-result in the end

### DIFF
--- a/client/bin/multi-client.js
+++ b/client/bin/multi-client.js
@@ -250,6 +250,10 @@ class NonInteractiveState {
 			`reports/final-result.json`,
 			JSON.stringify(summaries, null, 2),
 		);
+
+		// Output the final result in the end
+		console.log(`*******  Final Test Result of Leviathan Run  *******`)
+		console.log(nativeFs.readFileSync(`reports/final-result.json`, {encoding:'utf8', flag:'r'}))
 	});
 
 	const signalHandler = once(async (sig) => {


### PR DESCRIPTION
Would be nice to see the final result in the logs only rather than in another file

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>
