### PR TITLE
e2e: probe supervisor /ping instead of /v1/healthy

### DIFF
--- a/suites/e2e/tests/power-cycle/index.js
+++ b/suites/e2e/tests/power-cycle/index.js
@@ -89,10 +89,15 @@ module.exports = {
 				)
 
 				// we want to waitUntil here as the supervisor may take some time to come online.
+				// /ping is unauthenticated and unconditional, so it passes whenever the
+				// supervisor process is up. /v1/healthy includes a connectivity check
+				// that requires the device to be actively reporting state to balena-cloud,
+				// which the DUT in this suite never does (provisioned in local mode and
+				// not registered to a fleet).
 				await test.resolves(
 					this.utils.waitUntil(async () => {
 						const healthy = await this.worker.executeCommandInHostOS(
-							`curl --max-time 10 "localhost:48484/v1/healthy"`,
+							`curl --max-time 10 "localhost:48484/ping"`,
 							this.link
 						)
 						return (healthy === 'OK')


### PR DESCRIPTION
balena-supervisor v17.6.26 fixed the connectivity healthcheck (balena-os/balena-supervisor@22e4d646) so `/v1/healthy` now requires the device to be actively reporting state to balena-cloud, which the local-mode DUT in this suite never does. `/ping` just checks that the supervisor process is up, which is what this test actually wants. meta-balena did the same swap in their cloud suite for the same reason (balena-os/meta-balena@6afa76bd); this also unblocks every leviathan-worker PR since 2026-04-30 (e.g. balena-os/leviathan-worker#185).