### PR TITLE
minor: Add leviathan GitHub Action

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -32,6 +32,7 @@ jobs:
       SUITES: ./suites
       REPORTS: ./reports
       WORKSPACE: ./workspace
+      LEVIATHAN_ROOT: ./
       BALENACLOUD_ORG: testbot
       BALENACLOUD_APP_NAME: balena/testbot-rig
       QEMU_CPUS: 1
@@ -83,16 +84,21 @@ jobs:
       - name: Copy suite config
         run: cp -a ${{ env.SUITES }}/config.js ${{ env.WORKSPACE }}/config.js
 
-      - name: Build leviathan images
-        run: |
-          make build
-
-      - name: Run test suite
-        run: |
-          make config
-          make test || exit 1
-
-      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
-        with:
-          name: reports-${{ env.WORKER_TYPE }}-${{ env.DEVICE_TYPE }}
-          path: ${{ env.REPORTS }}
+      - name: Leviathan build + test
+        uses: ./ 
+        env:
+          BALENACLOUD_API_KEY: ${{ env.BALENACLOUD_API_KEY }}
+          BALENACLOUD_API_URL: ${{ env.BALENACLOUD_API_URL }}
+          BALENACLOUD_APP_NAME: ${{ env.BALENACLOUD_APP_NAME }}
+          BALENACLOUD_ORG: ${{ env.BALENACLOUD_ORG }}
+          BALENACLOUD_SSH_PORT: ${{ env.BALENACLOUD_SSH_PORT }}
+          BALENACLOUD_SSH_URL: ${{ env.BALENACLOUD_SSH_URL }}
+          DEVICE_TYPE: ${{ matrix.DEVICE_TYPE }}
+          LEVIATHAN_ROOT: ${{ env.LEVIATHAN_ROOT }}
+          QEMU_CPUS: 1
+          QEMU_MEMORY: "1G"
+          REPORTS: ${{ env.REPORTS }}
+          SUITES: ${{ env.SUITES }}
+          WORKER_TYPE: ${{ matrix.WORKER_TYPE }}
+          WORKSPACE: ${{ env.WORKSPACE }}
+          TEST_SUITE: e2e

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,51 @@
+name: 'Leviathan Action'
+description: 'Test your software directly on hardware using the Levaithan Testing framework'
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: (Virtual) Leviathan build & test 
+      working-directory: ${{ env.LEVIATHAN_ROOT }}/
+      if: env.WORKER_TYPE == 'qemu'
+      shell: bash
+      run: |
+        make config
+        make build
+        make local-test QEMU_SECUREBOOT=${QEMU_SECUREBOOT} FLASHER_SECUREBOOT=${FLASHER_SECUREBOOT}
+
+    - name: (Autokit) Leviathan build & test
+      working-directory: ${{ env.LEVIATHAN_ROOT }}/
+      if: env.WORKER_TYPE == 'testbot' || env.WORKER_TYPE == 'autokit'
+      shell: bash
+      run: |
+        make config
+        make build
+        make test
+
+    - name: Create Summary 
+      shell: bash
+      run: |
+        echo "### ${TEST_SUITE} Test Report"  >> $GITHUB_STEP_SUMMARY
+        
+        echo "| Total Tests | Ran | Passed | Failed | Skipped |" >> $GITHUB_STEP_SUMMARY
+        echo "|-------|-----|---------|--------|--------|" >> $GITHUB_STEP_SUMMARY
+        jq -r '.[0].stats | "\(.tests) 📋 | \(.ran) 🏃 |  \(.passed) ✅ | \(.failed) ❌ | \(.skipped) ⏭️"' ${REPORTS}/final-result.json >> $GITHUB_STEP_SUMMARY
+        
+        echo "#### Failed Tests" >> $GITHUB_STEP_SUMMARY
+        jq -r '.[0].tests | to_entries[] | select(.value == "failed") | .key' ${REPORTS}/final-result.json >> $GITHUB_STEP_SUMMARY
+
+        echo "#### Skipped Tests" >> $GITHUB_STEP_SUMMARY
+        jq -r '.[0].tests | to_entries[] | select(.value == "skipped") | .key' ${REPORTS}/final-result.json >> $GITHUB_STEP_SUMMARY
+
+    - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4
+      with:
+        name: reports-${{ env.WORKER_TYPE }}-${{ env.DEVICE_TYPE }}-${{ env.TEST_SUITE }}
+        path: ${{ env.REPORTS }}
+
+    - name: Teardown
+      shell: bash
+      working-directory: ${{ env.LEVIATHAN_ROOT }} 
+      run: |
+        make down


### PR DESCRIPTION
The first draft of the Leviathan GHA gaining feature parity to Jenkins leviathan-v2-template but with seperate test jobs in the matrix. Refer to test.yml

Fibery: https://balena.fibery.io/Work/Project/Create-a-GitHub-Action-workflow-for-Leviathan-builds-248

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>
