### PR TITLE
patch: Add .nojekyll file to docs

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -3,7 +3,7 @@
 		"lint:fix": "balena-lint -e js --fix lib/**/*",
 		"lint": "balena-lint -u -e js --tests lib/**/*",
 		"start": "node lib/main.js",
-		"docs": "npx typedoc --tsconfig tsconfig.json"
+		"docs": "npx typedoc --tsconfig tsconfig.json && touch ../docs/.nojekyll"
 	},
 	"dependencies": {
 		"ajv": "^6.12.6",


### PR DESCRIPTION
Jekyll build failing is leading to new docs not publishing. Stopping GH Jekyll builds.

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>
