### PR TITLE
core/lib: Make Protected Management Frames (PMF) support optional / d…

### DIFF
--- a/core/lib/components/os/balenaos.js
+++ b/core/lib/components/os/balenaos.js
@@ -115,6 +115,7 @@ const injectNetworkConfiguration = async (image, configuration, partition = 1) =
 			'[wifi-security]',
 			'auth-alg=open',
 			'key-mgmt=wpa-psk',
+			'pmf=1',
 			`psk=${configuration.wireless.psk}`,
 		]);
 	}


### PR DESCRIPTION
…isabled

when creating the wifi connection profile

We have a case where not setting this to optional will cause issues when authenticating to an AP created by the worker (a RPi 4 worker).

Change-type: patch