### PR TITLE
core: remove request timeout on flashing

### DIFF
--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -121,9 +121,11 @@ module.exports = class Worker {
 				this.logger.log(`Preparing to flash, attempt ${attempt}...`);
 
 				await new Promise(async (resolve, reject) => {
-					const req = rp.post({ uri: `${this.url}/dut/flash` });
+					const req = rp.post({ uri: `${this.url}/dut/flash`, timeout: 0 });
 
 					req.catch((error) => {
+						this.logger.log(`client side error: `)
+						this.logger.log(error.message)
 						reject(error);
 					});
 					req.finally(() => {


### PR DESCRIPTION
This is a change to be paired with https://github.com/balena-os/leviathan-worker/pull/91 to try to reduce the risk of connection drops while streaming the OS images to the worker. For larger images, especially when preloaded, the connection is prone to timing out. These PR's attempt to remove the http request and server timeouts. 

The seperate heartbeat timeout that we have will timeout the test run if something goes wrong. 

Change-type: patch