### PR TITLE
core: allow for balena machine ssh target

### DIFF
--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -79,6 +79,7 @@ module.exports = class Worker {
 		url,
 		username,
 		sshKey,
+		sshConfig = {}
 	) {
 		this.deviceType = deviceType;
 		this.url = url;
@@ -96,16 +97,15 @@ module.exports = class Worker {
 			this.url.includes(`worker`)
 			|| this.url.includes('unix:')
 		);
-		if (this.url.includes(`balena-devices.com`)) {
-			// worker is a testbot connected to balena cloud - we ssh into it via the vpn
+		if(!this.directConnect){
 			this.uuid = this.url.match(
-				/(?<=https:\/\/)(.*)(?=.balena-devices.com)/,
+				/https:\/\/([^\.]+)\./,
 			)[1];
-			this.workerHost = `ssh.balena-devices.com`;
-			this.workerUser = this.username;
-			this.workerPort = '22';
 			this.sshPrefix = `host ${this.uuid} `;
-		}
+			this.workerUser = this.username;
+			this.workerPort = sshConfig.port || 22;
+			this.workerHost = sshConfig.host || 'ssh.balena-devices.com'
+		}	
 	}
 
 	/**

--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -88,8 +88,8 @@ module.exports = class Worker {
 		this.sshKey = sshKey;
 		this.dutSshKey = `/tmp/id`;
 		this.logger = logger;
-		this.workerHost = new URL(this.url).hostname;
-		this.workerPort = '22222';
+		this.workerHost = sshConfig.host || 'ssh.balena-devices.com'
+		this.workerPort = sshConfig.port || 22;
 		this.workerUser = 'root';
 		this.sshPrefix = '';
 		this.uuid = '';
@@ -103,8 +103,6 @@ module.exports = class Worker {
 			)[1];
 			this.sshPrefix = `host ${this.uuid} `;
 			this.workerUser = this.username;
-			this.workerPort = sshConfig.port || 22;
-			this.workerHost = sshConfig.host || 'ssh.balena-devices.com'
 		}	
 	}
 
@@ -331,10 +329,12 @@ module.exports = class Worker {
 				};
 			} else {
 				config = {
-					host: 'ssh.balena-devices.com',
-					port: '22',
+					host: this.workerHost,
+					port: this.workerPort,
 					username: this.username,
 				};
+				console.log('local ssh attempt')
+				console.log(config)
 				command = `host ${target} ${command}`;
 			}
 

--- a/core/lib/components/balena/sdk.js
+++ b/core/lib/components/balena/sdk.js
@@ -109,7 +109,7 @@ module.exports = class BalenaSDK {
 					{
 						host: this.sshConfig.host,
 						username: await this.balena.auth.whoami(),
-						port: this.sshConfig.sshPort,
+						port: this.sshConfig.port,
 					},
 				);
 

--- a/suites/e2e/suite.js
+++ b/suites/e2e/suite.js
@@ -75,7 +75,7 @@ module.exports = {
 			utils: this.require('common/utils'),
 			sshKeyPath: join(homedir(), 'id'),
 			sshKeyLabel: this.suite.options.id,
-			sdk: new Balena(this.suite.options.balena.apiUrl, this.getLogger()),
+			sdk: new Balena(this.suite.options.balena.apiUrl, this.getLogger(), this.suite.options.config.sshConfig),
 			link: `${this.suite.options.balenaOS.config.uuid.slice(0, 7)}.local`,
 			worker: new Worker(
 				this.suite.deviceType.slug,
@@ -83,6 +83,7 @@ module.exports = {
 				this.suite.options.workerUrl,
 				this.suite.options.balena.organization,
 				join(homedir(), 'id'),
+				this.suite.options.config.sshConfig
 			),
 		});
 


### PR DESCRIPTION
Change-type: patch

The cloud and worker objects can now be initialised with an sshConfig 
```js
sshConfig: {
		host: 'ssh.devices.bm.balena-dev.com',
		port: '222',
	}
```

which can be added to the suites `config.js` and passed through to these objects in the test suite