### PR TITLE
add logging for ssh error and stop conn resets during reboot command

### DIFF
--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -344,6 +344,7 @@ module.exports = class Worker {
 					try {
 						result = await utils.executeCommandOverSSH(command, config);
 					} catch (err) {
+						console.log(`Failed to execute command: ${command}`)
 						console.error(err.message);
 						throw new Error(err);
 					}

--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -649,7 +649,7 @@ module.exports = class Worker {
 	async rebootDut(target) {
 		this.logger.log(`Rebooting the DUT`);
 		await this.executeCommandInHostOS(
-			`touch /tmp/reboot-check && systemd-run --on-active=2 reboot`,
+			`touch /tmp/reboot-check && systemd-run --on-active=5 reboot`,
 			target,
 		);
 		await this.executeCommandInHostOS(


### PR DESCRIPTION
two issues that popped up when there were connection failures following a reboot of the DUT (beaglebone)
1. We can't see what failed
2. when doing `rebootDut` the reboot can interrupt the ssh connection which leads to a loop of reboots

This PR increases the delay on the reboot command so that there's time for the ssh command to end first, stopping the loop of retrying the command. We also log the failed command if the ssh command fails. 