### PR TITLE
Add Systemctl Service State helpers

### DIFF
--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -725,4 +725,35 @@ module.exports = class Worker {
 			this.logger.log(`Couldn't retrieve logs with error: ${e}`);
 		}
 	}
+
+	/**
+	* Wait for a service to reach a certain state. For example: active/inactive
+	*
+	* @param {string} serviceName systemd service to query and wait for
+	* @param {string} expectedState for example: active/inactive
+	* @param {string} target the address of the device to query
+	* @param {string[]} waitUntilOptions optional custom values for waitUntil function. Refer to docs for more info.
+	*
+	* @category helper
+	*/
+	async waitForServiceState(serviceName, expectedState, target, waitUntilOptions = [false, 120, 250]) {
+		return utils.waitUntil(
+			async () => {
+				return worker
+					.executeCommandInHostOS(
+						`systemctl is-active ${serviceName} || true`,
+						target,
+					)
+					.then((serviceStatus) => {
+						return Promise.resolve(serviceStatus === expectedState);
+					})
+					.catch((err) => {
+						Promise.reject(err);
+					});
+			},
+			waitUntilOptions[0],
+			waitUntilOptions[1],
+			waitUntilOptions[2],
+		);
+	}
 };

--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -739,7 +739,8 @@ module.exports = class Worker {
 	async waitForServiceState(serviceName, expectedState, target, waitUntilOptions = [false, 120, 250]) {
 		return utils.waitUntil(
 			async () => {
-				return worker
+				console.log(`Waiting for service ${serviceName} to reach state ${expectedState}`);
+				return this
 					.executeCommandInHostOS(
 						`systemctl is-active ${serviceName} || true`,
 						target,

--- a/suites/e2e/suite.js
+++ b/suites/e2e/suite.js
@@ -51,7 +51,7 @@ const enableSerialConsole = async (imagePath) => {
 };
 
 module.exports = {
-	title: "Testbot Diagnostics",
+	title: "Autokit Diagnostics x Levaithan e2e tests",
 	run: async function (test) {
 		// The worker class contains methods to interact with the DUT, such as flashing, or executing a command on the device
 		const Worker = this.require("common/worker");
@@ -199,5 +199,17 @@ module.exports = {
 		// 		.worker.archiveLogs(this.id, this.context.get().link);
 		// });
 	},
-	tests: ["./tests/always-fail", "./tests/flash", "./tests/power-cycle", "./tests/serial"],
+
+	tests: [
+		// Worker/Hardware focused tests listed below
+		"./tests/always-fail", 
+		"./tests/flash", 
+		"./tests/power-cycle", 
+
+		// Leviathan Helpers tests listed below
+		"./tests/worker-helper", 
+
+		// Always keep this test last to be executed - it turns off the DUT
+		"./tests/serial"
+	],
 };

--- a/suites/e2e/tests/worker-helper/index.js
+++ b/suites/e2e/tests/worker-helper/index.js
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+"use strict";
+
+module.exports = {
+	title: 'Leviathan "Worker" Helpers Tests',
+	tests: [
+		{
+			title: "waitForServiceState()",
+			run: async function (test) {
+				await test.resolves(
+					Promise.all([
+						this.worker.waitForServiceState('balena-supervisor.service', 'active', this.link),
+						this.worker.waitForServiceState('balena.service', 'active', this.link)
+					]),
+					'Should wait for balena.service and balena-supervisor.service to be active'
+				);
+			},
+		},
+	],
+};


### PR DESCRIPTION
Also, includes tests for the helper to be tested consistently on every release of Leviathan. 

- minor: Add Systemctl Service State helper
- minor: Add Leviathan helpers e2e test suite
