### PR TITLE
Docs: Fix endpoint name from s/status/state

### DIFF
--- a/core/pagesconfig.json
+++ b/core/pagesconfig.json
@@ -30,7 +30,7 @@
                     "source": "../documentation/writing-tests.md"
                 },
                 {
-                    "title": "FAQ",
+                    "title": "Debugging FAQ",
                     "source": "../documentation/debugging.md"
                 },
                 {

--- a/documentation/debugging.md
+++ b/documentation/debugging.md
@@ -52,10 +52,10 @@ Testing with autokit requires several components to work together. All steps in 
 1. To check the availability of an autokit manually, you can run the following command:
 
 ```
-$ curl -X POST PUBLIC-DEVICE-URL-OF-AUTOKIT/status
+$ curl -X POST PUBLIC-DEVICE-URL-OF-AUTOKIT/state
 ```
 
-2. If the status is IDLE, we can run a short diagnostics test to see if the autokit works correctly. Run the Leviathan e2e test described in this section {@page Getting Started with Autokit Worker  | Start your first test run} on the autokit you want to verify. After completing the Leviathan prerequisites listed above the section, you can create your config.js and add the Public Device URL in the `workers` section.  
+2. If the state is IDLE, we can run a short diagnostics test to see if the autokit works correctly. Run the Leviathan e2e test described in this section {@page Getting Started with Autokit Worker  | Start your first test run} on the autokit you want to verify. After completing the Leviathan prerequisites listed above the section, you can create your config.js and add the Public Device URL in the `workers` section.  
 
 If the test completes without any errors, then the autokit should be ready to run the tests. 
 
@@ -81,14 +81,14 @@ No device could be found for this device type slug in the Autokit fleet you spec
 
 1. The wrong fleet or device type was being targeted. Check the test configuration present in the test logs.
 2. If not, check the balenaCloud fleet and check the `DUT` tag of the autokit devices in the fleet containing the device type slug. If you don't find a `DUT` tag matching the slug, then the worker doesn't exist. 
-3. If you find a device, check the status of the autokit by running the following command. 
+3. If you find a device, check the state of the autokit by running the following command. 
 
 ```
-$ curl -X POST PUBLIC-DEVICE-URL-OF-AUTOKIT/status
+$ curl -X POST PUBLIC-DEVICE-URL-OF-AUTOKIT/state
 ```
 
-4. If the status is BUSY, then the device is running tests for another job. 
-5. If the status is IDLE, then the device is available to run the tests but is still unable to take up the test job. Refer to [Recovering the Autokit](#recovering-the-autokit) section. 
+4. If the state is BUSY, then the device is running tests for another job. 
+5. If the state is IDLE, then the device is available to run the tests but is still unable to take up the test job. Refer to [Recovering the Autokit](#recovering-the-autokit) section. 
 
 
 ## Flashing issues

--- a/documentation/quickstart-autokit.md
+++ b/documentation/quickstart-autokit.md
@@ -114,7 +114,7 @@ A successful run of the e2e test suite without any errors makes sure that your a
 
 ## Troubleshooting
 
-Refer to {@page FAQ | FAQ's for common issues mentioned below and debug your test setup}
+Refer to {@page Debugging FAQ | FAQ's for common issues mentioned below and debug your test setup}
 
 1. Config issues
 2. Flashing issues

--- a/documentation/quickstart-qemu.md
+++ b/documentation/quickstart-qemu.md
@@ -74,6 +74,8 @@ make local-test
 
 This will trigger a build of client and core services using docker-compose and begin the test. The logs by various componenet will start streaming on the terminal. Wait for the test scenario to finish and check the device logs on the dashboard in the meantime. 
 
+> Refer to {@page Debugging FAQ | FAQ's for common issues mentioned below and debug your test setup}
+
 A successful run of the e2e test suite without any errors makes sure that your QEMU worker is set up correctly and can be used for further tests.
 
 ## Let's run some "real" tests


### PR DESCRIPTION
Fixing the endpoint name in debugging docs that queries state of the autokit at any given time.

Change-type: patch