### PR TITLE
lib/components/os: Add SRD3 JP4 and JP5 device type boot partition in…

### DIFF
--- a/core/lib/components/os/balenaos.js
+++ b/core/lib/components/os/balenaos.js
@@ -178,6 +178,10 @@ module.exports = class BalenaOS {
 			case 'jetson-nano':
 				this.bootPartition = 12;
 				break;
+			case 'srd3-xavier':
+				this.bootPartition = 37;
+				break;
+			case 'jetson-xavier-srd3-jp5':
 			case 'jetson-xavier':
 				this.bootPartition = 43;
 				break;


### PR DESCRIPTION
…dexes

The JP5 device-type uses the same boot partition index as the jetson-xavier on JP5.

Change-type: patch