### PR TITLE
patch: Remove internal presentation link to testbot

### DIFF
--- a/documentation/learn-more.md
+++ b/documentation/learn-more.md
@@ -11,7 +11,3 @@
 Vipul Gupta recently presented the topic Testing 100's of OS Images with Jenkins at [CDCon + GitOpsCon 2023](https://sched.co/1Jp87) at Open Source Summit 2023 North America, which talks about the journey Balena takes to build, test and release balenaOS releases from pull requests to production using Autokit and how even you can use it in your work. 
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/Gjp2hgIXhHQ?si=Nzc8FjGS3pudIEJF" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-
-## Internal materials
-
-Watch the primer of the automated testing project presented by the team in balena Summit 2021: https://drive.google.com/drive/u/0/folders/1Jjw76PoimYC9H8LAMcXGp106ezxWT35Q


### PR DESCRIPTION
This happenned because of it: https://balena.zulipchat.com/#narrow/stream/345885-aspect.2Fsecurity/topic/Share.20request.20for.20.22Testbots.20and.20the.20story.20so.20far!.22/near/442340747, so to reduce noise getting rid of the link. 

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>
