### PR TITLE
core: update CLI to 19.0.0

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,48 +1,63 @@
-FROM node:14.19.3-bullseye-slim as base
+FROM debian:bullseye-slim AS balena-cli
+
+WORKDIR /tmp
+
+ENV DEBCONF_NONINTERACTIVE_SEEN=true
+ENV DEBIAN_FRONTEND=noninteractive
+
+# hadolint ignore=DL3008
+RUN apt-get update && apt-get install --no-install-recommends -y \
+  ca-certificates \
+  curl \
+  unzip && \
+  rm -rf /var/lib/apt/lists/*
+
+# renovate: datasource=github-releases depName=balena-io/balena-cli
+ARG BALENA_CLI_VERSION=v19.0.0
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Install balena-cli via standlone zip
+RUN ARCH="$(dpkg --print-architecture | sed 's/amd/x/')" && \
+  curl -fsSL -o balena-cli.zip "https://github.com/balena-io/balena-cli/releases/download/${BALENA_CLI_VERSION}/balena-cli-${BALENA_CLI_VERSION}-linux-${ARCH}-standalone.zip" && \
+  unzip balena-cli.zip && \
+  cp -a balena-cli /usr/local/lib/balena-cli && \
+  ln -sf /usr/local/lib/balena-cli/balena /usr/local/bin/balena && \
+  balena version
+
+# The standalone balena-cli package is currently glibc only (no alpine/musl support)
+FROM node:14.19.3-bullseye-slim AS base
 
 WORKDIR /usr/app
 
-ENV DEBCONF_NONINTERACTIVE_SEEN true
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBCONF_NONINTERACTIVE_SEEN=true
+ENV DEBIAN_FRONTEND=noninteractive
 
 # install docker, balena-cli dependencies, and suite dependencies
 # https://github.com/balena-io/balena-cli/blob/master/INSTALL-LINUX.md#additional-dependencies
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install --no-install-recommends -y \
-	bind9-dnsutils \
-	ca-certificates \
-	docker.io \
-	git \
-	iproute2 \
-	jq \
-	openssh-client \
-	socat \
-	rsync \
-	unzip \
-	util-linux \
-	wget \
-	vim \
-	build-essential \
-	make \
-	python && \
-	apt-get clean && \
-	rm -rf /var/lib/apt/lists/*
+  bind9-dnsutils \
+  ca-certificates \
+  docker.io \
+  git \
+  iproute2 \
+  jq \
+  openssh-client \
+  socat \
+  rsync \
+  unzip \
+  util-linux \
+  wget \
+  vim \
+  build-essential \
+  make \
+  python && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
 
-ARG BALENA_CLI_REF="v17.0.0"
-ARG BALENA_CLI_VERSION="17.0.0"
-
-# Install balena-cli via standlone zip, only compatible with glibc (not alpine/musl)
-RUN if [ "$(uname -m)" = "arm64" ] || [ "$(uname -m)" = "aarch64" ] ; \
-	then \
-		wget -q -O balena-cli.zip "https://github.com/balena-io/balena-cli/releases/download/${BALENA_CLI_REF}/balena-cli-v${BALENA_CLI_VERSION}-linux-arm64-standalone.zip" && \
-		unzip balena-cli.zip && rm balena-cli.zip ; \
-	else \
-		wget -q -O balena-cli.zip "https://github.com/balena-io/balena-cli/releases/download/${BALENA_CLI_REF}/balena-cli-v${BALENA_CLI_VERSION}-linux-x64-standalone.zip" && \
-		unzip balena-cli.zip && rm balena-cli.zip ; \
-	fi
-
-# Add balena-cli to PATH
-ENV PATH /usr/app/balena-cli:$PATH
+COPY --from=balena-cli /usr/local/lib/balena-cli /usr/local/lib/balena-cli
+COPY --from=balena-cli /usr/local/bin/balena /usr/local/bin/balena
 
 RUN balena version
 

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -28,8 +28,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/*
 
-ARG BALENA_CLI_REF="v16.1.0"
-ARG BALENA_CLI_VERSION="16.1.0"
+ARG BALENA_CLI_REF="v17.0.0"
+ARG BALENA_CLI_VERSION="17.0.0"
 
 # Install balena-cli via standlone zip, only compatible with glibc (not alpine/musl)
 RUN if [ "$(uname -m)" = "arm64" ] || [ "$(uname -m)" = "aarch64" ] ; \

--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -487,7 +487,7 @@ module.exports = class Worker {
 				`tunnel`,
 				this.uuid,
 				`-p`,
-				`22222:${workerPort}`
+				`22222:127.0.0.1:${workerPort}`
 			];
 			let tunnelProcClient = spawn(`balena`, argsClient, {stdio: 'inherit'});
 


### PR DESCRIPTION
we were previously using CLI 16.0.0, which is now over 365 days since the next major release (17.0.0) , so its deprecated and won't work without adding the --unsupported flag, or updating. Choosing to update

Change-type: patch