### PR TITLE
Core: fix retry handling in flash function

### DIFF
--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -179,9 +179,6 @@ module.exports = class Worker {
 					req.on('data', (data) => {
 						const computedLine = RegExp('(.+?): (.*)').exec(data.toString());
 
-						// FOr debugging
-						this.logger.log(data.toString())
-
 						if (computedLine) {
 							if (computedLine[1] === 'error') {
 								req.cancel();
@@ -193,12 +190,16 @@ module.exports = class Worker {
 									this.logger.log('Flashing');
 								});
 								// Hide any errors as the lines we get can be half written
-								const state = JSON.parse(computedLine[2]);
-								if (state != null && isNumber(state.percentage)) {
-									this.logger.status({
-										message: 'Flashing',
-										percentage: state.percentage,
-									});
+								try{
+									const state = JSON.parse(computedLine[2]);
+									if (state != null && isNumber(state.percentage)) {
+										this.logger.status({
+											message: 'Flashing',
+											percentage: state.percentage,
+										});
+									}
+								} catch (error){
+									this.logger.log(`Error while parsing messages from worker`)
 								}
 							}
 

--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -179,6 +179,8 @@ module.exports = class Worker {
 					req.on('data', (data) => {
 						const computedLine = RegExp('(.+?): (.*)').exec(data.toString());
 
+						this.logger.log(data.toString());
+
 						if (computedLine) {
 							if (computedLine[1] === 'error') {
 								req.cancel();
@@ -210,7 +212,7 @@ module.exports = class Worker {
 					});
 
 					try{
-						pipeline(
+						await pipeline(
 							fs.createReadStream(imagePath),
 							createGzip({ level: 6 }),
 							req,

--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -156,7 +156,7 @@ module.exports = class Worker {
 
 					// Catch an error via a ECONNRESET or connection related error
 					req.catch((error) => {
-						this.logger.log(`Client side connection error: ${error.message} `)
+						this.logger.log(`Client side connection error: ${error.message}`)
 						reject(error);
 					});
 
@@ -178,6 +178,9 @@ module.exports = class Worker {
 					let lastStatus;
 					req.on('data', (data) => {
 						const computedLine = RegExp('(.+?): (.*)').exec(data.toString());
+
+						// FOr debugging
+						this.logger.log(data.toString())
 
 						if (computedLine) {
 							if (computedLine[1] === 'error') {
@@ -205,11 +208,16 @@ module.exports = class Worker {
 						}
 					});
 
-					pipeline(
-						fs.createReadStream(imagePath),
-						createGzip({ level: 6 }),
-						req,
-					);
+					try{
+						pipeline(
+							fs.createReadStream(imagePath),
+							createGzip({ level: 6 }),
+							req,
+						)
+					}catch(error){
+						this.logger.log(`Pipeline error: ${error.message}`);
+						reject(error); // Reject the outer Promise here
+					}
 				});
 				this.logger.log('Flash completed');
 			},


### PR DESCRIPTION
I think the use of finally() was causing the retry to not happen when it should, ;eading to an uncaught exception

Change-type: patch