### PR TITLE
Drop use of legacy compose binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,36 +49,20 @@ ifneq ($(BUILD_TAG),)
 COMPOSE_PROJECT_NAME := $(BUILD_TAG)
 endif
 
-DOCKERCOMPOSE := ./bin/docker-compose
-
-# install docker-compose as a run script
-# we require a specific release version that correctly supports device_cgroup_rules for the qemu worker
-# see https://github.com/docker/compose/issues/9059
-$(DOCKERCOMPOSE):
-	mkdir -p $(shell dirname "$@")
-ifeq ($(shell uname -m),arm64)
-	curl -fsSL "https://github.com/docker/compose/releases/download/v2.3.3/docker-compose-$(shell uname -s | tr '[:upper:]' '[:lower:]')-aarch64" -o $@
-else
-	curl -fsSL "https://github.com/docker/compose/releases/download/v2.3.3/docker-compose-$(shell uname -s | tr '[:upper:]' '[:lower:]')-$(shell uname -m)" -o $@
-endif
-	chmod +x $@
-
-.NOTPARALLEL: $(DOCKERCOMPOSE)
-
 help: ## Print help message
 	@echo -e "$$(grep -hE '^\S+:.*##' $(MAKEFILE_LIST) | sed -e 's/:.*##\s*/:/' -e 's/^\(.\+\):\(.*\)/\\x1b[36m\1\\x1b[m:\2/' | column -c2 -t -s :)"
 
 printenv:
 	@printenv
 
-config: $(DOCKERCOMPOSE) ## Print flattened docker-compose definition
-	$(DOCKERCOMPOSE) config
+config: ## Print flattened docker-compose definition
+	docker compose config
 
-build: $(DOCKERCOMPOSE) ## Build the required images
-	$(DOCKERCOMPOSE) build $(BUILDARGS)
+build: ## Build the required images
+	docker compose build $(BUILDARGS)
 
-test: $(DOCKERCOMPOSE) build ## Run the test suites
-	$(DOCKERCOMPOSE) up $(UPARGS) --exit-code-from client
+test: build ## Run the test suites
+	docker compose up $(UPARGS) --exit-code-from client
 
 local-test: ## Alias for 'make test WORKER_TYPE=qemu'
 	$(MAKE) test WORKER_TYPE=qemu
@@ -89,8 +73,8 @@ qemu: ## Alias for 'make test WORKER_TYPE=qemu'
 testbot:## Alias for 'make test WORKER_TYPE=testbot'
 	$(MAKE) test WORKER_TYPE=testbot
 
-stop: $(DOCKERCOMPOSE) ## Stop and remove any existing containers and volumes
-	-$(DOCKERCOMPOSE) down --remove-orphans --rmi all --volumes
+stop: ## Stop and remove any existing containers and volumes
+	-docker compose down --remove-orphans --rmi all --volumes
 
 down: stop ## Alias for 'make stop'
 


### PR DESCRIPTION
This reverts commit be4130f which pinned docker-compose to v2.3.3 in order to properly support the device_cgroup_rules directive.

This should be supported natively by compose v2.

See: https://github.com/docker/compose/commit/d8775c7a2832a0cdd47af6f9d5c5c46e83f29008
See: https://github.com/docker/compose/issues/9059
See: https://github.com/balena-os/leviathan/commit/be4130fff3bbbed25e9ce600548289d48db5c17b