### PR TITLE
remove nested retries in getDutIp function

### DIFF
--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -257,26 +257,19 @@ module.exports = class Worker {
 		return doRequest({ method: 'POST', uri: `${this.url}/proxy`, body: proxy, json: true });
 	}
 
+	// the default doRequest parameters lead to 5 retries
+	// the /dut/ip endpoint takes around 10s to scan on the worker side
+	// setting tries to 50 here leads to 50*([default doRequest interval = 2] + ~10) = 600s/10 mins
 	async getDutIp(
 		target,
-		timeout = {
-			interval: 1000,
-			tries: 30,
-		},
+		tries = 50
 	) {
-		return retry(
-			() => {
-				return doRequest({
-					uri: `${this.url}/dut/ip`,
-					body: { target },
-					json: true,
-				});
-			},
-			{
-				max_tries: timeout.tries,
-				interval: timeout.interval,
-				throw_original: true,
-			},
+		return doRequest({
+			uri: `${this.url}/dut/ip`,
+			body: { target },
+			json: true,
+		},
+		tries
 		);
 	}
 


### PR DESCRIPTION
the function that was being used to fetch the DUT ip from the worker had nested retries that led to 30x5 = 150 retries, and timeouts taking ~40 mins in the case the DUT wasn't reachable (autokit setup fault, device not booting, problem during flashing). This removes the nested retries and reduces the retries to 50 /  ~ 10mins