### PR TITLE
tests: Add autokit worker to serial test

### DIFF
--- a/suites/e2e/tests/serial/index.js
+++ b/suites/e2e/tests/serial/index.js
@@ -29,7 +29,7 @@ module.exports = {
 				properties: {
 					workerType: {
 						type: "string",
-						const: "testbot_hat",
+						enum: ["testbot_hat", "autokit"]
 					},
 				},
 			},


### PR DESCRIPTION
Found that autokit worker type devices were skipping the serial test, so added them in. 



Change-type: patch
Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>
