### PR TITLE
core: ssh tunnels: fix auth errors when worker is in prod mode

### DIFF
--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -458,7 +458,7 @@ module.exports = class Worker {
 			`${dutPort}:${ip}:${dutPort}`,
 			`-p`,
 			workerPort,
-			`root@127.0.0.1`,
+			`${this.username}@127.0.0.1`,
 			`-o`,
 			`StrictHostKeyChecking=no`,
 			`-o`,


### PR DESCRIPTION
When the worker is in production mode, ssh auth when creating the reverse tunnel to tunnel though it to the DUT failed. Using BC username auth with BC registered keys fixes it

tested on a prod worker with unipi3 DUT

resolves https://github.com/balena-os/leviathan/issues/1191

Change-type: patch