### PR TITLE
core: enable serial executeCommandinHostOS

### DIFF
--- a/suites/e2e/tests/serial/index.js
+++ b/suites/e2e/tests/serial/index.js
@@ -23,6 +23,16 @@ module.exports = {
 	tests: [
 		{
 			title: 'Recording DUT serial output',
+			workerContract: {
+				type: 'object',
+				required: ['workerType'],
+				properties: {
+					workerType: {
+						type: 'string',
+						const: 'testbot_hat'
+					},
+				},
+			},
 			run: async function (test) {
 				await delay(60 * 1000);
 				await this.context.get().worker.off();


### PR DESCRIPTION
enable tests to use serial as a comms channel for `executeCommandInHostOS()` instead of ssh.

Refer to this PR for motivations - and notes on the worker side implementation: https://github.com/balena-os/leviathan-worker/pull/63

I have also had to disable the test that reads the serial output that is written to a textfile for the qemu worker - to be replaced with an actual serial console test - but to get the worker PR merged, first I had to disable the test here

Change-type: patch