### PR TITLE
Deprecate worker release env var (again)

### DIFF
--- a/docker-compose.qemu.yml
+++ b/docker-compose.qemu.yml
@@ -2,7 +2,7 @@ version: "2"
 
 services:
   worker:
-    image: bh.cr/balena/leviathan-worker-${BALENA_ARCH:-amd64}/${WORKER_RELEASE:-2.9.1}
+    image: bh.cr/balena/leviathan-worker-${BALENA_ARCH:-amd64}/2.9.1
     device_cgroup_rules:
       # https://www.kernel.org/doc/Documentation/admin-guide/devices.txt
       # loopback devices


### PR DESCRIPTION
Change-type: patch

This env var breaks parsing by Renovate, and it is no longer used by Jenkins or leviathan-worker e2e.

See: https://github.com/balena-os/leviathan/pull/935
See: https://github.com/balena-os/leviathan/pull/918