### PR TITLE
lib/common/worker.js: Harden OS image upload

### DIFF
--- a/core/lib/common/worker.js
+++ b/core/lib/common/worker.js
@@ -164,15 +164,32 @@ module.exports = class Worker {
 				this.logger.log(`Sending image to worker, attempt ${attempt}...`);
 				// Send image to worker
 
-				try{
+				try {
+						// Check if the file actually exists before doing anything else
+						if (!fs.existsSync(GZIP_PATH)) {
+						    this.logger.log(`CRITICAL ERROR: The file ${GZIP_PATH} was not found at path: ${process.cwd()}/${GZIP_PATH}`);
+						}
+
+						const fileStats = fs.statSync(GZIP_PATH);
+						const zippedSizeInBytes = fileStats.size;
+
+						this.logger.log(`Calculated stream size: ${zippedSizeInBytes} bytes. Forcing Content-Length header.`);
+
+						const fileStream = fs.createReadStream(GZIP_PATH, {
+						    highWaterMark: 256 * 1024 // 256KB chunks (perfect throttle management for Cloudlink)
+						});
+
 						const res = await fetch(`${this.url}/dut/sendImage`, {
 						method: 'POST',
-						body: fs.createReadStream(GZIP_PATH),
+						body: fileStream,
 						headers: {
 							'Content-Type': 'application/octet-stream',
-							'Content-Encoding': 'gzip'
+							'Content-Encoding': 'gzip',
+							'Content-Length': zippedSizeInBytes.toString(),
+							'Connection': 'keep-alive'
 						},
-						duplex: 'half'
+						duplex: 'half',
+						timeout: 600000
 					});
 
 					if (!res.ok) {
@@ -181,6 +198,8 @@ module.exports = class Worker {
 					}
 
 				} catch(e) {
+					// Log the exact error causing the try block to fail
+					this.logger.log(`Failed inside try block during attempt ${attempt}. Error: ${e.message}`);
 					throw new Error(e);
 				}
 			},

--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -27,7 +27,6 @@ services:
 
   core:
     build: core
-    image: ghcr.io/balena-os/leviathan:${CORE_TAG:-latest-core}
     privileged: true # preload requires docker-in-docker
     volumes:
       - core-storage:/data


### PR DESCRIPTION
The following changes have been made:
- send the image filesize in order to prevent chunked transfers
- use keep alive to prevent timeouts

Change-type: patch