### PR TITLE
Bind mount private contracts in the core service

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -58,6 +58,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 COPY --from=balena-cli /usr/local/lib/balena /usr/local/lib/balena
 RUN ln -sf /usr/local/lib/balena/bin/balena /usr/local/bin/balena
 
+# hadolint ignore=DL3059
 RUN balena version
 
 COPY package*.json ./

--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -32,6 +32,8 @@ services:
     volumes:
       - core-storage:/data
       - reports-storage:/reports
+      # Private device types must checkout the private contracts repo to ./core/private-contracts
+      - ./core/private-contracts:/usr/app/private-contracts:ro
     tmpfs:
       - /var/run # use tmpfs docker-in-docker pid files
       - /var/lib/docker # use tmpfs for docker-in-docker data root


### PR DESCRIPTION
These contracts used to be copied to the core service at build time if private device types cloned the repo before running test suites.

However, since switching to pre-built images by default we need to manually mount private contracts to the core service.
