### PR TITLE
Client: Update alpine packages before installing packages

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -2,7 +2,7 @@ FROM node:18.16.0-alpine3.16
 WORKDIR /usr/src/app
 
 # hadolint ignore=DL3018
-RUN apk add --no-cache bash git
+RUN apk update && apk upgrade && apk add --no-cache bash git
 
 COPY package* ./
 RUN npm ci


### PR DESCRIPTION
Patch to resolve reliablity of Alpine packages being installed as part of client Dockerfile on GitHub Actions. 
This is fix is a best effort resolution to the the issue that we were facing. After implementing the fix, we didn't face the same after 6 retries of the job. 

Change-type: patch
Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>
