### PR TITLE
compose: map qemu volume into worker

### DIFF
--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -41,3 +41,4 @@ services:
 volumes:
   core-storage:
   reports-storage:
+  qemu:

--- a/docker-compose.qemu.yml
+++ b/docker-compose.qemu.yml
@@ -18,6 +18,7 @@ services:
     volumes:
       - "core-storage:/data"
       - "reports-storage:/reports"
+      - "qemu:/run/qemu/"
     environment:
       - UDEV=0
       - WORKER_TYPE=qemu
@@ -31,5 +32,7 @@ services:
     restart: 'no'
 
   core:
+    volumes:
+      - "qemu:/run/qemu"
     depends_on:
       - worker


### PR DESCRIPTION
This volume is used to share qemu's QMP socket between the worker and core containers, allowing tests to connect, receive events from, and control qemu.

Change-type: patch