### PR TITLE
add if: always() to report name generation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,7 @@ runs:
 
     - name: Generate artifact name
       shell: bash
+      if: always()
       id: report-name
       run: |
         if [ "$QEMU_SECUREBOOT" -eq 1 ]; then


### PR DESCRIPTION
makes sure we generate a report name even if tests fail

Change-type: patch