### PR TITLE
worker: extend total flashing timeout to 25 minutes

### DIFF
--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -219,7 +219,7 @@ module.exports = class Worker {
 				}
 			},
 			{
-				max_tries: 30,
+				max_tries: 60,
 				interval: 1000 * 25,
 			}
 		);


### PR DESCRIPTION
The total flashing time used to be:

30 tries × 25 seconds = 750 seconds (12.5 minutes)

This used to be on the limit of timeout for slowish SD cards and secure boot flashers that need to boot and re-program

It's now double that time:

60 tries × 25 seconds = 1,500 seconds (25 minutes)

Change-type: patch