### PR TITLE
update default worker version

### DIFF
--- a/docker-compose.qemu.yml
+++ b/docker-compose.qemu.yml
@@ -2,7 +2,7 @@ version: "2"
 
 services:
   worker:
-    image: bh.cr/balena/leviathan-worker-${BALENA_ARCH:-amd64}/${WORKER_RELEASE:-2.6.13}
+    image: bh.cr/balena/leviathan-worker-${BALENA_ARCH:-amd64}/${WORKER_RELEASE:-2.9.1}
     device_cgroup_rules:
       # https://www.kernel.org/doc/Documentation/admin-guide/devices.txt
       # loopback devices


### PR DESCRIPTION
This bumps the default worker release that is used in the absence  of the `WORKER_RELEASE` env var. Previously it defaulted to 2.6.13, which was prior to several changes that break compatibility to the latest version of the meta-balena test suites. This meant when running locally, without `WORKER_RELEASE` pointing to a more recent release, the tests wouldn't work

Change-type: patch