### PR TITLE
Ensure we always pass the BALENA_ARCH worker build arg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ export
 
 # optional docker-compose args
 PULLARGS := --include-deps --policy=always
-BUILDARGS := --progress=plain --parallel --pull --build-arg WORKER_VERSION --build-arg BALENA_ARCH
+BUILDARGS := --progress=plain --parallel --pull
 UPARGS := --force-recreate --remove-orphans
 
 QEMUCOMPOSEFILE := docker-compose.qemu.yml

--- a/docker-compose.qemu.yml
+++ b/docker-compose.qemu.yml
@@ -2,7 +2,11 @@ version: "2"
 
 services:
   worker:
-    build: worker
+    build:
+      context: worker
+      dockerfile: Dockerfile
+      args:
+        BALENA_ARCH: ${BALENA_ARCH}
     device_cgroup_rules:
       # https://www.kernel.org/doc/Documentation/admin-guide/devices.txt
       # loopback devices


### PR DESCRIPTION
'docker compose up' will build any missing images,
but does not accept build-args from the command line

instead, we want to always inherit some build args
from the environment via docker compose substitution