### PR TITLE
docker-compose-qemu: allow to configure internal disk

### DIFF
--- a/docker-compose.qemu.yml
+++ b/docker-compose.qemu.yml
@@ -27,6 +27,7 @@ services:
       - QEMU_CPUS=${QEMU_CPUS}
       - QEMU_MEMORY=${QEMU_MEMORY}
       - QEMU_DEBUG=${QEMU_DEBUG}
+      - QEMU_INTERNAL_STORAGE=${QEMU_INTERNAL_STORAGE}
     restart: 'no'
 
   core:


### PR DESCRIPTION
Whether the internal disk is attached or not will be defined by the environment. This allows to test the migrator that requires booting only the external disk.

Change-type: patch