### PR TITLE
add timeout netcat processes

### DIFF
--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -497,7 +497,7 @@ module.exports = class Worker {
 		// this will be torn down at the end of the tests when the core is destroyed
 		let argsClient = [
 			`tcp-listen:${dutPort},reuseaddr,fork`,
-			`system:ssh ${this.workerUser}@${this.workerHost} -p ${this.workerPort} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ${this.sshKey} ${this.sshPrefix}/usr/bin/nc localhost ${workerPort}`,
+			`system:ssh ${this.workerUser}@${this.workerHost} -p ${this.workerPort} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ${this.sshKey} ${this.sshPrefix}timeout 600 /usr/bin/nc localhost ${workerPort}`,
 		];
 
 		let tunnelProcClient = spawn(`socat`, argsClient);


### PR DESCRIPTION
This is an attempted fix for the following problem:

- most tests are failing with the latest meta-balena unmanaged test suite at the final test
- the connection seems to just timeout - when looking at a device in the stuck state I saw thousands of stale socat+ssh processes
- I added a timeout to the command to close these after they've been open a long time 

Seems to fix the problem - not a great fix but all tests are blocked at the moment

Change-type: patch